### PR TITLE
Add net6.0 to the test targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,11 @@ jobs:
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: |
+            9.0.x
+            6.0.x
     - name: Build & Test
       run: make
 
@@ -32,9 +34,11 @@ jobs:
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: |
+            9.0.x
+            6.0.x
     - name: Build & Test
       run: make
     - name: Upload to Codecov
@@ -51,8 +55,10 @@ jobs:
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: |
+            9.0.x
+            6.0.x
     - name: Build & Test
       run: make

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <!-- Use a pre .NET 8 build of S.C.Immutable that doesn't support literals. -->
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageVersion Include="System.Formats.Cbor" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Formats.Cbor" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="JsonSchema.Net" Version="7.2.3" />
     <PackageVersion Include="FSharp.Core" Version="8.0.401" />

--- a/tests/PolyType.Roslyn.Tests/PolyType.Roslyn.Tests.csproj
+++ b/tests/PolyType.Roslyn.Tests/PolyType.Roslyn.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationHelpers.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationHelpers.cs
@@ -246,7 +246,7 @@ public static class CompilationHelpers
         return (lineSpan.EndLinePosition.Line, lineSpan.EndLinePosition.Character);
     }
 
-#if !NET || !NET8_0_OR_GREATER
+#if !NET || NET6_0
     private const string PolyfillAttributes = """
         namespace System.Runtime.CompilerServices
         {

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
@@ -27,7 +27,7 @@ public static class CompilationTests
                 public List<int> List { get; set; }
                 public Dictionary<string, int> Dict { get; set; }
 
-            #if NET
+            #if NET8_0_OR_GREATER
                 public static PolyType.Abstractions.ITypeShape<MyPoco> Test()
                     => PolyType.Abstractions.TypeShapeProvider.Resolve<MyPoco>();
             #endif
@@ -119,7 +119,7 @@ public static class CompilationTests
         Assert.Empty(result.Diagnostics);
     }
 
-#if NET
+#if NET8_0_OR_GREATER
     [Fact]
     public static void UseTypesWithNullableAnnotations_NoWarnings()
     {
@@ -187,7 +187,7 @@ public static class CompilationTests
         Compilation compilation = CompilationHelpers.CreateCompilation("""
             using PolyType;
 
