### PR TITLE
Remove use of DIMs in the abstraction types.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -158,3 +158,6 @@ dotnet_diagnostic.IDE0005.severity = none
 
 # xUnit2005: Do not use identity check on value type
 dotnet_diagnostic.xUnit2005.severity = none
+
+# SA1208: System using directives should be placed before other using directives
+dotnet_diagnostic.SA1208.severity = none

--- a/applications/ConfigurationBinder.AOT/ConfigurationBinder.AOT.csproj
+++ b/applications/ConfigurationBinder.AOT/ConfigurationBinder.AOT.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PublishAot>true</PublishAot>

--- a/applications/ObjectMapper.AOT/ObjectMapper.AOT.csproj
+++ b/applications/ObjectMapper.AOT/ObjectMapper.AOT.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>

--- a/applications/RandomGeneratorApp.AOT/RandomGeneratorApp.AOT.csproj
+++ b/applications/RandomGeneratorApp.AOT/RandomGeneratorApp.AOT.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>

--- a/applications/SerializationApp.AOT/SerializationApp.AOT.csproj
+++ b/applications/SerializationApp.AOT/SerializationApp.AOT.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <Nullable>enable</Nullable>

--- a/applications/SerializationApp.Reflection/SerializationApp.Reflection.csproj
+++ b/applications/SerializationApp.Reflection/SerializationApp.Reflection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>

--- a/applications/ValidationApp.AOT/ValidationApp.AOT.csproj
+++ b/applications/ValidationApp.AOT/ValidationApp.AOT.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>

--- a/src/PolyType/Abstractions/IConstructorParameterShape.cs
+++ b/src/PolyType/Abstractions/IConstructorParameterShape.cs
@@ -103,8 +103,4 @@ public interface IConstructorParameterShape<TArgumentState, TParameterType> : IC
     /// The default value specified by the parameter, if applicable.
     /// </summary>
     new TParameterType? DefaultValue { get; }
-
-    ITypeShape IConstructorParameterShape.ParameterType => ParameterType;
-    object? IConstructorParameterShape.DefaultValue => DefaultValue;
-    object? IConstructorParameterShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitConstructorParameter(this, state);
 }

--- a/src/PolyType/Abstractions/IConstructorShape.cs
+++ b/src/PolyType/Abstractions/IConstructorShape.cs
@@ -78,7 +78,4 @@ public interface IConstructorShape<TDeclaringType, TArgumentState> : IConstructo
     /// <exception cref="InvalidOperationException">The <see cref="IConstructorShape.ParameterCount"/> of the constructor is zero.</exception>
     /// <returns>A parameterized delegate returning an instance of <typeparamref name="TDeclaringType"/>.</returns>
     Constructor<TArgumentState, TDeclaringType> GetParameterizedConstructor();
-
-    IObjectTypeShape IConstructorShape.DeclaringType => DeclaringType;
-    object? IConstructorShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitConstructor(this, state);
 }

--- a/src/PolyType/Abstractions/IDictionaryTypeShape.cs
+++ b/src/PolyType/Abstractions/IDictionaryTypeShape.cs
@@ -102,13 +102,4 @@ public interface IDictionaryTypeShape<TDictionary, TKey, TValue> : ITypeShape<TD
     /// <exception cref="InvalidOperationException">The collection is not <see cref="CollectionConstructionStrategy.Enumerable"/>.</exception>
     /// <returns>A delegate constructing a collection from an enumerable of values.</returns>
     Func<IEnumerable<KeyValuePair<TKey, TValue>>, TDictionary> GetEnumerableConstructor();
-
-    /// <inheritdoc/>
-    ITypeShape IDictionaryTypeShape.KeyType => KeyType;
-
-    /// <inheritdoc/>
-    ITypeShape IDictionaryTypeShape.ValueType => ValueType;
-
-    /// <inheritdoc/>
-    object? ITypeShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitDictionary(this, state);
 }

--- a/src/PolyType/Abstractions/IEnumTypeShape.cs
+++ b/src/PolyType/Abstractions/IEnumTypeShape.cs
@@ -9,9 +9,6 @@ public interface IEnumTypeShape : ITypeShape
     /// The shape of the underlying type used to represent the enum.
     /// </summary>
     ITypeShape UnderlyingType { get; }
-
-    /// <inheritdoc/>
-    TypeShapeKind ITypeShape.Kind => TypeShapeKind.Enum;
 }
 
 /// <summary>
