### PR TITLE
Base `PrettyPrinter` on `TextWriter` instead of `StringBuilder`

### DIFF
--- a/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.cs
+++ b/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.cs
@@ -4,8 +4,8 @@ using System.Text;
 
 namespace PolyType.Examples.PrettyPrinter;
 
-/// <summary>A delegate that formats a pretty-printed value to a string builder.</summary>
-public delegate void PrettyPrinter<T>(StringBuilder builder, int indentation, T? value);
+/// <summary>A delegate that formats a pretty-printed value to a <see cref="TextWriter"/>.</summary>
+public delegate void PrettyPrinter<T>(TextWriter builder, int indentation, T? value);
 
 /// <summary>Provides a pretty printer for .NET types built on top of PolyType.</summary>
 public static partial class PrettyPrinter
@@ -43,7 +43,7 @@ public static partial class PrettyPrinter
     /// <returns>A string containing a pretty-printed rendering of the value.</returns>
     public static string Print<T>(this PrettyPrinter<T> prettyPrinter, T? value)
     {
-        var sb = new StringBuilder();
+        var sb = new StringWriter();
         prettyPrinter(sb, 0, value);
         return sb.ToString();
     }


### PR DESCRIPTION
`TextWriter` is a more abstract class, which allows for writing directly to streams or STDOUT, which seems a common scenario for this example, rather than being forced to create one large string.

This doesn't preclude use of `StringBuilder` though, since the `StringWriter : TextWriter` class can create or reuse a `StringBuilder` object while conforming to the `TextWriter` type.