### PR TITLE
Use IReadOnlyList when modelling properties and constructor params

### DIFF
--- a/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
@@ -25,13 +25,11 @@ public static partial class CborSerializer
 
         public object? VisitObject<T>(IObjectTypeShape<T> objectShape, object? state)
         {
-            CborPropertyConverter<T>[] properties = objectShape
-                .GetProperties()
+            CborPropertyConverter<T>[] properties = objectShape.Properties
                 .Select(prop => (CborPropertyConverter<T>)prop.Accept(this)!)
                 .ToArray();
             
-            IConstructorShape? ctor = objectShape.GetConstructor();
-            return ctor != null
+            return objectShape.Constructor is { } ctor
                 ? (CborObjectConverter<T>)ctor.Accept(this, state: properties)!
                 : new CborObjectConverter<T>(properties);
         }
@@ -46,13 +44,12 @@ public static partial class CborSerializer
         {
             var properties = (CborPropertyConverter<TDeclaringType>[])state!;
 
-            if (constructor.ParameterCount == 0)
+            if (constructor.Parameters is [])
             {
                 return new CborObjectConverterWithDefaultCtor<TDeclaringType>(constructor.GetDefaultConstructor(), properties);
             }
 
-            CborPropertyConverter<TArgumentState>[] constructorParams = constructor
-                .GetParameters()
+            CborPropertyConverter<TArgumentState>[] constructorParams = constructor.Parameters
                 .Select(param => (CborPropertyConverter<TArgumentState>)param.Accept(this)!)
                 .ToArray();
 

--- a/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
+++ b/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
@@ -29,19 +29,17 @@ public static partial class ConfigurationBinderTS
         
         public override object? VisitObject<T>(IObjectTypeShape<T> objectShape, object? state = null)
         {
-            IConstructorShape? ctorShape = objectShape.GetConstructor();
-            return ctorShape != null
+            return objectShape.Constructor is { } ctorShape
                 ? ctorShape.Accept(this) 
                 : throw new NotSupportedException(typeof(T).ToString());
         }
 
         public override object? VisitConstructor<TDeclaringType, TArgumentState>(IConstructorShape<TDeclaringType, TArgumentState> constructorShape, object? state = null)
         {
-            if (constructorShape.ParameterCount == 0)
+            if (constructorShape.Parameters is [])
             {
                 Func<TDeclaringType> defaultCtor = constructorShape.GetDefaultConstructor();
-                (string Name, PropertyBinder<TDeclaringType> Binder)[] propertyBinders = constructorShape.DeclaringType
-                    .GetProperties()
+                (string Name, PropertyBinder<TDeclaringType> Binder)[] propertyBinders = constructorShape.DeclaringType.Properties
                     .Where(prop => prop.HasSetter)
                     .Select(prop => (prop.Name, (PropertyBinder<TDeclaringType>)prop.Accept(this)!))
                     .ToArray();
@@ -69,8 +67,7 @@ public static partial class ConfigurationBinderTS
             {
                 Func<TArgumentState> argStateCtor = constructorShape.GetArgumentStateConstructor();
                 Constructor<TArgumentState, TDeclaringType> paramCtor = constructorShape.GetParameterizedConstructor();
-                (string Name, bool IsRequired, PropertyBinder<TArgumentState> Binder)[] paramBinders = constructorShape
-                    .GetParameters()
+                (string Name, bool IsRequired, PropertyBinder<TArgumentState> Binder)[] paramBinders = constructorShape.Parameters
                     .Select(param => (param.Name, param.IsRequired, (PropertyBinder<TArgumentState>)param.Accept(this)!))
                     .ToArray();
 

--- a/src/PolyType.Examples/Counter/Counter.Builder.cs
+++ b/src/PolyType.Examples/Counter/Counter.Builder.cs
@@ -12,7 +12,7 @@ public static partial class Counter
 
         public override object? VisitObject<T>(IObjectTypeShape<T> type, object? state)
         {
-            Func<T, long>[] propertyCounters = type.GetProperties()
+            Func<T, long>[] propertyCounters = type.Properties
                 .Where(prop => prop.HasGetter)
                 .Select(prop => (Func<T, long>)prop.Accept(this)!)
                 .ToArray();

--- a/src/PolyType.Examples/JsonSchema/JsonSchemaGenerator.cs
+++ b/src/PolyType.Examples/JsonSchema/JsonSchemaGenerator.cs
@@ -124,10 +124,10 @@ public static class JsonSchemaGenerator
                 case IObjectTypeShape objectShape:
                     schema = new();
 
-                    if (objectShape.HasProperties)
+                    if (objectShape.Properties is not [])
                     {
-                        IConstructorShape? ctor = objectShape.GetConstructor();
-                        Dictionary<string, IConstructorParameterShape>? ctorParams = ctor?.GetParameters()
+                        IConstructorShape? ctor = objectShape.Constructor;
+                        Dictionary<string, IConstructorParameterShape>? ctorParams = ctor?.Parameters
                             .Where(p => p.Kind is ConstructorParameterKind.ConstructorParameter || p.IsRequired)
                             .ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
 
@@ -135,7 +135,7 @@ public static class JsonSchemaGenerator
                         JsonArray? required = null;
 
                         Push("properties");
-                        foreach (IPropertyShape prop in objectShape.GetProperties())
+                        foreach (IPropertyShape prop in objectShape.Properties)
                         {
                             IConstructorParameterShape? associatedParameter = null;
                             ctorParams?.TryGetValue(prop.Name, out associatedParameter);

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
@@ -33,12 +33,11 @@ public static partial class JsonSerializerTS
                 return new JsonPolymorphicObjectConverter(generationContext.ParentCache!);
             }
 
-            JsonPropertyConverter<T>[] properties = type.GetProperties()
+            JsonPropertyConverter<T>[] properties = type.Properties
                 .Select(prop => (JsonPropertyConverter<T>)prop.Accept(this)!)
                 .ToArray();
 
-            IConstructorShape? ctor = type.GetConstructor();
-            return ctor != null
+            return type.Constructor is { } ctor
                 ? (JsonObjectConverter<T>)ctor.Accept(this, state: properties)!
                 : new JsonObjectConverter<T>(properties);
         }
@@ -53,13 +52,12 @@ public static partial class JsonSerializerTS
         {
             var properties = (JsonPropertyConverter<TDeclaringType>[])state!;
 
-            if (constructor.ParameterCount == 0)
+            if (constructor.Parameters is [])
             {
                 return new JsonObjectConverterWithDefaultCtor<TDeclaringType>(constructor.GetDefaultConstructor(), properties);
             }
 
-            JsonPropertyConverter<TArgumentState>[] constructorParams = constructor
-                .GetParameters()
+            JsonPropertyConverter<TArgumentState>[] constructorParams = constructor.Parameters
                 .Select(param => (JsonPropertyConverter<TArgumentState>)param.Accept(this)!)
                 .ToArray();
 

--- a/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.Builder.cs
+++ b/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.Builder.cs
@@ -28,8 +28,7 @@ public static partial class PrettyPrinter
         public override object? VisitObject<T>(IObjectTypeShape<T> type, object? state)
         {
             string typeName = FormatTypeName(typeof(T));
-            PrettyPrinter<T>[] propertyPrinters = type
-                .GetProperties()
+            PrettyPrinter<T>[] propertyPrinters = type.Properties
                 .Where(prop => prop.HasGetter)
                 .Select(prop => (PrettyPrinter<T>?)prop.Accept(this)!)
                 .Where(prop => prop != null)

--- a/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.Builder.cs
+++ b/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.Builder.cs
@@ -32,7 +32,7 @@ public static partial class StructuralEqualityComparer
 
             return new ObjectEqualityComparer<T>
             {
-                PropertyComparers = type.GetProperties()
+                PropertyComparers = type.Properties
                     .Where(prop => prop.HasGetter)
                     .Select(prop => (EqualityComparer<T>)prop.Accept(this)!)
                     .ToArray(),

--- a/src/PolyType.Examples/Validation/Validator.Builder.cs
+++ b/src/PolyType.Examples/Validation/Validator.Builder.cs
@@ -13,8 +13,7 @@ public static partial class Validator
 
         public override object? VisitObject<T>(IObjectTypeShape<T> type, object? state)
         {
-            (string, Validator<T>)[] propertyValidators = type
-                .GetProperties()
+            (string, Validator<T>)[] propertyValidators = type.Properties
                 .Where(prop => prop.HasGetter)
                 .Select(prop => (prop.Name, Validator: (Validator<T>?)prop.Accept(this)))
                 .Where(prop => prop.Validator != null)

--- a/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
+++ b/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
@@ -23,13 +23,12 @@ public static partial class XmlSerializer
 
         public object? VisitObject<T>(IObjectTypeShape<T> type, object? state)
         {
-            XmlPropertyConverter<T>[] properties = type.GetProperties()
+            XmlPropertyConverter<T>[] properties = type.Properties
                 .Select(prop => (XmlPropertyConverter<T>)prop.Accept(this)!)
                 .ToArray();
 
             // Prefer the default constructor if available.
-            IConstructorShape? ctor = type.GetConstructor();
-            return ctor != null
+            return type.Constructor is { } ctor
                 ? (XmlObjectConverter<T>)ctor.Accept(this, state: properties)!
                 : new XmlObjectConverter<T>(properties);
         }
@@ -44,12 +43,12 @@ public static partial class XmlSerializer
         {
             var properties = (XmlPropertyConverter<TDeclaringType>[])state!;
 
-            if (constructor.ParameterCount == 0)
+            if (constructor.Parameters is [])
             {
                 return new XmlObjectConverterWithDefaultCtor<TDeclaringType>(constructor.GetDefaultConstructor(), properties);
             }
 
-            XmlPropertyConverter<TArgumentState>[] constructorParams = constructor.GetParameters()
+            XmlPropertyConverter<TArgumentState>[] constructorParams = constructor.Parameters
                 .Select(param => (XmlPropertyConverter<TArgumentState>)param.Accept(this)!)
                 .ToArray();
 

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Constructors.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Constructors.cs
@@ -347,7 +347,7 @@ internal sealed partial class SourceFormatter
                 {
                     ParameterKind.ConstructorParameter => "ConstructorParameter",
                     ParameterKind.RequiredMember or
-                    ParameterKind.OptionalMember => parameter.IsField ? "FieldInitializer" : "PropertyInitializer",
+                    ParameterKind.OptionalMember => "MemberInitializer",
                     _ => throw new InvalidOperationException($"Unsupported parameter kind: {parameter.Kind}"),
                 };
 

--- a/src/PolyType/Abstractions/ConstructorParameterKind.cs
+++ b/src/PolyType/Abstractions/ConstructorParameterKind.cs
@@ -11,12 +11,7 @@ public enum ConstructorParameterKind
     ConstructorParameter,
 
     /// <summary>
-    /// Represents a property initializer.
+    /// Represents a member initializer.
     /// </summary>
-    PropertyInitializer,
-
-    /// <summary>
-    /// Represents a field initializer.
-    /// </summary>
-    FieldInitializer,
+    MemberInitializer,
 }

--- a/src/PolyType/Abstractions/IConstructorShape.cs
+++ b/src/PolyType/Abstractions/IConstructorShape.cs
@@ -13,15 +13,6 @@ public interface IConstructorShape
     IObjectTypeShape DeclaringType { get; }
 
     /// <summary>
-    /// Gets the total number of parameters required by the constructor.
-    /// </summary>
-    /// <remarks>
-    /// This number includes both constructor parameters and
-    /// any available property or field initializers.
-    /// </remarks>
-    int ParameterCount { get; }
-
-    /// <summary>
     /// Gets a value indicating whether the constructor is declared public.
     /// </summary>
     bool IsPublic { get; }
@@ -32,10 +23,13 @@ public interface IConstructorShape
     ICustomAttributeProvider? AttributeProvider { get; }
 
     /// <summary>
-    /// Creates an enumeration of strongly-typed models for the constructor's parameters.
+    /// Gets the shapes of the parameters accepted by the constructor.
     /// </summary>
-    /// <returns>An enumeration of <see cref="IConstructorParameterShape"/> models.</returns>
-    IEnumerable<IConstructorParameterShape> GetParameters();
+    /// <remarks>
+    /// Includes all formal parameters of the underlying constructor,
+    /// as well as any member that can be specified in a member initializer expression.
+    /// </remarks>
+    IReadOnlyList<IConstructorParameterShape> Parameters { get; }
 
     /// <summary>
     /// Accepts an <see cref="ITypeShapeVisitor"/> for strongly-typed traversal.
@@ -61,21 +55,21 @@ public interface IConstructorShape<TDeclaringType, TArgumentState> : IConstructo
     /// <summary>
     /// Creates a delegate wrapping a parameterless constructor, if applicable.
     /// </summary>
-    /// <exception cref="InvalidOperationException">The <see cref="IConstructorShape.ParameterCount"/> of the constructor is not zero.</exception>
+    /// <exception cref="InvalidOperationException">The <see cref="IConstructorShape.Parameters"/> property of the constructor is empty.</exception>
     /// <returns>A parameterless delegate creating a default instance of <typeparamref name="TArgumentState"/>.</returns>
     Func<TDeclaringType> GetDefaultConstructor();
 
     /// <summary>
     /// Creates a constructor delegate for creating a default argument state instance.
     /// </summary>
-    /// <exception cref="InvalidOperationException">The <see cref="IConstructorShape.ParameterCount"/> of the constructor is zero.</exception>
+    /// <exception cref="InvalidOperationException">The <see cref="IConstructorShape.Parameters"/> property of the constructor is not empty.</exception>
     /// <returns>A delegate for constructing new <typeparamref name="TArgumentState"/> instances.</returns>
     Func<TArgumentState> GetArgumentStateConstructor();
 
     /// <summary>
     /// Creates a constructor delegate parameterized on an argument state object.
     /// </summary>
-    /// <exception cref="InvalidOperationException">The <see cref="IConstructorShape.ParameterCount"/> of the constructor is zero.</exception>
+    /// <exception cref="InvalidOperationException">The <see cref="IConstructorShape.Parameters"/> property of the constructor is not empty.</exception>
     /// <returns>A parameterized delegate returning an instance of <typeparamref name="TDeclaringType"/>.</returns>
     Constructor<TArgumentState, TDeclaringType> GetParameterizedConstructor();
 }

--- a/src/PolyType/Abstractions/IObjectTypeShape.cs
+++ b/src/PolyType/Abstractions/IObjectTypeShape.cs
@@ -16,26 +16,16 @@ public interface IObjectTypeShape : ITypeShape
     bool IsTupleType { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the current type defines any property shapes.
-    /// </summary>
-    bool HasProperties { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether the current type includes a constructor shape.
-    /// </summary>
-    bool HasConstructor { get; }
-
-    /// <summary>
     /// Gets all available property/field shapes for the given type.
     /// </summary>
     /// <returns>An enumeration of all available property/field shapes.</returns>
-    IEnumerable<IPropertyShape> GetProperties();
+    IReadOnlyList<IPropertyShape> Properties { get; }
 
     /// <summary>
     /// Gets the constructor shape for the given type, if available.
     /// </summary>
-    /// <returns>A <see cref="IConstructorShape"/> representation of the constructor.</returns>
-    IConstructorShape? GetConstructor();
+    /// <returns>An <see cref="IConstructorShape"/> representation of the constructor.</returns>
+    IConstructorShape? Constructor { get; }
 }
 
 /// <summary>

--- a/src/PolyType/ReflectionProvider/ReflectionConstructorParameterShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionConstructorParameterShape.cs
@@ -119,8 +119,5 @@ internal sealed class MemberInitializerShapeInfo : IParameterShapeInfo
     public ICustomAttributeProvider? AttributeProvider => MemberInfo;
     public bool HasDefaultValue => false;
     public object? DefaultValue => null;
-    public ConstructorParameterKind Kind =>
-        MemberInfo.MemberType is MemberTypes.Field
-        ? ConstructorParameterKind.FieldInitializer
-        : ConstructorParameterKind.PropertyInitializer;
+    public ConstructorParameterKind Kind => ConstructorParameterKind.MemberInitializer;
 }

--- a/src/PolyType/ReflectionProvider/ReflectionPropertyShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionPropertyShape.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using PolyType.Abstractions;
 

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -351,4 +351,9 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
     {
         return ReflectionHelpers.IsNullabilityInfoContextSupported ? new() : null;
     }
+
+    internal static readonly EqualityComparer<(Type Type, string Name)> CtorParameterEqualityComparer =
+        CommonHelpers.CreateTupleComparer(
+            EqualityComparer<Type>.Default,
+            CommonHelpers.CamelCaseInvariantComparer.Instance);
 }

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProviderOptions.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProviderOptions.cs
@@ -1,7 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-
-namespace PolyType.ReflectionProvider;
+﻿namespace PolyType.ReflectionProvider;
 
 /// <summary>
 /// Exposes configuration options for the reflection-based type shape provider.

--- a/src/PolyType/SourceGenModel/SourceGenConstructorShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenConstructorShape.cs
@@ -50,8 +50,8 @@ public sealed class SourceGenConstructorShape<TDeclaringType, TArgumentState> : 
     /// </summary>
     public Constructor<TArgumentState, TDeclaringType>? ParameterizedConstructorFunc { get; init; }
 
-    IEnumerable<IConstructorParameterShape> IConstructorShape.GetParameters()
-        => GetParametersFunc?.Invoke() ?? [];
+    IReadOnlyList<IConstructorParameterShape> IConstructorShape.Parameters => _parameters ??= (GetParametersFunc?.Invoke()).AsReadOnlyList();
+    private IReadOnlyList<IConstructorParameterShape>? _parameters;
 
     Func<TDeclaringType> IConstructorShape<TDeclaringType, TArgumentState>.GetDefaultConstructor()
         => DefaultConstructorFunc ?? throw new InvalidOperationException("Constructor shape does not specify a default constructor.");

--- a/src/Shared/Helpers/CommonHelpers.cs
+++ b/src/Shared/Helpers/CommonHelpers.cs
@@ -173,4 +173,9 @@ internal static class CommonHelpers
                 obj.Item1 is { } item1 ? left.GetHashCode(item1) : 0,
                 obj.Item2 is { } item2 ? right.GetHashCode(item2) : 0);
     }
+
+    public static IReadOnlyList<T> AsReadOnlyList<T>(this IEnumerable<T>? enumerable)
+    {
+        return enumerable is null or ICollection<T> { Count: 0 } ? Array.Empty<T>() : [.. enumerable];
+    }
 }

--- a/tests/PolyType.Tests/JsonSchemaTests.cs
+++ b/tests/PolyType.Tests/JsonSchemaTests.cs
@@ -60,7 +60,7 @@ public abstract class JsonSchemaTests(ProviderUnderTest providerUnderTest)
                 break;
 
             case IObjectTypeShape objectShape:
-                if (objectShape.HasProperties)
+                if (objectShape.Properties is not [])
                 {
                     AssertType("object");
                     Assert.Contains("properties", schema);

--- a/tests/PolyType.Tests/ObjectMapperTests.cs
+++ b/tests/PolyType.Tests/ObjectMapperTests.cs
@@ -22,7 +22,7 @@ public abstract class ObjectMapperTests(ProviderUnderTest providerUnderTest)
 
         if (!typeof(T).IsValueType && testCase.Value != null)
         {
-            if (shape is IObjectTypeShape { HasConstructor: false, HasProperties: false })
+            if (shape is IObjectTypeShape { Constructor: null, Properties: [] })
             {
                 // Trivial objects without ctors or properties are not copied.
                 Assert.Same((object?)mappedValue, (object?)testCase.Value);


### PR DESCRIPTION
Fix #77.