-            #if NET
+            #if NET8_0_OR_GREATER
             public static class Test
             {
                 public static void TestMethod()
@@ -327,7 +327,7 @@ public static class CompilationTests
             using PolyType.Abstractions;
 
             ITypeShape<MyPoco> shape;
-            #if NET
+            #if NET8_0_OR_GREATER
             shape = TypeShapeProvider.Resolve<MyPoco, Witness>();
             #endif
             shape = TypeShapeProvider.Resolve<MyPoco>(Witness.ShapeProvider);

--- a/tests/PolyType.SourceGenerator.UnitTests/PolyType.SourceGenerator.UnitTests.csproj
+++ b/tests/PolyType.SourceGenerator.UnitTests/PolyType.SourceGenerator.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/PolyType.Tests/CborTests.cs
+++ b/tests/PolyType.Tests/CborTests.cs
@@ -55,7 +55,7 @@ public abstract partial class CborTests(ProviderUnderTest providerUnderTest)
         yield return [TestCase.Create(Guid.Empty, p), "D903EA5000000000000000000000000000000000"];
         yield return [TestCase.Create(TimeSpan.MinValue, p), "D825FBC26AD7F29ABCAF48"];
         yield return [TestCase.Create(DateTimeOffset.MinValue, p), "C074303030312D30312D30315430303A30303A30305A"];
-#if NET
+#if NET8_0_OR_GREATER
         yield return [TestCase.Create(Int128.MaxValue, p), "C2507FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"];
         yield return [TestCase.Create((Half)3.14, p), "F94248"];
         yield return [TestCase.Create(DateOnly.MaxValue, p), "C074393939392D31322D33315430303A30303A30305A"];

--- a/tests/PolyType.Tests/JsonSchemaTests.cs
+++ b/tests/PolyType.Tests/JsonSchemaTests.cs
@@ -95,7 +95,7 @@ public abstract class JsonSchemaTests(ProviderUnderTest providerUnderTest)
     [MemberData(nameof(TestTypes.GetTestCases), MemberType = typeof(TestTypes))]
     public void SchemaMatchesJsonSerializer<T>(TestCase<T> testCase)
     {
-#if NET
+#if NET8_0_OR_GREATER
         if (typeof(T) == typeof(Int128) || typeof(T) == typeof(UInt128) ||
             typeof(T) == typeof(Int128?) || typeof(T) == typeof(UInt128?))
         {

--- a/tests/PolyType.Tests/JsonTests.cs
+++ b/tests/PolyType.Tests/JsonTests.cs
@@ -269,7 +269,7 @@ public abstract partial class JsonTests(ProviderUnderTest providerUnderTest)
 
     public static IEnumerable<object?[]> GetMultiDimensionalArraysAndExpectedJson()
     {
-#if NET
+#if NET8_0_OR_GREATER
         Witness p = new();
 #else
         ITypeShapeProvider p = Witness.ShapeProvider;
@@ -345,7 +345,7 @@ public abstract partial class JsonTests(ProviderUnderTest providerUnderTest)
         { 
             new JsonStringEnumConverter(),
             new BigIntegerConverter(),
-#if NET
+#if NET8_0_OR_GREATER
             new RuneConverter(),
 #endif
         },

--- a/tests/PolyType.Tests/PolyType.Tests.csproj
+++ b/tests/PolyType.Tests/PolyType.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -20,6 +20,10 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Compile Include="..\..\src\Shared\Polyfills\LinkerAttributes\*.cs " Link="Shared\Polyfills\LinkerAttributes\%(Filename).cs" />
     <Compile Include="..\..\src\Shared\Polyfills\NullabilityInfo\*.cs " Link="Shared\Polyfills\NullabilityInfo\%(Filename).cs" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <Compile Include="..\..\src\Shared\Polyfills\LinkerAttributes\RequiresDynamicCodeAttribute.cs" Link="Shared\Polyfills\LinkerAttributes\%(Filename).cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -723,7 +723,7 @@ public sealed class TypeShapeProviderTests_SourceGen() : TypeShapeProviderTests(
         Assert.Same(testCase.DefaultShape, Witness.ShapeProvider.GetShape(testCase.Type));
     }
 
-#if NET
+#if NET8_0_OR_GREATER
     [Theory]
     [MemberData(nameof(TestTypes.GetTestCases), MemberType = typeof(TestTypes))]
     public void IShapeableOfT_ReturnsExpectedSingleton<T, TProvider>(TestCase<T, TProvider> testCase)

--- a/tests/PolyType.Tests/XmlTests.cs
+++ b/tests/PolyType.Tests/XmlTests.cs
@@ -69,7 +69,7 @@ public abstract class XmlTests(ProviderUnderTest providerUnderTest)
         yield return [TestCase.Create(Guid.Empty, p), "<value>00000000-0000-0000-0000-000000000000</value>"];
         yield return [TestCase.Create(TimeSpan.MinValue, p), "<value>-10675199.02:48:05.4775808</value>"];
         yield return [TestCase.Create(DateTimeOffset.MinValue, p), "<value>0001-01-01T00:00:00Z</value>"];
-#if NET
+#if NET8_0_OR_GREATER
         yield return [TestCase.Create(Int128.MaxValue, p), "<value>170141183460469231731687303715884105727</value>"];
         yield return [TestCase.Create((Half)1, p), "<value>1</value>"];
         yield return [TestCase.Create(DateOnly.MaxValue, p), "<value>9999-12-31</value>"];


### PR DESCRIPTION
Even though net6.0 is now out of support, it provides a good way to test the `netstandard2.0` build of the library in non-Windows environments.