### PR TITLE
Rework witness type generation scheme.

### DIFF
--- a/src/PolyType.SourceGenerator/Model/TypeDeclarationModel.cs
+++ b/src/PolyType.SourceGenerator/Model/TypeDeclarationModel.cs
@@ -10,6 +10,6 @@ public record TypeDeclarationModel
     public required ImmutableEquatableArray<string> ContainingTypes { get; init; }
     public required string SourceFilenamePrefix { get; init; }
     public required string? Namespace { get; init; }
-    public required bool ImplementsITypeShapeProvider { get; init; }
+    public required bool IsWitnessTypeDeclaration { get; init; }
     public required ImmutableEquatableSet<TypeId> ShapeableOfTImplementations { get; init; }
 }

--- a/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
@@ -7,7 +7,7 @@ public sealed partial class Parser
     private static DiagnosticDescriptor TypeNotSupported { get; } = new DiagnosticDescriptor(
         id: "TS0001",
         title: "Type shape generation not supported for type.",
-        messageFormat: "Type shape generation not supported for type '{0}'.",
+        messageFormat: "The type '{0}' is not supported for PolyType generation.",
         category: "PolyType.SourceGenerator",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
@@ -50,5 +50,13 @@ public sealed partial class Parser
         messageFormat: "The type '{0}' contains multiple constructors with a ConstructorShapeAttribute.",
         category: "PolyType.SourceGenerator",
         defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static DiagnosticDescriptor GeneratedTypeIsStatic { get; } = new DiagnosticDescriptor(
+        id: "TS0007",
+        title: "Types annotated with GenerateShapeAttribute cannot be static.",
+        messageFormat: "The type '{0}' that has been annotated with GenerateShapeAttribute cannot be static.",
+        category: "PolyType.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 }

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -235,7 +235,7 @@ public sealed partial class Parser : TypeDataModelGenerator
             ContainingTypes = parentStack?.ToImmutableEquatableArray() ?? [],
             Namespace = FormatNamespace(context.TypeSymbol),
             SourceFilenamePrefix = context.TypeSymbol.ToDisplayString(RoslynHelpers.QualifiedNameOnlyFormat),
-            ImplementsITypeShapeProvider = isWitnessTypeDeclaration,
+            IsWitnessTypeDeclaration = isWitnessTypeDeclaration,
             ShapeableOfTImplementations = shapeableOfTImplementations?.ToImmutableEquatableSet() ?? [],
         };
 
@@ -345,7 +345,7 @@ public sealed partial class Parser : TypeDataModelGenerator
         Namespace = "PolyType.SourceGenerator",
         SourceFilenamePrefix = "PolyType.SourceGenerator.ShapeProvider",
         TypeDeclarationHeader = "internal sealed partial class ShapeProvider",
-        ImplementsITypeShapeProvider = true,
+        IsWitnessTypeDeclaration = false,
         ContainingTypes = [],
         ShapeableOfTImplementations = [],
     };

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -25,7 +25,7 @@ public sealed partial class Parser : TypeDataModelGenerator
 
     // All types used as generic parameters so we must exclude ref structs.
     protected override bool IsSupportedType(ITypeSymbol type)
-        => base.IsSupportedType(type) && !type.IsRefLikeType;
+        => base.IsSupportedType(type) && !type.IsRefLikeType && !type.IsStatic;
 
     // Erase nullable annotations and tuple labels from generated types.
     protected override ITypeSymbol NormalizeType(ITypeSymbol type)
@@ -183,6 +183,12 @@ public sealed partial class Parser : TypeDataModelGenerator
         if (!isPartialHierarchy)
         {
             ReportDiagnostic(GeneratedTypeNotPartial, declarationSyntax.GetLocation(), context.TypeSymbol.ToDisplayString());
+            return null;
+        }
+
+        if (context.TypeSymbol.IsStatic)
+        {
+            ReportDiagnostic(GeneratedTypeIsStatic, declarationSyntax.GetLocation(), context.TypeSymbol.ToDisplayString());
             return null;
         }
 

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.ITypeShapeProvider.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.ITypeShapeProvider.cs
@@ -71,16 +71,16 @@ internal sealed partial class SourceFormatter
         return writer.ToSourceText();
     }
 
