### PR TITLE
Fix naming inconsistency for IDictionaryTypeShape.

### DIFF
--- a/docs/core-abstractions.md
+++ b/docs/core-abstractions.md
@@ -107,14 +107,14 @@ It should be noted that the visitor is only used when constructing, or _folding_
 A collection type in this context refers to any type implementing `IEnumerable`, and this is further refined into enumerable and dictionary shapes:
 
 ```C#
-public interface IEnumerableShape<TEnumerable, TElement> : ITypeShape<TEnumerable>
+public interface IEnumerableTypeShape<TEnumerable, TElement> : ITypeShape<TEnumerable>
 {
     ITypeShape<TElement> ElementType { get; }
 
     Func<TEnumerable, IEnumerable<TElement>> GetGetEnumerable();
 }
 
-public interface IDictionaryShape<TDictionary, TKey, TValue> : ITypeShape<TDictionary>
+public interface IDictionaryTypeShape<TDictionary, TKey, TValue> : ITypeShape<TDictionary>
 {
     ITypeShape<TKey> KeyType { get; }
     ITypeShape<TValue> ValueType { get; }
@@ -128,8 +128,8 @@ A collection type is classed as a dictionary if it implements one of the known d
 ```C#
 public interface ITypeShapeVisitor
 {
-    object? VisitEnumerable<TEnumerable, TElement>(IEnumerableShape<TEnumerable, TElement> enumerableShape, object? state = null);
-    object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null);
+    object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state = null);
+    object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null);
 }
 ```
 
@@ -138,7 +138,7 @@ Using the above we can now extend `CounterVisitor` so that collection types are 
 ```C#
 partial class CounterVisitor : TypeShapeVisitor
 {
-    public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableShape<TEnumerable, TElement> enumerableShape, object? _)
+    public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? _)
     {
         var elementCounter = (Func<TElement, int>)enumerableShape.ElementType.Accept(this)!;
         Func<TEnumerable, IEnumerable<TElement>> getEnumerable = enumerableShape.GetGetEnumerable();
@@ -154,7 +154,7 @@ partial class CounterVisitor : TypeShapeVisitor
         });
     }
 
-    public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? _)
+    public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? _)
     {
         var keyCounter = (Func<TKey, int>)dictionaryShape.KeyType.Accept(this);
         var valueCounter = (Func<TValue, int>)dictionaryShape.ValueType.Accept(this);
@@ -223,10 +223,10 @@ partial class CounterVisitor : TypeShapeVisitor
 To recap, the `ITypeShape` model splits .NET types into five separate kinds:
 
 * Base `ITypeShape` instances which may or may not define properties,
-* `IEnumerableShape` instances describing enumerable types,
-* `IDictionaryShape` instances describing dictionary types,
-* `IEnumShape` instances describing enum types and
-* `INullableShape` instances describing `Nullable<T>` types.
+* `IEnumerableTypeShape` instances describing enumerable types,
+* `IDictionaryTypeShape` instances describing dictionary types,
+* `IEnumTypeShape` instances describing enum types and
+* `INullableTypeShape` instances describing `Nullable<T>` types.
 
 ## Constructing and mutating types
 

--- a/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
@@ -96,7 +96,7 @@ public static partial class CborSerializer
             };
         }
 
-        public object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state) where TKey : notnull
+        public object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state) where TKey : notnull
         {
             CborConverter<TKey> keyConverter = BuildConverter(dictionaryShape.KeyType);
             CborConverter<TValue> valueConverter = BuildConverter(dictionaryShape.ValueType);

--- a/src/PolyType.Examples/Cloner/Cloner.cs
+++ b/src/PolyType.Examples/Cloner/Cloner.cs
@@ -239,7 +239,7 @@ public static class Cloner
             }
         }
 
-        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? _)
+        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? _)
         {
             var keyCloner = BuildCloner(dictionaryShape.KeyType);
             var valueCloner = BuildCloner(dictionaryShape.ValueType);

--- a/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.cs
+++ b/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.cs
@@ -224,7 +224,7 @@ public static class ConfigurationBinderTS
             }
         }
 
