### PR TITLE
Add support for surrogate type shapes.

### DIFF
--- a/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
@@ -141,6 +141,12 @@ public static partial class CborSerializer
             return new CborEnumConverter<TEnum>();
         }
 
+        public object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state)
+        {
+            CborConverter<TSurrogate> surrogateConverter = GetOrAddConverter(surrogateShape.SurrogateType);
+            return new CborSurrogateConverter<T, TSurrogate>(surrogateShape.Marshaller, surrogateConverter);
+        }
+
         private static readonly Dictionary<Type, CborConverter> s_builtInConverters = new CborConverter[]
         {
             new BoolConverter(),

--- a/src/PolyType.Examples/CborSerializer/Converters/CborSurrogateConverter.cs
+++ b/src/PolyType.Examples/CborSerializer/Converters/CborSurrogateConverter.cs
@@ -1,0 +1,12 @@
+using System.Formats.Cbor;
+
+namespace PolyType.Examples.CborSerializer.Converters;
+
+internal sealed class CborSurrogateConverter<T, TSurrogate>(IMarshaller<T, TSurrogate> marshaller, CborConverter<TSurrogate> surrogateConverter) : CborConverter<T>
+{
+    public override void Write(CborWriter writer, T? value) =>
+        surrogateConverter.Write(writer, marshaller.ToSurrogate(value));
+
+    public override T? Read(CborReader reader) =>
+        marshaller.FromSurrogate(surrogateConverter.Read(reader));
+}

--- a/src/PolyType.Examples/Cloner/Cloner.Builder.cs
+++ b/src/PolyType.Examples/Cloner/Cloner.Builder.cs
@@ -269,6 +269,13 @@ public static partial class Cloner
             return new Func<T?, T?>(t => t.HasValue ? elementCloner(t.Value) : null);
         }
 
+        public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? _)
+        {
+            var marshaller = surrogateShape.Marshaller;
+            var surrogateCloner = GetOrAddCloner(surrogateShape.SurrogateType);
+            return new Func<T?, T?>(t => marshaller.FromSurrogate(surrogateCloner(marshaller.ToSurrogate(t))));
+        }
+
         private static IEnumerable<KeyValuePair<Type, object>> GetBuiltInCloners()
         {
             yield return Create<string>(str => str);

--- a/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
+++ b/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
@@ -254,6 +254,13 @@ public static partial class ConfigurationBinderTS
             }
         }
 
+        public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
+        {
+            Func<IConfiguration, TSurrogate?> surrogateBinder = GetOrAddBinder(surrogateShape.SurrogateType);
+            var marshaller = surrogateShape.Marshaller;
+            return new Func<IConfiguration, T?>(configuration => marshaller.FromSurrogate(surrogateBinder(configuration)));
+        }
+
         public override object? VisitNullable<T>(INullableTypeShape<T> nullableShape, object? state = null)
         {
             Func<IConfiguration, T> elementBinder = GetOrAddBinder(nullableShape.ElementType);

--- a/src/PolyType.Examples/Counter/Counter.Builder.cs
+++ b/src/PolyType.Examples/Counter/Counter.Builder.cs
@@ -55,6 +55,13 @@ public static partial class Counter
             return new Func<T?, long>(t => t.HasValue ? elementTypeCounter(t.Value) : 0);
         }
 
+        public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
+        {
+            var surrogateCounter = (Func<TSurrogate?, long>)surrogateShape.SurrogateType.Accept(this)!;
+            var marshaller = surrogateShape.Marshaller;
+            return new Func<T?, long>(t => surrogateCounter(marshaller.ToSurrogate(t)));
+        }
+
         public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state)
         {
             Func<TEnumerable, IEnumerable<TElement>> enumerableGetter = enumerableShape.GetGetEnumerable();

--- a/src/PolyType.Examples/JsonSchema/JsonSchemaGenerator.cs
+++ b/src/PolyType.Examples/JsonSchema/JsonSchemaGenerator.cs
@@ -86,6 +86,9 @@ public static class JsonSchemaGenerator
                 case INullableTypeShape nullableShape:
                     schema = GenerateSchema(nullableShape.ElementType, cacheLocation: false);
                     break;
+                
+                case ISurrogateTypeShape surrogateShape:
+                    return GenerateSchema(surrogateShape.SurrogateType, cacheLocation: false);
 
                 case IEnumerableTypeShape enumerableShape:
                     for (int i = 0; i < enumerableShape.Rank; i++)

--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonSurrogateConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonSurrogateConverter.cs
@@ -1,0 +1,13 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PolyType.Examples.JsonSerializer.Converters;
+
+internal sealed class JsonSurrogateConverter<T, TSurrogate>(IMarshaller<T, TSurrogate> marshaller, JsonConverter<TSurrogate> surrogateConverter) : JsonConverter<T>
+{
+    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        marshaller.FromSurrogate(surrogateConverter.Read(ref reader, typeof(T), options));
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) =>
+        surrogateConverter.Write(writer, marshaller.ToSurrogate(value)!, options);
+}

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
@@ -153,6 +153,12 @@ public static partial class JsonSerializerTS
             return converter.CreateConverter(typeof(TEnum), s_options);
         }
 