@@ -26,10 +23,4 @@ public interface IEnumTypeShape<TEnum, TUnderlying> : ITypeShape<TEnum>, IEnumTy
     /// The shape of the underlying type used to represent the enum.
     /// </summary>
     new ITypeShape<TUnderlying> UnderlyingType { get; }
-
-    /// <inheritdoc/>
-    ITypeShape IEnumTypeShape.UnderlyingType => UnderlyingType;
-
-    /// <inheritdoc/>
-    object? ITypeShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitEnum(this, state);
 }

--- a/src/PolyType/Abstractions/IEnumerableTypeShape.cs
+++ b/src/PolyType/Abstractions/IEnumerableTypeShape.cs
@@ -27,9 +27,6 @@ public interface IEnumerableTypeShape : ITypeShape
     /// Gets the rank of the enumerable, if a multi-dimensional array.
     /// </summary>
     int Rank { get; }
-
-    /// <inheritdoc/>
-    TypeShapeKind ITypeShape.Kind => TypeShapeKind.Enumerable;
 }
 
 /// <summary>
@@ -89,10 +86,4 @@ public interface IEnumerableTypeShape<TEnumerable, TElement> : ITypeShape<TEnume
     /// <exception cref="InvalidOperationException">The collection is not <see cref="CollectionConstructionStrategy.Enumerable"/>.</exception>
     /// <returns>A delegate constructing a collection from an enumerable of values.</returns>
     Func<IEnumerable<TElement>, TEnumerable> GetEnumerableConstructor();
-
-    /// <inheritdoc/>
-    ITypeShape IEnumerableTypeShape.ElementType => ElementType;
-
-    /// <inheritdoc/>
-    object? ITypeShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitEnumerable(this, state);
 }

--- a/src/PolyType/Abstractions/INullableTypeShape.cs
+++ b/src/PolyType/Abstractions/INullableTypeShape.cs
@@ -9,9 +9,6 @@ public interface INullableTypeShape : ITypeShape
     /// The shape of the element type of the nullable.
     /// </summary>
     ITypeShape ElementType { get; }
-
-    /// <inheritdoc/>
-    TypeShapeKind ITypeShape.Kind => TypeShapeKind.Nullable;
 }
 
 /// <summary>
@@ -25,10 +22,4 @@ public interface INullableTypeShape<T> : ITypeShape<T?>, INullableTypeShape
     /// The shape of the element type of the nullable.
     /// </summary>
     new ITypeShape<T> ElementType { get; }
-
-    /// <inheritdoc/>
-    ITypeShape INullableTypeShape.ElementType => ElementType;
-
-    /// <inheritdoc/>
-    object? ITypeShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitNullable(this, state);
 }

--- a/src/PolyType/Abstractions/IObjectTypeShape.cs
+++ b/src/PolyType/Abstractions/IObjectTypeShape.cs
@@ -36,17 +36,10 @@ public interface IObjectTypeShape : ITypeShape
     /// </summary>
     /// <returns>A <see cref="IConstructorShape"/> representation of the constructor.</returns>
     IConstructorShape? GetConstructor();
-
-    /// <inheritdoc/>
-    TypeShapeKind ITypeShape.Kind => TypeShapeKind.Object;
 }
 
 /// <summary>
 /// Provides a strongly typed shape model for a .NET object.
 /// </summary>
 /// <typeparam name="T">The type of .NET object.</typeparam>
-public interface IObjectTypeShape<T> : ITypeShape<T>, IObjectTypeShape
-{
-    /// <inheritdoc/>
-    object? ITypeShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitObject(this, state);
-}
+public interface IObjectTypeShape<T> : ITypeShape<T>, IObjectTypeShape;

--- a/src/PolyType/Abstractions/IPropertyShape.cs
+++ b/src/PolyType/Abstractions/IPropertyShape.cs
@@ -116,13 +116,4 @@ public interface IPropertyShape<TDeclaringType, TPropertyType> : IPropertyShape
     /// <exception cref="InvalidOperationException">The property has no accessible setter.</exception>
     /// <returns>A setter delegate for the property.</returns>
     Setter<TDeclaringType, TPropertyType> GetSetter();
-
-    /// <inheritdoc/>
-    IObjectTypeShape IPropertyShape.DeclaringType => DeclaringType;
-
-    /// <inheritdoc/>
-    ITypeShape IPropertyShape.PropertyType => PropertyType;
-
-    /// <inheritdoc/>
-    object? IPropertyShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitProperty(this, state);
 }