-        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
+        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
         {
             if (!s_builtInParsers.TryGetValue(typeof(TKey), out object? parser))
             {

--- a/src/PolyType.Examples/Counter/Counter.Builder.cs
+++ b/src/PolyType.Examples/Counter/Counter.Builder.cs
@@ -83,7 +83,7 @@ public static partial class Counter
             });
         }
 
-        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state)
+        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state)
         {
             Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> dictionaryGetter = dictionaryShape.GetGetDictionary();
             Func<TKey, long> keyTypeCounter = BuildCounter(dictionaryShape.KeyType);

--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonDictionaryConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonDictionaryConverter.cs
@@ -6,7 +6,7 @@ using PolyType.Examples.Utilities;
 
 namespace PolyType.Examples.JsonSerializer.Converters;
 
-internal class JsonDictionaryConverter<TDictionary, TKey, TValue>(JsonConverter<TKey> keyConverter, JsonConverter<TValue> valueConverter, IDictionaryShape<TDictionary, TKey, TValue> shape) : JsonConverter<TDictionary>
+internal class JsonDictionaryConverter<TDictionary, TKey, TValue>(JsonConverter<TKey> keyConverter, JsonConverter<TValue> valueConverter, IDictionaryTypeShape<TDictionary, TKey, TValue> shape) : JsonConverter<TDictionary>
     where TKey : notnull
 {
     private static readonly bool s_isDictionary = typeof(Dictionary<TKey, TValue>).IsAssignableFrom(typeof(TDictionary));
@@ -69,7 +69,7 @@ internal class JsonDictionaryConverter<TDictionary, TKey, TValue>(JsonConverter<
 internal sealed class JsonMutableDictionaryConverter<TDictionary, TKey, TValue>(
     JsonConverter<TKey> keyConverter,
     JsonConverter<TValue> valueConverter,
-    IDictionaryShape<TDictionary, TKey, TValue> shape,
+    IDictionaryTypeShape<TDictionary, TKey, TValue> shape,
     Func<TDictionary> createObject,
     Setter<TDictionary, KeyValuePair<TKey, TValue>> addDelegate) : JsonDictionaryConverter<TDictionary, TKey, TValue>(keyConverter, valueConverter, shape)
     where TKey : notnull
@@ -111,7 +111,7 @@ internal sealed class JsonMutableDictionaryConverter<TDictionary, TKey, TValue>(
 internal abstract class JsonImmutableDictionaryConverter<TDictionary, TKey, TValue>(
     JsonConverter<TKey> keyConverter,
     JsonConverter<TValue> valueConverter,
-    IDictionaryShape<TDictionary, TKey, TValue> shape)
+    IDictionaryTypeShape<TDictionary, TKey, TValue> shape)
     : JsonDictionaryConverter<TDictionary, TKey, TValue>(keyConverter, valueConverter, shape)
     where TKey : notnull
 {
@@ -150,7 +150,7 @@ internal abstract class JsonImmutableDictionaryConverter<TDictionary, TKey, TVal
 internal sealed class JsonEnumerableConstructorDictionaryConverter<TDictionary, TKey, TValue>(
     JsonConverter<TKey> keyConverter,
     JsonConverter<TValue> valueConverter,
-    IDictionaryShape<TDictionary, TKey, TValue> shape,
+    IDictionaryTypeShape<TDictionary, TKey, TValue> shape,
     Func<IEnumerable<KeyValuePair<TKey, TValue>>, TDictionary> constructor)
     : JsonImmutableDictionaryConverter<TDictionary, TKey, TValue>(keyConverter, valueConverter, shape)
     where TKey : notnull
@@ -162,7 +162,7 @@ internal sealed class JsonEnumerableConstructorDictionaryConverter<TDictionary, 
 internal sealed class JsonSpanConstructorDictionaryConverter<TDictionary, TKey, TValue>(
     JsonConverter<TKey> keyConverter,
     JsonConverter<TValue> valueConverter,
-    IDictionaryShape<TDictionary, TKey, TValue> shape,
+    IDictionaryTypeShape<TDictionary, TKey, TValue> shape,
     SpanConstructor<KeyValuePair<TKey, TValue>, TDictionary> constructor)
     : JsonImmutableDictionaryConverter<TDictionary, TKey, TValue>(keyConverter, valueConverter, shape)
     where TKey : notnull

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
@@ -112,7 +112,7 @@ public static partial class JsonSerializerTS
             };
         }
 
-        public object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state) where TKey : notnull
+        public object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state) where TKey : notnull
         {
             JsonConverter<TKey> keyConverter = BuildJsonConverter(dictionaryShape.KeyType);
             JsonConverter<TValue> valueConverter = BuildJsonConverter(dictionaryShape.ValueType);

--- a/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
+++ b/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
@@ -95,7 +95,7 @@ public static partial class Mapper
             return targetEnumerable.Accept(visitor, state: enumerableShape);
         }
 