+        public object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state)
+        {
+            JsonConverter<TSurrogate> surrogateConverter = GetOrAddConverter(surrogateShape.SurrogateType);
+            return new JsonSurrogateConverter<T, TSurrogate>(surrogateShape.Marshaller, surrogateConverter);
+        }
+
         private static readonly Dictionary<Type, JsonConverter> s_defaultConverters = new JsonConverter[]
         {
             JsonMetadataServices.BooleanConverter,

--- a/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.Builder.cs
+++ b/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.Builder.cs
@@ -196,6 +196,13 @@ public static partial class PrettyPrinter
             });
         }
 
+        public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
+        {
+            PrettyPrinter<TSurrogate> surrogatePrinter = GetOrAddPrettyPrinter(surrogateShape.SurrogateType);
+            var marshaller = surrogateShape.Marshaller;
+            return new PrettyPrinter<T>((sb, indentation, t) => surrogatePrinter(sb, indentation, marshaller.ToSurrogate(t)));
+        }
+
         private static void WriteLine(StringBuilder builder, int indentation)
         {
             builder.AppendLine();

--- a/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
+++ b/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
@@ -316,6 +316,13 @@ public partial class RandomGenerator
             });
         }
 
+        public object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state)
+        {
+            IMarshaller<T, TSurrogate> marshaller = surrogateShape.Marshaller;
+            RandomGenerator<TSurrogate> surrogateGenerator = GetOrAddGenerator(surrogateShape.SurrogateType);
+            return new RandomGenerator<T>((Random random, int size) => marshaller.FromSurrogate(surrogateGenerator(random, size))!);
+        }
+
         private static IEnumerable<KeyValuePair<Type, (object Generator, RandomGenerator<object?> BoxingGenerator)>> CreateDefaultGenerators()
         {
             yield return Create((random, _) => NextBoolean(random));

--- a/src/PolyType.Examples/StructuralEquality/Comparers/SurrogateEqualityComparer.cs
+++ b/src/PolyType.Examples/StructuralEquality/Comparers/SurrogateEqualityComparer.cs
@@ -1,0 +1,9 @@
+namespace PolyType.Examples.StructuralEquality.Comparers;
+
+internal sealed class SurrogateEqualityComparer<T, TSurrogate>(
+    IEqualityComparer<TSurrogate> surrogateComparer,
+    IMarshaller<T, TSurrogate> mapper) : EqualityComparer<T>
+{
+    public override bool Equals(T? x, T? y) => surrogateComparer.Equals(mapper.ToSurrogate(x)!, mapper.ToSurrogate(y)!);
+    public override int GetHashCode(T obj) => mapper.ToSurrogate(obj)?.GetHashCode() ?? 0;
+}

--- a/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.Builder.cs
+++ b/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.Builder.cs
@@ -61,6 +61,12 @@ public static partial class StructuralEqualityComparer
             };
         }
 
+        public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
+        {
+            var surrogateComparer = GetOrAddEqualityComparer(surrogateShape.SurrogateType);
+            return new SurrogateEqualityComparer<T, TSurrogate>(surrogateComparer, surrogateShape.Marshaller);
+        }
+
         public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state)
         {
             IEqualityComparer<TKey> keyComparer = GetOrAddEqualityComparer(dictionaryShape.KeyType);

--- a/src/PolyType.Examples/Validation/Validator.Builder.cs
+++ b/src/PolyType.Examples/Validation/Validator.Builder.cs
@@ -156,6 +156,16 @@ public static partial class Validator
             return null; // Nothing to validate for enums.
         }
 