--- a/src/PolyType/Abstractions/ITypeShape.cs
+++ b/src/PolyType/Abstractions/ITypeShape.cs
@@ -48,9 +48,4 @@ public interface ITypeShape
 /// Provides a strongly typed shape model for a given .NET type.
 /// </summary>
 /// <typeparam name="T">The type that the shape describes.</typeparam>
-public interface ITypeShape<T> : ITypeShape
-{
-    Type ITypeShape.Type => typeof(T);
-    ICustomAttributeProvider ITypeShape.AttributeProvider => typeof(T);
-    object? ITypeShape.Invoke(ITypeShapeFunc function, object? state) => function.Invoke(this, state);
-}
+public interface ITypeShape<T> : ITypeShape;

--- a/src/PolyType/ReflectionProvider/ReflectionConstructorParameterShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionConstructorParameterShape.cs
@@ -37,6 +37,8 @@ internal sealed class ReflectionConstructorParameterShape<TArgumentState, TParam
     public TParameter? DefaultValue => (TParameter?)_parameterInfo.DefaultValue;
     object? IConstructorParameterShape.DefaultValue => _parameterInfo.DefaultValue;
     public ICustomAttributeProvider? AttributeProvider => _parameterInfo.AttributeProvider;
+    ITypeShape IConstructorParameterShape.ParameterType => ParameterType;
+    object? IConstructorParameterShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitConstructorParameter(this, state);
 
     public Setter<TArgumentState, TParameter> GetSetter()
         => _provider.MemberAccessor.CreateConstructorArgumentStateSetter<TArgumentState, TParameter>(_ctorInfo, Position);

--- a/src/PolyType/ReflectionProvider/ReflectionConstructorShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionConstructorShape.cs
@@ -14,6 +14,8 @@ internal sealed class ReflectionConstructorShape<TDeclaringType, TArgumentState>
     public int ParameterCount => ctorInfo.Parameters.Length;
     public ICustomAttributeProvider? AttributeProvider => ctorInfo.AttributeProvider;
     public bool IsPublic => ctorInfo.IsPublic;