-        public override object? VisitDictionary<TSourceDictionary, TSourceKey, TSourceValue>(IDictionaryShape<TSourceDictionary, TSourceKey, TSourceValue> sourceDictionary, object? state)
+        public override object? VisitDictionary<TSourceDictionary, TSourceKey, TSourceValue>(IDictionaryTypeShape<TSourceDictionary, TSourceKey, TSourceValue> sourceDictionary, object? state)
         {
             var targetDictionary = (IDictionaryTypeShape)state!;
             var visitor = new DictionaryScopedVisitor<TSourceDictionary, TSourceKey, TSourceValue>(this);
@@ -305,9 +305,9 @@ public static partial class Mapper
         private sealed class DictionaryScopedVisitor<TSourceDictionary, TSourceKey, TSourceValue>(Builder baseVisitor) : TypeShapeVisitor
             where TSourceKey : notnull
         {
-            public override object? VisitDictionary<TTargetDictionary, TTargetKey, TTargetValue>(IDictionaryShape<TTargetDictionary, TTargetKey, TTargetValue> targetDictionary, object? state)
+            public override object? VisitDictionary<TTargetDictionary, TTargetKey, TTargetValue>(IDictionaryTypeShape<TTargetDictionary, TTargetKey, TTargetValue> targetDictionary, object? state)
             {
-                var sourceDictionary = (IDictionaryShape<TSourceDictionary, TSourceKey, TSourceValue>)state!;
+                var sourceDictionary = (IDictionaryTypeShape<TSourceDictionary, TSourceKey, TSourceValue>)state!;
                 var sourceGetDictionary = sourceDictionary.GetGetDictionary();
 
                 var keyMapper = baseVisitor.BuildMapper(sourceDictionary.KeyType, targetDictionary.KeyType);

--- a/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.Builder.cs
+++ b/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.Builder.cs
@@ -133,7 +133,7 @@ public static partial class PrettyPrinter
             });
         }
 
-        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state)
+        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state)
         {
             string typeName = FormatTypeName(typeof(TDictionary));
             Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> dictionaryGetter = dictionaryShape.GetGetDictionary();

--- a/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
+++ b/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
@@ -227,7 +227,7 @@ public partial class RandomGenerator
             }
         }
 
-        public object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state) where TKey : notnull
+        public object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state) where TKey : notnull
         {
             RandomGenerator<TKey> keyGenerator = BuildGenerator(dictionaryShape.KeyType);
             RandomGenerator<TValue> valueGenerator = BuildGenerator(dictionaryShape.ValueType);

--- a/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.Builder.cs
+++ b/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.Builder.cs
@@ -62,7 +62,7 @@ public static partial class StructuralEqualityComparer
             };
         }
 