+        public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
+        {
+            var surrogateValidator = GetOrAddValidator(surrogateShape.SurrogateType);
+            var marshaller = surrogateShape.Marshaller;
+
+            return surrogateValidator is null ? null : 
+                new Validator<T>((T? value, List<string> path, ref List<string>? errors) => 
+                    surrogateValidator(marshaller.ToSurrogate(value), path, ref errors));
+        }
+
         /// <summary>
         /// Creates a trivial validator that always succeeds.
         /// </summary>

--- a/src/PolyType.Examples/XmlSerializer/Converters/XmlSurrogateConverter.cs
+++ b/src/PolyType.Examples/XmlSerializer/Converters/XmlSurrogateConverter.cs
@@ -1,0 +1,13 @@
+using System.Xml;
+
+namespace PolyType.Examples.XmlSerializer.Converters;
+
+internal sealed class XmlSurrogateConverter<T, TSurrogate>(IMarshaller<T, TSurrogate> marshaller, XmlConverter<TSurrogate> surrogateConverter)
+    : XmlConverter<T>
+{
+    public override void Write(XmlWriter writer, string localName, T? value) =>
+        surrogateConverter.Write(writer, localName, marshaller.ToSurrogate(value));
+
+    public override T? Read(XmlReader reader) =>
+        marshaller.FromSurrogate(surrogateConverter.Read(reader));
+}

--- a/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
+++ b/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
@@ -137,6 +137,12 @@ public static partial class XmlSerializer
             return new XmlEnumConverter<TEnum>();
         }
 