+    IObjectTypeShape IConstructorShape.DeclaringType => DeclaringType;
+    object? IConstructorShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitConstructor(this, state);
 
     public Func<TArgumentState> GetArgumentStateConstructor()
     {

--- a/src/PolyType/ReflectionProvider/ReflectionEnumTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumTypeShape.cs
@@ -2,9 +2,11 @@
 
 namespace PolyType.ReflectionProvider;
 
-internal sealed class ReflectionEnumTypeShape<TEnum, TUnderlying>(ReflectionTypeShapeProvider provider) : IEnumTypeShape<TEnum, TUnderlying>
+internal sealed class ReflectionEnumTypeShape<TEnum, TUnderlying>(ReflectionTypeShapeProvider provider) : ReflectionTypeShape<TEnum>(provider), IEnumTypeShape<TEnum, TUnderlying>
     where TEnum : struct, Enum
 {
-    public ITypeShape<TUnderlying> UnderlyingType => provider.GetShape<TUnderlying>();
-    public ITypeShapeProvider Provider => provider;
+    public override TypeShapeKind Kind => TypeShapeKind.Enum;
+    public override object? Accept(ITypeShapeVisitor visitor, object? state = null) => visitor.VisitEnum(this, state);
+    public ITypeShape<TUnderlying> UnderlyingType => Provider.GetShape<TUnderlying>();
+    ITypeShape IEnumTypeShape.UnderlyingType => UnderlyingType;
 }

--- a/src/PolyType/ReflectionProvider/ReflectionNullableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionNullableTypeShape.cs
@@ -2,9 +2,11 @@
 
 namespace PolyType.ReflectionProvider;
 
-internal sealed class ReflectionNullableTypeShape<T>(ReflectionTypeShapeProvider provider) : INullableTypeShape<T>
+internal sealed class ReflectionNullableTypeShape<T>(ReflectionTypeShapeProvider provider) : ReflectionTypeShape<T?>(provider), INullableTypeShape<T>
     where T : struct
 {
-    public ITypeShape<T> ElementType => provider.GetShape<T>();
-    public ITypeShapeProvider Provider => provider;
+    public override TypeShapeKind Kind => TypeShapeKind.Nullable;
+    public override object? Accept(ITypeShapeVisitor visitor, object? state = null) => visitor.VisitNullable(this, state);
+    public ITypeShape<T> ElementType => Provider.GetShape<T>();
+    ITypeShape INullableTypeShape.ElementType => ElementType;
 }

--- a/src/PolyType/ReflectionProvider/ReflectionPropertyShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionPropertyShape.cs
@@ -59,6 +59,10 @@ internal sealed class ReflectionPropertyShape<TDeclaringType, TPropertyType> : I
     public bool HasGetter { get; }
     public bool HasSetter { get; }
 
+    IObjectTypeShape IPropertyShape.DeclaringType => DeclaringType;
+    ITypeShape IPropertyShape.PropertyType => PropertyType;
+    object? IPropertyShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitProperty(this, state);
+
     public Getter<TDeclaringType, TPropertyType> GetGetter()
     {
         if (!HasGetter)

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShape.cs
@@ -1,0 +1,16 @@
+﻿using PolyType.Abstractions;
+using System.Reflection;
+
+namespace PolyType.ReflectionProvider;
+
+internal abstract class ReflectionTypeShape<T>(ReflectionTypeShapeProvider provider) : ITypeShape<T>
+{
+    public abstract TypeShapeKind Kind { get; }
+    public abstract object? Accept(ITypeShapeVisitor visitor, object? state = null);
+    public ReflectionTypeShapeProvider Provider => provider;
+    public Type Type => typeof(T);
+
+    ITypeShapeProvider ITypeShape.Provider => provider;
+    ICustomAttributeProvider? ITypeShape.AttributeProvider => typeof(T);
+    object? ITypeShape.Invoke(ITypeShapeFunc function, object? state) => function.Invoke(this, state);
+}

--- a/src/PolyType/SourceGenModel/SourceGenConstructorParameterShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenConstructorParameterShape.cs
@@ -68,5 +68,6 @@ public sealed class SourceGenConstructorParameterShape<TArgumentState, TParamete
     object? IConstructorParameterShape.DefaultValue => HasDefaultValue ? DefaultValue : null;
     ITypeShape IConstructorParameterShape.ParameterType => ParameterType;
     ICustomAttributeProvider? IConstructorParameterShape.AttributeProvider => AttributeProviderFunc?.Invoke();
+    object? IConstructorParameterShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitConstructorParameter(this, state);
     Setter<TArgumentState, TParameter> IConstructorParameterShape<TArgumentState, TParameter>.GetSetter() => Setter;
 }

--- a/src/PolyType/SourceGenModel/SourceGenConstructorShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenConstructorShape.cs
@@ -62,5 +62,7 @@ public sealed class SourceGenConstructorShape<TDeclaringType, TArgumentState> : 
     Constructor<TArgumentState, TDeclaringType> IConstructorShape<TDeclaringType, TArgumentState>.GetParameterizedConstructor()
         => ParameterizedConstructorFunc ?? throw new InvalidOperationException("Constructor shape does not specify a parameterized constructor.");
 
+    object? IConstructorShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitConstructor(this, state);
     ICustomAttributeProvider? IConstructorShape.AttributeProvider => AttributeProviderFunc?.Invoke();
+    IObjectTypeShape IConstructorShape.DeclaringType => DeclaringType;
 }

--- a/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
@@ -8,14 +8,9 @@ namespace PolyType.SourceGenModel;
 /// <typeparam name="TDictionary">The type of the dictionary.</typeparam>
 /// <typeparam name="TKey">The type of the dictionary key.</typeparam>
 /// <typeparam name="TValue">The type of the dictionary value.</typeparam>