-        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state)
+        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state)
         {
             IEqualityComparer<TKey> keyComparer = BuildEqualityComparer(dictionaryShape.KeyType);
             IEqualityComparer<TValue> valueComparer = BuildEqualityComparer(dictionaryShape.ValueType);

--- a/src/PolyType.Examples/Validation/Validator.Builder.cs
+++ b/src/PolyType.Examples/Validation/Validator.Builder.cs
@@ -90,7 +90,7 @@ public static partial class Validator
             });
         }
 
-        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state)
+        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state)
         {
             Validator<TValue>? valueValidator = BuildValidator(dictionaryShape.ValueType);
             if (valueValidator is null)

--- a/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
+++ b/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
@@ -92,7 +92,7 @@ public static partial class XmlSerializer
             };
         }
 
-        public object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state) where TKey : notnull
+        public object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state) where TKey : notnull
         {
             XmlConverter<TKey> keyConverter = BuildConverter(dictionaryShape.KeyType);
             XmlConverter<TValue> valueConverter = BuildConverter(dictionaryShape.ValueType);

--- a/src/PolyType/Abstractions/IDictionaryTypeShape.cs
+++ b/src/PolyType/Abstractions/IDictionaryTypeShape.cs
@@ -46,7 +46,7 @@ public interface IDictionaryTypeShape : ITypeShape
 /// Typically covers types implementing interfaces such as <see cref="IDictionary{TKey, TValue}"/>,
 /// <see cref="IReadOnlyDictionary{TKey, TValue}"/> or <see cref="IDictionary"/>.
 /// </remarks>
-public interface IDictionaryShape<TDictionary, TKey, TValue> : ITypeShape<TDictionary>, IDictionaryTypeShape
+public interface IDictionaryTypeShape<TDictionary, TKey, TValue> : ITypeShape<TDictionary>, IDictionaryTypeShape
     where TKey : notnull
 {
     /// <summary>

--- a/src/PolyType/Abstractions/ITypeShapeVisitor.cs
+++ b/src/PolyType/Abstractions/ITypeShapeVisitor.cs
@@ -76,7 +76,7 @@ public interface ITypeShapeVisitor
     object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state = null);
 
     /// <summary>
-    /// Visits an <see cref="IDictionaryShape{TDictionary, TKey, TValue}"/> instance representing a dictionary type.
+    /// Visits an <see cref="IDictionaryTypeShape{TDictionary, TKey, TValue}"/> instance representing a dictionary type.
     /// </summary>
     /// <typeparam name="TDictionary">The type of the visited dictionary.</typeparam>
     /// <typeparam name="TKey">The key type of the visited dictionary.</typeparam>
@@ -84,6 +84,6 @@ public interface ITypeShapeVisitor
     /// <param name="dictionaryShape">The dictionary shape to visit.</param>
     /// <param name="state">Defines user-provided state.</param>
     /// <returns>The result produced by the visitor.</returns>
-    object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
+    object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
         where TKey : notnull;
 }

--- a/src/PolyType/Abstractions/TypeShapeVisitor.cs
+++ b/src/PolyType/Abstractions/TypeShapeVisitor.cs
@@ -83,7 +83,7 @@ public abstract class TypeShapeVisitor : ITypeShapeVisitor
         => ThrowNotImplemented(nameof(VisitEnumerable));
 
     /// <summary>
-    /// Visits an <see cref="IDictionaryShape{TDictionary, TKey, TValue}"/> instance representing a dictionary type.
+    /// Visits an <see cref="IDictionaryTypeShape{TDictionary, TKey, TValue}"/> instance representing a dictionary type.
     /// </summary>
     /// <typeparam name="TDictionary">The type of the visited dictionary.</typeparam>
     /// <typeparam name="TKey">The key type of the visited dictionary.</typeparam>
@@ -91,7 +91,7 @@ public abstract class TypeShapeVisitor : ITypeShapeVisitor
     /// <param name="dictionaryShape">The dictionary shape to visit.</param>
     /// <param name="state">Defines user-provided state.</param>
     /// <returns>The result produced by the visitor.</returns>
-    public virtual object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
+    public virtual object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
         where TKey : notnull
         => ThrowNotImplemented(nameof(VisitDictionary));
 