-    private static SourceText FormatITypeShapeProviderStub(TypeDeclarationModel typeDeclaration, TypeShapeProviderModel provider)
+    private static SourceText FormatWitnessTypeMainFile(TypeDeclarationModel typeDeclaration, TypeShapeProviderModel provider)
     {
         var writer = new SourceWriter();
         StartFormatSourceFile(writer, typeDeclaration);
 
         writer.WriteLine($$"""
-            {{typeDeclaration.TypeDeclarationHeader}} : global::PolyType.ITypeShapeProvider
+            {{typeDeclaration.TypeDeclarationHeader}}
             {
-                global::PolyType.Abstractions.ITypeShape? global::PolyType.ITypeShapeProvider.GetShape(global::System.Type type) 
-                    => {{provider.ProviderDeclaration.Id.FullyQualifiedName}}.{{ProviderSingletonProperty}}.GetShape(type);
+                /// <summary>Gets the source generated <see cref="global::PolyType.ITypeShapeProvider"/> corresponding to the current witness type.</summary>
+                public static global::PolyType.ITypeShapeProvider ShapeProvider => {{provider.ProviderDeclaration.Id.FullyQualifiedName}}.{{ProviderSingletonProperty}};
             }
             """);
 

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Type.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Type.cs
@@ -7,7 +7,7 @@ namespace PolyType.SourceGenerator;
 
 internal sealed partial class SourceFormatter
 {
-    private SourceText FormatType(TypeShapeProviderModel provider, TypeShapeModel type)
+    private SourceText FormatProvidedType(TypeShapeProviderModel provider, TypeShapeModel type)
     {
         string generatedPropertyType = $"global::PolyType.Abstractions.ITypeShape<{type.Type.FullyQualifiedName}>";
         string generatedFactoryMethodName = $"__Create_{type.SourceIdentifier}";

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
@@ -23,20 +23,20 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
     private void AddAllSourceFiles(SourceProductionContext context, TypeShapeProviderModel provider)
     {
         context.CancellationToken.ThrowIfCancellationRequested();
-        context.AddSource($"{provider.ProviderDeclaration.SourceFilenamePrefix}.g.cs", FormatMainFile(provider));
+        context.AddSource($"{provider.ProviderDeclaration.SourceFilenamePrefix}.g.cs", FormatProviderMainFile(provider));
         context.AddSource($"{provider.ProviderDeclaration.SourceFilenamePrefix}.ITypeShapeProvider.g.cs", FormatProviderInterfaceImplementation(provider));
 
         foreach (TypeShapeModel type in provider.ProvidedTypes.Values)
         {
             context.CancellationToken.ThrowIfCancellationRequested();
-            context.AddSource($"{provider.ProviderDeclaration.SourceFilenamePrefix}.{type.SourceIdentifier}.g.cs", FormatType(provider, type));
+            context.AddSource($"{provider.ProviderDeclaration.SourceFilenamePrefix}.{type.SourceIdentifier}.g.cs", FormatProvidedType(provider, type));
         }
 
         foreach (TypeDeclarationModel typeDeclaration in provider.AnnotatedTypes)
         {
-            if (typeDeclaration.ImplementsITypeShapeProvider)
+            if (typeDeclaration.IsWitnessTypeDeclaration)
             {
-                context.AddSource($"{typeDeclaration.SourceFilenamePrefix}.ITypeShapeProvider.g.cs", FormatITypeShapeProviderStub(typeDeclaration, provider));
+                context.AddSource($"{typeDeclaration.SourceFilenamePrefix}.g.cs", FormatWitnessTypeMainFile(typeDeclaration, provider));
             }
 
             foreach (TypeId typeToImplement in typeDeclaration.ShapeableOfTImplementations)
@@ -50,7 +50,7 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
         }
     }
 
-    private static SourceText FormatMainFile(TypeShapeProviderModel provider)
+    private static SourceText FormatProviderMainFile(TypeShapeProviderModel provider)
     {
         var writer = new SourceWriter();
         StartFormatSourceFile(writer, provider.ProviderDeclaration);

--- a/src/PolyType/GenerateShapeAttribute.cs
+++ b/src/PolyType/GenerateShapeAttribute.cs
@@ -14,5 +14,5 @@ public sealed class GenerateShapeAttribute : Attribute;
 /// implementation that includes <typeparamref name="T"/>.
 /// </summary>
 /// <typeparam name="T">The type for which shape metadata will be generated.</typeparam>
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
 public sealed class GenerateShapeAttribute<T> : Attribute;

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
@@ -309,19 +309,27 @@ public static class CompilationTests
         Assert.Empty(result.Diagnostics);
     }
 
-    [Fact]
-    public static void RecordWitnessType_NoErrors()
+    [Theory]
+    [InlineData("partial class")]
+    [InlineData("sealed partial class")]
+    [InlineData("partial struct")]
+    [InlineData("partial record")]
+    [InlineData("sealed partial record")]
+    [InlineData("partial record struct")]
+    public static void SupportedWitnessTypeKinds_NoErrors(string kind)
     {
-        Compilation compilation = CompilationHelpers.CreateCompilation("""
+        Compilation compilation = CompilationHelpers.CreateCompilation($"""
             using PolyType;
             using PolyType.Abstractions;
 
-            ITypeShape<MyPoco> shape = TypeShapeProvider.Resolve<MyPoco, Witness>();
+            ITypeShape<MyPoco> shape;
+            shape = TypeShapeProvider.Resolve<MyPoco, Witness>();
+            shape = TypeShapeProvider.Resolve<MyPoco>(Witness.ShapeProvider);
 
             record MyPoco(string[] Values);
 
             [GenerateShape<MyPoco>]
-            partial record Witness;
+            {kind} Witness;
             """, outputKind: OutputKind.ConsoleApplication);
 
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);

--- a/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
@@ -210,4 +210,46 @@ public static class DiagnosticTests
         Assert.Equal((9, 11), diagnostic.Location.GetStartPosition());
         Assert.Equal((9, 17), diagnostic.Location.GetEndPosition());
     }
+
+    [Fact]
+    public static void GenerateShapeOnStaticClass_ProducesError()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+           using PolyType;
+
+           [GenerateShape]
+           static partial class MyClass;
+           """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+
+        Assert.Equal("TS0007", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Equal((2, 0), diagnostic.Location.GetStartPosition());
+        Assert.Equal((3, 29), diagnostic.Location.GetEndPosition());
+    }
+
+    [Fact]
+    public static void GenerateShapeOfTOnStaticClass_ProducesError()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+           using PolyType;
+
+           [GenerateShape<MyPoco>]
+           static partial class Witness;
+
+           record MyPoco;
+           """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+
+        Assert.Equal("TS0007", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Equal((2, 0), diagnostic.Location.GetStartPosition());
+        Assert.Equal((3, 29), diagnostic.Location.GetEndPosition());
+    }
 }

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -666,12 +666,20 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
 public sealed class TypeShapeProviderTests_NoNullableAnnotations() : TypeShapeProviderTests(RefectionProviderUnderTest.NoNullableAnnotations);
 public sealed class TypeShapeProviderTests_SourceGen() : TypeShapeProviderTests(SourceGenProviderUnderTest.Default)
 {
+    [Fact]
+    public void WitnessType_ShapeProvider_IsSingleton()
+    {
+        ITypeShapeProvider provider = SourceGenProvider.ShapeProvider;
+
+        Assert.NotNull(provider);
+        Assert.Same(provider, SourceGenProvider.ShapeProvider);
+    }
+
     [Theory]
     [MemberData(nameof(TestTypes.GetTestCases), MemberType = typeof(TestTypes))]
-    public void WitnessType_ImplementsITypeShapeProvider(ITestCase testCase)
+    public void WitnessType_ShapeProvider_MatchesGeneratedShapes(ITestCase testCase)
     {
-        SourceGenProvider provider = new();
-        ITypeShapeProvider shapeProvider = Assert.IsAssignableFrom<ITypeShapeProvider>(provider);
-        Assert.Same(testCase.DefaultShape, shapeProvider.GetShape(testCase.Type));
+        Assert.Same(SourceGenProvider.ShapeProvider, testCase.DefaultShape.Provider);
+        Assert.Same(testCase.DefaultShape, SourceGenProvider.ShapeProvider.GetShape(testCase.Type));
     }
 }


### PR DESCRIPTION
Rework the witness type generation scheme so that the `ITypeShapeProvider` is exposed as a generated `ShapeProvider` static property rather than having the witness type implement the interface itself. This is to make sure that the same singleton provider is always returned to users that might need it, which makes it easier to define caches that are keyed on the particular singleton.

cc @AArnott 