### PR TITLE
Add ExcludeFromCodeCoverageAttribute to generated ShapeProvider and Witness files

### DIFF
--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.ShapeProvider.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.ShapeProvider.cs
@@ -13,6 +13,7 @@ internal sealed partial class SourceFormatter
 
         writer.WriteLine("""/// <summary>The source generated <see cref="global::PolyType.SourceGenModel.SourceGenTypeShapeProvider"/> implementation for the current assembly.</summary>""");
         writer.WriteLine($"""[global::System.CodeDom.Compiler.GeneratedCodeAttribute({FormatStringLiteral(PolyTypeGenerator.SourceGeneratorName)}, {FormatStringLiteral(PolyTypeGenerator.SourceGeneratorVersion)})]""");
+        writer.WriteLine("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]");
         writer.WriteLine($"{provider.ProviderDeclaration.TypeDeclarationHeader} : global::PolyType.SourceGenModel.SourceGenTypeShapeProvider");
         writer.WriteLine('{');
         writer.Indentation++;
@@ -93,7 +94,7 @@ internal sealed partial class SourceFormatter
     {
         var writer = new SourceWriter();
         StartFormatSourceFile(writer, typeDeclaration);
-
+        writer.WriteLine("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]");
         writer.WriteLine($$"""
             {{typeDeclaration.TypeDeclarationHeader}}
             {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.ShapeProvider.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.ShapeProvider.cs
@@ -13,7 +13,7 @@ internal sealed partial class SourceFormatter
 
         writer.WriteLine("""/// <summary>The source generated <see cref="global::PolyType.SourceGenModel.SourceGenTypeShapeProvider"/> implementation for the current assembly.</summary>""");
         writer.WriteLine($"""[global::System.CodeDom.Compiler.GeneratedCodeAttribute({FormatStringLiteral(PolyTypeGenerator.SourceGeneratorName)}, {FormatStringLiteral(PolyTypeGenerator.SourceGeneratorVersion)})]""");
-        writer.WriteLine("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]");
+        writer.WriteLine("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]");
         writer.WriteLine($"{provider.ProviderDeclaration.TypeDeclarationHeader} : global::PolyType.SourceGenModel.SourceGenTypeShapeProvider");
         writer.WriteLine('{');
         writer.Indentation++;
@@ -94,7 +94,7 @@ internal sealed partial class SourceFormatter
     {
         var writer = new SourceWriter();
         StartFormatSourceFile(writer, typeDeclaration);
-        writer.WriteLine("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]");
+        writer.WriteLine("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]");
         writer.WriteLine($$"""
             {{typeDeclaration.TypeDeclarationHeader}}
             {


### PR DESCRIPTION
I've added them only for the ShapeProvider and Witness files, not the partial types annotated with the GenerateShape Attribute as these are under user-control as far as I understand it.

Do you want tests that the attributes are added?
I could not find any tests actually verifying the generated source code or the generated trees.

fixes #102 