+        public object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state)
+        {
+            XmlConverter<TSurrogate> surrogateConverter = GetOrAddConverter(surrogateShape.SurrogateType);
+            return new XmlSurrogateConverter<T, TSurrogate>(surrogateShape.Marshaller, surrogateConverter);
+        }
+
         private static readonly Dictionary<Type, XmlConverter> s_defaultConverters = new XmlConverter[]
         {
             new BoolConverter(),

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.cs
@@ -92,7 +92,7 @@ public partial class TypeDataModelGenerator
     {
         if (location is not null && !KnownSymbols.Compilation.ContainsLocation(location))
         {
-            // If the location is outside of the current compilation,
+            // If the location is outside the current compilation,
             // fall back to the default location for the generator.
             location = DefaultLocation;
         }
@@ -260,7 +260,7 @@ public partial class TypeDataModelGenerator
             return status;
         }
 
-    None:
+        None:
         // A supported type of unrecognized kind, do not include any metadata.
         model = new TypeDataModel { Type = type };
         return TypeDataModelGenerationStatus.Success;

--- a/src/PolyType.SourceGenerator/Model/SurrogateShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/SurrogateShapeModel.cs
@@ -1,0 +1,16 @@
+using Microsoft.CodeAnalysis;
+using PolyType.Roslyn;
+
+namespace PolyType.SourceGenerator.Model;
+
+public sealed record SurrogateShapeModel : TypeShapeModel
+{
+    public required TypeId SurrogateType { get; init; }
+    public required TypeId MarshallerType { get; init; }
+}
+
+public sealed class SurrogateTypeDataModel : TypeDataModel
+{
+    public required ITypeSymbol SurrogateType { get; init; }
+    public required ITypeSymbol MarshallerType { get; init; }
+}

--- a/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
@@ -75,4 +75,15 @@ public sealed partial class Parser
         category: "PolyType.SourceGenerator",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+    
+    private static DiagnosticDescriptor InvalidMarshaller { get; } = new DiagnosticDescriptor(
+        id: "TS0010",
+        title: "Type contains invalid marshaller configuration.",
+        messageFormat: 
+            "The type '{0}' contains invalid marshaller configuration. " +
+            "A valid marshaller must be a public type with a default constructor and exactly one IMarshaller<,> implementation for the current type.",
+
+        category: "PolyType.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/PolyType.SourceGenerator/PolyType.SourceGenerator.csproj
+++ b/src/PolyType.SourceGenerator/PolyType.SourceGenerator.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <Compile Include="..\PolyType\Abstractions\TypeShapeKind.cs" Link="Shared\PolyType\Abstractions\%(Filename).cs" />
+    <Compile Include="..\PolyType\TypeShapeKind.cs" Link="Shared\PolyType\%(Filename).cs" />
     <Compile Include="..\Shared\Helpers\CommonHelpers.cs" Link="PolyType.Roslyn\Shared\Helpers\%(Filename).cs" />
     <Compile Include="..\Shared\Helpers\DebugExt.cs" Link="Shared\Helpers\%(Filename).cs" />
     <Compile Include="..\PolyType.Roslyn\**\*.cs" Exclude="**\bin\**;**\obj\**" Link="PolyType.Roslyn\%(RecursiveDir)%(Filename)%(Extension)" />

--- a/src/PolyType.SourceGenerator/PolyTypeKnownSymbols.cs
+++ b/src/PolyType.SourceGenerator/PolyTypeKnownSymbols.cs
@@ -22,6 +22,9 @@ public sealed class PolyTypeKnownSymbols(Compilation compilation) : KnownSymbols
 
     public INamedTypeSymbol? ParameterShapeAttribute => GetOrResolveType("PolyType.ParameterShapeAttribute", ref _ParameterShapeAttribute);
     private Option<INamedTypeSymbol?> _ParameterShapeAttribute;
+    
+    public INamedTypeSymbol? MarshallerType => GetOrResolveType("PolyType.IMarshaller`2", ref _Marshaller);
+    private Option<INamedTypeSymbol?> _Marshaller;
 
     public TargetFramework TargetFramework => _targetFramework ??= ResolveTargetFramework();
     private TargetFramework? _targetFramework;

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Surrogate.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Surrogate.cs
@@ -1,0 +1,22 @@
+using PolyType.Roslyn;
+using PolyType.SourceGenerator.Model;
+
+namespace PolyType.SourceGenerator;
+
+internal sealed partial class SourceFormatter
+{
+    private void FormatSurrogateTypeShapeFactory(SourceWriter writer, string methodName, SurrogateShapeModel surrogateShapeModel)
+    {
+        writer.WriteLine($$"""
+           private global::PolyType.Abstractions.ITypeShape<{{surrogateShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
+           {
+               return new global::PolyType.SourceGenModel.SourceGenSurrogateTypeShape<{{surrogateShapeModel.Type.FullyQualifiedName}}, {{surrogateShapeModel.SurrogateType.FullyQualifiedName}}>
+               {
+                   Marshaller = new {{surrogateShapeModel.MarshallerType.FullyQualifiedName}}(),
+                   SurrogateType = {{GetShapeModel(surrogateShapeModel.SurrogateType).SourceIdentifier}},
+                   Provider = this,
+               };
+           }
+           """);
+    }
+}

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Type.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Type.cs
@@ -40,6 +40,10 @@ internal sealed partial class SourceFormatter
             case NullableShapeModel nullableShapeModel:
                 FormatNullableTypeShapeFactory(writer, generatedFactoryMethodName, nullableShapeModel);
                 break;
+            
+            case SurrogateShapeModel surrogateShapeModel:
+                FormatSurrogateTypeShapeFactory(writer, generatedFactoryMethodName, surrogateShapeModel);
+                break;
 
             case EnumerableShapeModel enumerableShapeModel:
                 FormatEnumerableTypeShapeFactory(writer, generatedFactoryMethodName, enumerableShapeModel);

--- a/src/PolyType.TestCases/ITestCase.cs
+++ b/src/PolyType.TestCases/ITestCase.cs
@@ -66,6 +66,11 @@ public interface ITestCase
     /// Gets a value indicating whether the type is an abstract class or an interface.
     /// </summary>
     public bool IsAbstract { get; }
+    
+    /// <summary>
+    /// Gets a value indicating whether the type is defined with a surrogate marshaller.
+    /// </summary>
+    public bool UsesMarshaller { get; } 
 
     /// <summary>
     /// Gets the value specified in <see cref="TypeShapeAttribute.Kind"/>.

--- a/src/PolyType.TestCases/TestCaseOfT.cs
+++ b/src/PolyType.TestCases/TestCaseOfT.cs
@@ -22,6 +22,8 @@ public sealed record TestCase<T, TProvider>(T? Value) : TestCase<T>(Value, TProv
 /// <param name="DefaultShape">The default type shape of the value, typically source generated.</param>
 public record TestCase<T> : ITestCase
 {
+    private TypeShapeAttribute? _shapeAttribute;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="TestCase{T}"/> class.
     /// </summary>
@@ -107,13 +109,18 @@ public record TestCase<T> : ITestCase
     public bool IsAbstract => typeof(T).IsAbstract || typeof(T).IsInterface;
 
     /// <summary>
+    /// Gets a value indicating whether the type is defined with a surrogate marshaller.
+    /// </summary>
+    public bool UsesMarshaller => (_shapeAttribute ??= typeof(T).GetCustomAttribute<TypeShapeAttribute>())?.Marshaller is not null;
+
+    /// <summary>
     /// Gets a value indicating whether the type configuration specifies a custom kind.
     /// </summary>
     public TypeShapeKind? CustomKind
     {
         get
         {
-            TypeShapeKind? kind = typeof(T).GetCustomAttribute<TypeShapeAttribute>()?.Kind;
+            TypeShapeKind? kind = (_shapeAttribute ??= typeof(T).GetCustomAttribute<TypeShapeAttribute>())?.Kind;
             return kind == (TypeShapeKind)(-1) ? null : kind;
         }
     }

--- a/src/PolyType/Abstractions/ISurrogateTypeShape.cs
+++ b/src/PolyType/Abstractions/ISurrogateTypeShape.cs
@@ -1,0 +1,30 @@
+namespace PolyType.Abstractions;
+
+/// <summary>
+/// Provides a strongly typed shape model for a .NET type that employs a surrogate type.
+/// </summary>
+public interface ISurrogateTypeShape : ITypeShape
+{
+    /// <summary>
+    /// Gets the shape of the surrogate type.
+    /// </summary>
+    ITypeShape SurrogateType { get; }
+}
+
+/// <summary>
+/// Provides a strongly typed shape model for a .NET type that employs a surrogate type.
+/// </summary>
+/// <typeparam name="T">The type the shape describes.</typeparam>
+/// <typeparam name="TSurrogate">The surrogate type being specified by the shape.</typeparam>
+public interface ISurrogateTypeShape<T, TSurrogate> : ITypeShape<T>, ISurrogateTypeShape
+{
+    /// <summary>
+    /// Gets the bidirectional mapper between <typeparamref name="T"/> and <typeparamref name="TSurrogate"/>.
+    /// </summary>
+    IMarshaller<T, TSurrogate> Marshaller { get; }
+
+    /// <summary>
+    /// Gets the shape of the element type of the nullable.
+    /// </summary>
+    new ITypeShape<TSurrogate> SurrogateType { get; }
+}

--- a/src/PolyType/Abstractions/ITypeShapeVisitor.cs
+++ b/src/PolyType/Abstractions/ITypeShapeVisitor.cs
@@ -86,4 +86,14 @@ public interface ITypeShapeVisitor
     /// <returns>The result produced by the visitor.</returns>
     object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
         where TKey : notnull;
+
+    /// <summary>
+    /// Visits an <see cref="ISurrogateTypeShape{T, TSurrogate}"/> instance representing a type employing a surrogate type.
+    /// </summary>
+    /// <typeparam name="T">The type represented by the shape instance.</typeparam>
+    /// <typeparam name="TSurrogate">The surrogate type used by the shape.</typeparam>
+    /// <param name="surrogateShape">The surrogate shape to visit.</param>
+    /// <param name="state">Defines user-provided state.</param>
+    /// <returns>The result produced by the visitor.</returns>
+    object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null);
 }

--- a/src/PolyType/Abstractions/TypeShapeVisitor.cs
+++ b/src/PolyType/Abstractions/TypeShapeVisitor.cs
@@ -95,6 +95,17 @@ public abstract class TypeShapeVisitor : ITypeShapeVisitor
         where TKey : notnull
         => ThrowNotImplemented(nameof(VisitDictionary));
 
+    /// <summary>
+    /// Visits an <see cref="ISurrogateTypeShape{T, TSurrogate}"/> instance representing a type employing a surrogate type.
+    /// </summary>
+    /// <typeparam name="T">The type represented by the shape instance.</typeparam>
+    /// <typeparam name="TSurrogate">The surrogate type used by the shape.</typeparam>
+    /// <param name="surrogateShape">The surrogate shape to visit.</param>
+    /// <param name="state">Defines user-provided state.</param>
+    /// <returns>The result produced by the visitor.</returns>
+    public virtual object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
+        => ThrowNotImplemented(nameof(VisitSurrogate));
+
     private object? ThrowNotImplemented(string methodName)
         => throw new NotImplementedException($"The visitor method {GetType().Name}.{methodName} has not been implemented.");
 }

--- a/src/PolyType/GenerateShapeAttribute.cs
+++ b/src/PolyType/GenerateShapeAttribute.cs
@@ -24,7 +24,7 @@ public sealed class GenerateShapeAttribute : Attribute;
 /// The source generator will include a static property in the annotated class pointing
 /// to the <see cref="ITypeShapeProvider"/> that was generated for the entire project.
 ///
-/// For projects targeting .NET 8 or later, this will additionally augments the class
+/// For projects targeting .NET 8 or later, this additionally augments the class
 /// with an implementation of IShapeable for <typeparamref name="T"/>.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]

--- a/src/PolyType/IMarshaller.cs
+++ b/src/PolyType/IMarshaller.cs
@@ -1,0 +1,28 @@
+namespace PolyType;
+
+/// <summary>
+/// Represents a bidirectional mapping between <typeparamref name="T"/> and <typeparamref name="TSurrogate"/>.
+/// </summary>
+/// <typeparam name="T">The source type.</typeparam>
+/// <typeparam name="TSurrogate">The surrogate type.</typeparam>
+/// <remarks>
+/// Implementations should form a bijection between <typeparamref name="T"/> and <typeparamref name="TSurrogate"/>,
+/// meaning that chaining <see cref="ToSurrogate"/> with <see cref="FromSurrogate"/> and vice versa should
+/// always produce equal results.
+/// </remarks>
+public interface IMarshaller<T, TSurrogate>
+{
+    /// <summary>
+    /// Maps an instance of <typeparamref name="T"/> to <typeparamref name="TSurrogate"/>.
+    /// </summary>
+    /// <param name="value">The input of type <typeparamref name="T"/>.</param>
+    /// <returns>A value of type <typeparamref name="TSurrogate"/> corresponding to <paramref name="value"/>.</returns>
+    TSurrogate? ToSurrogate(T? value);
+
+    /// <summary>
+    /// Maps an instance of <typeparamref name="TSurrogate"/> back to <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="surrogate">The input of type <typeparamref name="TSurrogate"/>.</param>
+    /// <returns>A value of type <typeparamref name="T"/> corresponding to <paramref name="surrogate"/>.</returns>
+    T? FromSurrogate(TSurrogate? surrogate);
+}

--- a/src/PolyType/ReflectionProvider/ReflectionSurrogateTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionSurrogateTypeShape.cs
@@ -1,0 +1,15 @@
+using PolyType.Abstractions;
+
+namespace PolyType.ReflectionProvider;
+
+internal sealed class ReflectionSurrogateTypeShape<T, TSurrogate>(
+    IMarshaller<T, TSurrogate> marshaller,
+    ReflectionTypeShapeProvider provider)
+    : ReflectionTypeShape<T>(provider), ISurrogateTypeShape<T, TSurrogate>
+{
+    public override TypeShapeKind Kind => TypeShapeKind.Surrogate;
+    public override object? Accept(ITypeShapeVisitor visitor, object? state = null) => visitor.VisitSurrogate(this, state);
+    public IMarshaller<T, TSurrogate> Marshaller => marshaller;
+    public ITypeShape<TSurrogate> SurrogateType => Provider.GetShape<TSurrogate>();
+    ITypeShape ISurrogateTypeShape.SurrogateType => SurrogateType;
+}

--- a/src/PolyType/SourceGenModel/SourceGenSurrogateTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenSurrogateTypeShape.cs
@@ -1,0 +1,29 @@
+using PolyType.Abstractions;
+
+namespace PolyType.SourceGenModel;
+
+/// <summary>
+/// Source generator model for surrogate type shapes.
+/// </summary>
+/// <typeparam name="T">The type that the shape describes.</typeparam>
+/// <typeparam name="TSurrogate">The surrogate type used by the shape.</typeparam>
+public sealed class SourceGenSurrogateTypeShape<T, TSurrogate> : SourceGenTypeShape<T>, ISurrogateTypeShape<T, TSurrogate>
+{
+    /// <summary>
+    /// Gets the marshaller to <typeparamref name="TSurrogate"/>.
+    /// </summary>
+    public required IMarshaller<T, TSurrogate> Marshaller { get; init; }
+
+    /// <summary>
+    /// Gets the shape of the surrogate type.
+    /// </summary>
+    public required ITypeShape<TSurrogate> SurrogateType { get; init; }
+
+    /// <inheritdoc/>
+    public override TypeShapeKind Kind => TypeShapeKind.Surrogate;
+
+    /// <inheritdoc/>
+    public override object? Accept(ITypeShapeVisitor visitor, object? state = null) => visitor.VisitSurrogate(this, state);
+
+    ITypeShape ISurrogateTypeShape.SurrogateType => SurrogateType;
+}

--- a/src/PolyType/TypeShapeAttribute.cs
+++ b/src/PolyType/TypeShapeAttribute.cs
@@ -6,11 +6,22 @@ namespace PolyType;
 /// <summary>
 /// Configures the generated <see cref="ITypeShape"/> of the annotated type.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Enum, AllowMultiple = false, Inherited = false)]
 public sealed class TypeShapeAttribute : Attribute
 {
     private const TypeShapeKind Undefined = (TypeShapeKind)(-1);
     private readonly TypeShapeKind _kind = Undefined;
+
+    /// <summary>
+    /// Gets a type implementing an <see cref="IMarshaller{T,TSurrogate}"/> to a surrogate type.
+    /// </summary>
+    /// <remarks>
+    /// The type should have a parameterless constructor and must implement <see cref="IMarshaller{T,TSurrogate}"/>
+    /// where either of the two generic types should match the annotated type.
+    ///
+    /// Types that specify a <see cref="Marshaller"/> will be of shape <see cref="ISurrogateTypeShape"/>.
+    /// </remarks>
+    public Type? Marshaller { get; init; }
 
     /// <summary>
     /// Gets the kind that should be generated for the annotated type.

--- a/src/PolyType/TypeShapeKind.cs
+++ b/src/PolyType/TypeShapeKind.cs
@@ -1,7 +1,11 @@
-﻿namespace PolyType.Abstractions;
+﻿#if IS_MAIN_POLYTYPE_PROJECT
+using PolyType.Abstractions;
+#endif
+
+namespace PolyType;
 
 /// <summary>
-/// Defines kinds of an <see cref="ITypeShape"/> instance.
+/// Defines kinds of an <see cref="ITypeShape{T}"/> instance.
 /// </summary>
 #if IS_MAIN_POLYTYPE_PROJECT
 public
@@ -39,4 +43,9 @@ enum TypeShapeKind
     /// Shape represents a dictionary type using <see cref="IDictionaryTypeShape"/>.
     /// </summary>
     Dictionary = 5,
+
+    /// <summary>
+    /// Shape that maps to a surrogate type using <see cref="ISurrogateTypeShape"/>.
+    /// </summary>
+    Surrogate = 6,
 }

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationHelpers.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationHelpers.cs
@@ -45,7 +45,8 @@ public static class CompilationHelpers
         MetadataReference[]? additionalReferences = null,
         string assemblyName = "TestAssembly",
         CSharpParseOptions? parseOptions = null,
-        OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
+        OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary,
+        NullableContextOptions nullableContextOptions = NullableContextOptions.Enable)
     {
         parseOptions ??= s_defaultParseOptions;
         additionalReferences ??= [];
@@ -81,12 +82,12 @@ public static class CompilationHelpers
             MetadataReference.CreateFromFile(typeof(PolyType.Abstractions.ITypeShape).Assembly.Location),
             .. additionalReferences,
         ];
