### PR TITLE
Add nuget.config

### DIFF
--- a/PolyType.sln
+++ b/PolyType.sln
@@ -47,10 +47,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Packages.props = Directory.Packages.props
 		Dockerfile = Dockerfile
 		global.json = global.json
+		key.snk = key.snk
 		LICENSE = LICENSE
 		Makefile = Makefile
+		nuget.config = nuget.config
 		README.md = README.md
-		key.snk = key.snk
 		version.json = version.json
 	EndProjectSection
 EndProject

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
On clone+build, I get [NU1507](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1507) because I have multiple package sources defined:

"Warning As Error: There are 3 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source."

Fix by adding a nuget.config