### PR TITLE
Never emit the `GenerateShapeAttribute<T>` into a user's assembly

### DIFF
--- a/src/PolyType/GenerateShapeAttribute.cs
+++ b/src/PolyType/GenerateShapeAttribute.cs
@@ -1,4 +1,6 @@
-﻿namespace PolyType;
+﻿using System.Diagnostics;
+
+namespace PolyType;
 
 /// <summary>
 /// Instructs the PolyType source generator to include the annotated type
@@ -21,11 +23,15 @@ public sealed class GenerateShapeAttribute : Attribute;
 /// </summary>
 /// <typeparam name="T">The type for which shape metadata will be generated.</typeparam>
 /// <remarks>
+/// <para>
 /// The source generator will include a static property in the annotated class pointing
 /// to the <see cref="ITypeShapeProvider"/> that was generated for the entire project.
-///
+/// </para>
+/// <para>
 /// For projects targeting .NET 8 or later, this additionally augments the class
 /// with an implementation of IShapeable for <typeparamref name="T"/>.
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+[Conditional("NEVER")] // only the source generator uses this, and avoiding generic attributes avoid .NET Framework and Unity issues.
 public sealed class GenerateShapeAttribute<T> : Attribute;


### PR DESCRIPTION
It isn't necessary, since it only triggers source generation within the compilation of the code that applies it. It's also problematic because some runtimes (e.g. .NET Framework and unity) do not support generic attributes and reflection APIs throw when they encounter it.