-
+        
         return CSharpCompilation.Create(
             assemblyName,
             syntaxTrees: syntaxTrees,
             references: references,
-            options: new CSharpCompilationOptions(outputKind)
+            options: new CSharpCompilationOptions(outputKind, nullableContextOptions: nullableContextOptions)
         );
     }
 

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
@@ -24,8 +24,8 @@ public static class CompilationTests
 
                 public bool Bool { get; }
                 public string String { get; }
-                public List<int> List { get; set; }
-                public Dictionary<string, int> Dict { get; set; }
+                public List<int>? List { get; set; }
+                public Dictionary<string, int>? Dict { get; set; }
 
             #if NET8_0_OR_GREATER
                 public static PolyType.Abstractions.ITypeShape<MyPoco> Test()
@@ -419,7 +419,6 @@ public static class CompilationTests
     {
         Compilation compilation = CompilationHelpers.CreateCompilation("""
             using PolyType;
-            using PolyType.Abstractions;
 
             [GenerateShape, TypeShape(Kind = TypeShapeKind.None)]
             public partial record ObjectAsNone(string Name, int Age);

--- a/tests/PolyType.Tests/JsonSchemaTests.cs
+++ b/tests/PolyType.Tests/JsonSchemaTests.cs
@@ -39,6 +39,11 @@ public abstract class JsonSchemaTests(ProviderUnderTest providerUnderTest)
                 nullableElementSchema.Remove("type");
                 Assert.True(JsonNode.DeepEquals(nullableElementSchema, schema));
                 break;
+            
+            case ISurrogateTypeShape surrogateShape:
+                JsonObject surrogateSchema = JsonSchemaGenerator.Generate(surrogateShape.SurrogateType);
+                Assert.True(JsonNode.DeepEquals(surrogateSchema, schema));
+                break;
 
             case IEnumerableTypeShape enumerableShape:
                 if (enumerableShape.Type == typeof(byte[]))

--- a/tests/PolyType.Tests/JsonTests.cs
+++ b/tests/PolyType.Tests/JsonTests.cs
@@ -319,6 +319,20 @@ public abstract partial class JsonTests(ProviderUnderTest providerUnderTest)
         string json = converter.Serialize(value);
         Assert.Equal(ExpectedJson, json);
     }
+    
+    [Fact]
+    public void Roundtrip_ClassWithMarshaller()
+    {
+        const string ExpectedJson = "\"the actual value\"";
+        var converter = JsonSerializerTS.CreateConverter<TypeWithStringSurrogate>(providerUnderTest.Provider);
+
+        TypeWithStringSurrogate value = new("the actual value");
+        string json = converter.Serialize(value);
+        Assert.Equal(ExpectedJson, json);
+        
+        TypeWithStringSurrogate? deserializedValue = converter.Deserialize(json);
+        Assert.Equal(value, deserializedValue);
+    }
 
     [Fact]
     public void ClassWithInitOnlyProperties_MissingPayloadPreservesDefaultValues()
@@ -359,6 +373,7 @@ public abstract partial class JsonTests(ProviderUnderTest providerUnderTest)
         value.IsLongTuple ||
         value.HasRefConstructorParameters ||
         value.CustomKind is not null ||
+        value.UsesMarshaller ||
         value.Value is DerivedClassWithVirtualProperties; // https://github.com/dotnet/runtime/issues/96996
 }
 


### PR DESCRIPTION
The `TypeShape` attribute can now be used to specify marshallers to surrogate types:

```C#
[TypeShape(Marshaller = typeof(EnvelopeMarshaller))]
record Envelope(string Value);

class EnvelopeMarshaller : IMarshaller<Envelope, string>
{
    public string? ToSurrogate(Envelope? envelope) => envelope?.Value;
    public Envelope FromSurrogate(string? surrogateString) => new(surrogateString ?? "");
}
```

The above configures `Envelope` to admit a string-based shape using the specified surrogate representation. In other words, it assumes a string schema instead of that of an object. Surrogates are used as a more versatile alternative compared to format-specific converters.

In the following example, we marshal the internal state of an object to a surrogate struct:

```C#
[TypeShape(Marshaller = typeof(Marshaller))]
public class PocoWithInternalState(int value1, string value2)
{
    private readonly _value1 = value1;
    private readonly _value2 = value2;

    public record struct Surrogate(int Value1, string Value2);

    public sealed class Marshaller : IMarshaller<PocoWithInternalState, Surrogate>
    {
        public Surrogate ToSurrogate(PocoWithInternalState? poco) => poco is null ? default : new(poco._value1, poco._value2);
        public PocoWithInternalState FromSurrogate(Surrogate surrogate) => new(poco._value1, poco._value2 ?? "");
    }
}
```

cc @AArnott

Fix #70. Fix #9.