--- a/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
@@ -10,7 +10,7 @@ namespace PolyType.ReflectionProvider;
 
 [RequiresUnreferencedCode(ReflectionTypeShapeProvider.RequiresUnreferencedCodeMessage)]
 [RequiresDynamicCode(ReflectionTypeShapeProvider.RequiresDynamicCodeMessage)]
-internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>(ReflectionTypeShapeProvider provider) : IDictionaryShape<TDictionary, TKey, TValue>
+internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>(ReflectionTypeShapeProvider provider) : IDictionaryTypeShape<TDictionary, TKey, TValue>
     where TKey : notnull
 {
     private CollectionConstructionStrategy? _constructionStrategy;

--- a/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
@@ -8,7 +8,7 @@ namespace PolyType.SourceGenModel;
 /// <typeparam name="TDictionary">The type of the dictionary.</typeparam>
 /// <typeparam name="TKey">The type of the dictionary key.</typeparam>
 /// <typeparam name="TValue">The type of the dictionary value.</typeparam>
-public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : IDictionaryShape<TDictionary, TKey, TValue>
+public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : IDictionaryTypeShape<TDictionary, TKey, TValue>
     where TKey : notnull
 {
     /// <summary>
@@ -56,18 +56,18 @@ public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : ID
     /// </summary>
     public SpanConstructor<KeyValuePair<TKey, TValue>, TDictionary>? SpanConstructorFunc { get; init; }
 
-    Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> IDictionaryShape<TDictionary, TKey, TValue>.GetGetDictionary()
+    Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> IDictionaryTypeShape<TDictionary, TKey, TValue>.GetGetDictionary()
         => GetDictionaryFunc;
 
-    Func<TDictionary> IDictionaryShape<TDictionary, TKey, TValue>.GetDefaultConstructor()
+    Func<TDictionary> IDictionaryTypeShape<TDictionary, TKey, TValue>.GetDefaultConstructor()
         => DefaultConstructorFunc ?? throw new InvalidOperationException("Dictionary shape does not specify a default constructor.");
 
-    Setter<TDictionary, KeyValuePair<TKey, TValue>> IDictionaryShape<TDictionary, TKey, TValue>.GetAddKeyValuePair()
+    Setter<TDictionary, KeyValuePair<TKey, TValue>> IDictionaryTypeShape<TDictionary, TKey, TValue>.GetAddKeyValuePair()
         => AddKeyValuePairFunc ?? throw new InvalidOperationException("Dictionary shape does not specify an append delegate.");
 
-    Func<IEnumerable<KeyValuePair<TKey, TValue>>, TDictionary> IDictionaryShape<TDictionary, TKey, TValue>.GetEnumerableConstructor()
+    Func<IEnumerable<KeyValuePair<TKey, TValue>>, TDictionary> IDictionaryTypeShape<TDictionary, TKey, TValue>.GetEnumerableConstructor()
         => EnumerableConstructorFunc ?? throw new InvalidOperationException("Dictionary shape does not specify an enumerable constructor.");
 
-    SpanConstructor<KeyValuePair<TKey, TValue>, TDictionary> IDictionaryShape<TDictionary, TKey, TValue>.GetSpanConstructor()
+    SpanConstructor<KeyValuePair<TKey, TValue>, TDictionary> IDictionaryTypeShape<TDictionary, TKey, TValue>.GetSpanConstructor()
         => SpanConstructorFunc ?? throw new InvalidOperationException("Dictionary shape does not specify a span constructor.");
 }

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -281,7 +281,7 @@ public abstract class TypeShapeProviderTests(IProviderUnderTest providerUnderTes
 
     private sealed class DictionaryTestVisitor : TypeShapeVisitor
     {
-        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state)
+        public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state)
         {
             TDictionary dictionary;
             RandomGenerator<TKey> keyGenerator = RandomGenerator.Create((ITypeShape<TKey>)dictionaryShape.KeyType);


### PR DESCRIPTION
@AArnott heads up for this upcoming breaking change.