### PR TITLE
Add nullable ref annotations to `IMarshaller<T, TSurrogate>`

### DIFF
--- a/src/PolyType/IMarshaller.cs
+++ b/src/PolyType/IMarshaller.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace PolyType;
 
 /// <summary>
@@ -17,6 +19,7 @@ public interface IMarshaller<T, TSurrogate>
     /// </summary>
     /// <param name="value">The input of type <typeparamref name="T"/>.</param>
     /// <returns>A value of type <typeparamref name="TSurrogate"/> corresponding to <paramref name="value"/>.</returns>
+    [return: NotNullIfNotNull(nameof(value))]
     TSurrogate? ToSurrogate(T? value);
 
     /// <summary>
@@ -24,5 +27,6 @@ public interface IMarshaller<T, TSurrogate>
     /// </summary>
     /// <param name="surrogate">The input of type <typeparamref name="TSurrogate"/>.</param>
     /// <returns>A value of type <typeparamref name="T"/> corresponding to <paramref name="surrogate"/>.</returns>
+    [return: NotNullIfNotNull(nameof(surrogate))]
     T? FromSurrogate(TSurrogate? surrogate);
 }


### PR DESCRIPTION
In calling into this interface, the lack of these annotations makes callers add additional checks that should not be necessary when we consider the reasonable assumption that a non-null input should produce a non-null output.