### PR TITLE
Add link to release notes to nuget package metadata

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -36,4 +36,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
+  <Target Name="PrepareReleaseNotes" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
+    <PropertyGroup>
+      <PackageReleaseNotes Condition="'$(RepositoryUrl)'!=''">$(RepositoryUrl)/releases/tag/v$(Version)</PackageReleaseNotes>
+    </PropertyGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
The nuget.org gallery will show a Release Notes tab for packages that carry this metadata. Rather than be obligated to copy the release notes into the metadata directly, I find it convenient to merely link to the release notes on the GitHub release (which I see you already create).

However one change would be necessary in your workflow: I see that you release 0.x.1 to nuget.org, but your tag and github release name are merely v0.x. For this auto-linking to work, the github release must match the nuget version number (with a 'v' prefix added).
So only merge this if you're willing for your next release and tag name to be `v0.24.1`.

And FWIW, my workflow tends to be to run `nbgv tag` locally and push the tag it creates, thereby ensuring that the tag name and the nuget package version always agree. Then I go to GitHub's releases page and create a release based on that pre-created tag.