-public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : IDictionaryTypeShape<TDictionary, TKey, TValue>
+public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : SourceGenTypeShape<TDictionary>, IDictionaryTypeShape<TDictionary, TKey, TValue>
     where TKey : notnull
 {
-    /// <summary>
-    /// The provider that generated this shape.
-    /// </summary>
-    public required ITypeShapeProvider Provider { get; init; }
-
     /// <summary>
     /// The type shape of the dictionary key.
     /// </summary>
@@ -55,6 +50,15 @@ public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : ID
     /// The function that constructs a dictionary from a span of key-value pairs.
     /// </summary>
     public SpanConstructor<KeyValuePair<TKey, TValue>, TDictionary>? SpanConstructorFunc { get; init; }
+
+    /// <inheritdoc/>
+    public override TypeShapeKind Kind => TypeShapeKind.Dictionary;
+
+    /// <inheritdoc/>
+    public override object? Accept(ITypeShapeVisitor visitor, object? state = null) => visitor.VisitDictionary(this, state);
+
+    ITypeShape IDictionaryTypeShape.KeyType => KeyType;
+    ITypeShape IDictionaryTypeShape.ValueType => ValueType;
 
     Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> IDictionaryTypeShape<TDictionary, TKey, TValue>.GetGetDictionary()
         => GetDictionaryFunc;

--- a/src/PolyType/SourceGenModel/SourceGenEnumTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenEnumTypeShape.cs
@@ -7,16 +7,19 @@ namespace PolyType.SourceGenModel;
 /// </summary>
 /// <typeparam name="TEnum">The type of the enum.</typeparam>
 /// <typeparam name="TUnderlying">The type of the underlying type of the enum.</typeparam>
-public sealed class SourceGenEnumTypeShape<TEnum, TUnderlying> : IEnumTypeShape<TEnum, TUnderlying>
+public sealed class SourceGenEnumTypeShape<TEnum, TUnderlying> : SourceGenTypeShape<TEnum>, IEnumTypeShape<TEnum, TUnderlying>
     where TEnum : struct, Enum
 {
-    /// <summary>
-    /// The provider that generated this shape.
-    /// </summary>
-    public required ITypeShapeProvider Provider { get; init; }
-
     /// <summary>
     /// The shape of the underlying type of the enum.
     /// </summary>
     public required ITypeShape<TUnderlying> UnderlyingType { get; init; }
+
+    /// <inheritdoc/>
+    public override TypeShapeKind Kind => TypeShapeKind.Enum;
+
+    /// <inheritdoc/>
+    public override object? Accept(ITypeShapeVisitor visitor, object? state = null) => visitor.VisitEnum(this, state);
+
+    ITypeShape IEnumTypeShape.UnderlyingType => UnderlyingType;
 }

--- a/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
@@ -7,13 +7,8 @@ namespace PolyType.SourceGenModel;
 /// </summary>
 /// <typeparam name="TEnumerable">The type of the enumerable collection.</typeparam>
 /// <typeparam name="TElement">The element type of the collection.</typeparam>
-public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : IEnumerableTypeShape<TEnumerable, TElement>
+public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : SourceGenTypeShape<TEnumerable>, IEnumerableTypeShape<TEnumerable, TElement>
 {
-    /// <summary>
-    /// The provider that generated this shape.
-    /// </summary>
-    public required ITypeShapeProvider Provider { get; init; }
-
     /// <summary>
     /// The shape of the element type.
     /// </summary>
@@ -53,6 +48,14 @@ public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : IEnume
     /// The function that constructs a collection from a span.
     /// </summary>
     public SpanConstructor<TElement, TEnumerable>? SpanConstructorFunc { get; init; }
+
+    /// <inheritdoc/>
+    public override TypeShapeKind Kind => TypeShapeKind.Enumerable;
+
+    /// <inheritdoc/>
+    public override object? Accept(ITypeShapeVisitor visitor, object? state = null) => visitor.VisitEnumerable(this, state);
+
+    ITypeShape IEnumerableTypeShape.ElementType => ElementType;
 
     Func<TEnumerable, IEnumerable<TElement>> IEnumerableTypeShape<TEnumerable, TElement>.GetGetEnumerable()
         => GetEnumerableFunc;

--- a/src/PolyType/SourceGenModel/SourceGenNullableTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenNullableTypeShape.cs
@@ -6,16 +6,19 @@ namespace PolyType.SourceGenModel;
 /// Source generator model for nullable types.
 /// </summary>
 /// <typeparam name="T">The element type of the nullable type.</typeparam>
-public sealed class SourceGenNullableTypeShape<T> : INullableTypeShape<T>
+public sealed class SourceGenNullableTypeShape<T> : SourceGenTypeShape<T?>, INullableTypeShape<T>
     where T : struct
 {
-    /// <summary>
-    /// The provider that generated this shape.
-    /// </summary>
-    public required ITypeShapeProvider Provider { get; init; }
-
     /// <summary>
     /// The shape of the element type.
     /// </summary>
     public required ITypeShape<T> ElementType { get; init; }
+
+    /// <inheritdoc/>
+    public override TypeShapeKind Kind => TypeShapeKind.Nullable;
+
+    /// <inheritdoc/>
+    public override object? Accept(ITypeShapeVisitor visitor, object? state = null) => visitor.VisitNullable(this, state);
+
+    ITypeShape INullableTypeShape.ElementType => ElementType;
 }

--- a/src/PolyType/SourceGenModel/SourceGenObjectTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenObjectTypeShape.cs
@@ -6,13 +6,8 @@ namespace PolyType.SourceGenModel;
 /// Source generator model for object type shapes.
 /// </summary>
 /// <typeparam name="TObject">The type whose shape is described.</typeparam>
-public sealed class SourceGenObjectTypeShape<TObject> : IObjectTypeShape<TObject>
+public sealed class SourceGenObjectTypeShape<TObject> : SourceGenTypeShape<TObject>, IObjectTypeShape<TObject>
 {
-    /// <summary>
-    /// The provider that generated this shape.
-    /// </summary>
-    public required ITypeShapeProvider Provider { get; init; }
-
     /// <summary>
     /// Whether the type represents a record.
     /// </summary>
@@ -33,12 +28,18 @@ public sealed class SourceGenObjectTypeShape<TObject> : IObjectTypeShape<TObject
     /// </summary>
     public Func<IConstructorShape>? CreateConstructorFunc { get; init; }
 
+    /// <inheritdoc/>
+    public override TypeShapeKind Kind => TypeShapeKind.Object;
+
+    /// <inheritdoc/>
+    public override object? Accept(ITypeShapeVisitor visitor, object? state = null) => visitor.VisitObject(this, state);
+
+    bool IObjectTypeShape.HasProperties => CreatePropertiesFunc is not null;
+    bool IObjectTypeShape.HasConstructor => CreateConstructorFunc is not null;
+
     IEnumerable<IPropertyShape> IObjectTypeShape.GetProperties() =>
         CreatePropertiesFunc?.Invoke() ?? [];
 
     IConstructorShape? IObjectTypeShape.GetConstructor() =>
         CreateConstructorFunc?.Invoke();
-
-    bool IObjectTypeShape.HasProperties => CreatePropertiesFunc != null;
-    bool IObjectTypeShape.HasConstructor => CreateConstructorFunc != null;
 }

--- a/src/PolyType/SourceGenModel/SourceGenPropertyShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenPropertyShape.cs
@@ -71,7 +71,10 @@ public sealed class SourceGenPropertyShape<TDeclaringType, TPropertyType> : IPro
     Setter<TDeclaringType, TPropertyType> IPropertyShape<TDeclaringType, TPropertyType>.GetSetter()
         => Setter is { } setter ? setter : throw new InvalidOperationException("Property shape does not specify a setter.");
 
+    ITypeShape IPropertyShape.PropertyType => PropertyType;
+    IObjectTypeShape IPropertyShape.DeclaringType => DeclaringType;
     bool IPropertyShape.HasGetter => Getter is not null;
     bool IPropertyShape.HasSetter => Setter is not null;
     ICustomAttributeProvider? IPropertyShape.AttributeProvider => AttributeProviderFunc?.Invoke();
+    object? IPropertyShape.Accept(ITypeShapeVisitor visitor, object? state) => visitor.VisitProperty(this, state);
 }

--- a/src/PolyType/SourceGenModel/SourceGenTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenTypeShape.cs
@@ -1,0 +1,35 @@
+﻿using PolyType.Abstractions;
+using System.Reflection;
+
+namespace PolyType.SourceGenModel;
+
+/// <summary>
+/// Source generator model for type shapes.
+/// </summary>
+/// <typeparam name="T">The type that the shape describes.</typeparam>
+public abstract class SourceGenTypeShape<T> : ITypeShape<T>
+{
+    /// <summary>
+    /// Determines the <see cref="TypeShapeKind"/> that the current shape supports.
+    /// </summary>
+    public abstract TypeShapeKind Kind { get; }
+
+    /// <summary>
+    /// The provider used to generate this instance.
+    /// </summary>
+    public required ITypeShapeProvider Provider { get; init; }
+
+    Type ITypeShape.Type => typeof(T);
+    ICustomAttributeProvider? ITypeShape.AttributeProvider => typeof(T);
+
+    /// <summary>
+    /// Accepts an <see cref="ITypeShapeVisitor"/> for strongly-typed traversal.
+    /// </summary>
+    /// <param name="visitor">The visitor to accept.</param>
+    /// <param name="state">The state parameter to pass to the underlying visitor.</param>
+    /// <returns>The <see cref="object"/> result returned by the visitor.</returns>
+    public abstract object? Accept(ITypeShapeVisitor visitor, object? state = null);
+
+    /// <inheritdoc/>
+    object? ITypeShape.Invoke(ITypeShapeFunc function, object? state) => function.Invoke(this, state);
+}


### PR DESCRIPTION
Contributes to #49. Works around https://github.com/dotnet/runtime/issues/109893.