### PR TITLE
Add `IUnionCaseShape.IsTagSpecified` property

### DIFF
--- a/src/PolyType.Roslyn/Model/DerivedTypeModel.cs
+++ b/src/PolyType.Roslyn/Model/DerivedTypeModel.cs
@@ -23,6 +23,11 @@ public sealed class DerivedTypeModel
     public required int Tag { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether <see cref="Tag"/> has been explicitly specified or inferred in a less stable way.
+    /// </summary>
+    public required bool IsTagSpecified { get; init; }
+
+    /// <summary>
     /// The index of the derived type.
     /// </summary>
     public required int Index { get; init; }

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.cs
@@ -302,7 +302,7 @@ public partial class TypeDataModelGenerator
     {
         // 1. Resolve the shapes for all derived types.
         List<DerivedTypeModel> derivedTypeModels = [];
-        DerivedTypeModel baseTypeModel = new() { Type = type, Name = null!, Tag = -1, Index = -1, IsBaseType = true };
+        DerivedTypeModel baseTypeModel = new() { Type = type, Name = null!, Tag = -1, IsTagSpecified = false, Index = -1, IsBaseType = true };
         foreach (DerivedTypeModel derivedType in ResolveDerivedTypes(type))
         {
             if (IncludeNestedType(derivedType.Type, ref ctx) is TypeDataModelGenerationStatus.Success)

--- a/src/PolyType.SourceGenerator/Model/UnionShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/UnionShapeModel.cs
@@ -17,6 +17,7 @@ public sealed record UnionCaseModel
     public required TypeId Type { get; init; }
     public required string Name { get; init; }
     public required int Tag { get; init; }
+    public required bool IsTagSpecified { get; init; }
     public required int Index { get; init; }
     public required bool IsBaseType { get; init; }
 }

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -222,6 +222,7 @@ public sealed partial class Parser
                     Type = CreateTypeId(derived.Type),
                     Name = derived.Name,
                     Tag = derived.Tag,
+                    IsTagSpecified = derived.IsTagSpecified,
                     Index = derived.Index,
                     IsBaseType = derived.IsBaseType,
                 })

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -162,7 +162,8 @@ public sealed partial class Parser : TypeDataModelGenerator
                 continue;
             }
 
-            tag = tag < 0 ? i : tag;
+            bool isTagSpecified = tag >= 0;
+            tag = isTagSpecified ? tag : i;
             name ??= derivedType.Name;
 
             if (!types.Add(derivedType))
@@ -188,6 +189,7 @@ public sealed partial class Parser : TypeDataModelGenerator
                 Type = derivedType,
                 Name = name,
                 Tag = tag,
+                IsTagSpecified = isTagSpecified,
                 Index = i,
                 IsBaseType = SymbolEqualityComparer.Default.Equals(derivedType, type),
             };

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.FSharpUnion.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.FSharpUnion.cs
@@ -46,6 +46,7 @@ internal sealed partial class SourceFormatter
                     Type = {{unionCase.TypeModel.SourceIdentifier}},
                     Name = "{{unionCase.Name}}",
                     Tag = {{unionCase.Tag}},
+                    IsTagSpecified = false,
                     Index = {{unionCase.Tag}},
                 },
                 """);

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Union.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Union.cs
@@ -57,8 +57,9 @@ internal sealed partial class SourceFormatter
                 new global::PolyType.SourceGenModel.SourceGenUnionCaseShape<{{unionCase.Type.FullyQualifiedName}}, {{unionShapeModel.Type.FullyQualifiedName}}>
                 {
                     Type = {{unionCaseType.SourceIdentifier}},
-                    Name = "{{unionCase.Name}}",
+                    Name = {{FormatStringLiteral(unionCase.Name)}},
                     Tag = {{unionCase.Tag}},
+                    IsTagSpecified = {{FormatBool(unionCase.IsTagSpecified)}},
                     Index = {{unionCase.Index}},
                 },
                 """);

--- a/src/PolyType/Abstractions/IUnionCaseShape.cs
+++ b/src/PolyType/Abstractions/IUnionCaseShape.cs
@@ -24,6 +24,11 @@ public interface IUnionCaseShape
     int Tag { get; }
 
     /// <summary>
+    /// Gets a value indicating whether <see cref="Tag"/> has been explicitly specified or inferred in a less stable way.
+    /// </summary>
+    bool IsTagSpecified { get; }
+
+    /// <summary>
     /// Gets the unique index corresponding to the current union case.
     /// </summary>
     /// <remarks>

--- a/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
@@ -58,6 +58,7 @@ internal sealed class FSharpUnionCaseShape<TUnionCase, TUnion>(FSharpUnionCaseIn
     public ITypeShape<TUnionCase> Type { get; } = new FSharpUnionCaseTypeShape<TUnionCase>(unionCaseInfo, provider);
     public string Name => unionCaseInfo.Name;
     public int Tag => unionCaseInfo.Tag;
+    public bool IsTagSpecified => false; // F# tags are inferred from the union case ordering
     public int Index => unionCaseInfo.Tag;
     ITypeShape IUnionCaseShape.Type => Type;
     public object? Accept(ITypeShapeVisitor visitor, object? state = null) => visitor.VisitUnionCase(this, state);

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -422,9 +422,10 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
     internal IUnionCaseShape CreateUnionCaseShape(IUnionTypeShape unionTypeShape, DerivedTypeShapeAttribute derivedTypeAttribute, int index)
     {
         string name = derivedTypeAttribute.Name;
-        int tag = derivedTypeAttribute.Tag < 0 ? index : derivedTypeAttribute.Tag;
+        bool isTagSpecified = derivedTypeAttribute.Tag >= 0;
+        int tag = isTagSpecified ? derivedTypeAttribute.Tag : index;
         Type unionCaseType = typeof(ReflectionUnionCaseShape<,>).MakeGenericType(derivedTypeAttribute.Type, unionTypeShape.Type);
-        return (IUnionCaseShape)Activator.CreateInstance(unionCaseType, unionTypeShape, name, tag, index, this)!;
+        return (IUnionCaseShape)Activator.CreateInstance(unionCaseType, unionTypeShape, name, tag, isTagSpecified, index, this)!;
     }
 
     internal static IConstructorShapeInfo CreateTupleConstructorShapeInfo(Type tupleType)

--- a/src/PolyType/ReflectionProvider/ReflectionUnionCaseShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionUnionCaseShape.cs
@@ -2,7 +2,7 @@
 
 namespace PolyType.ReflectionProvider;
 
-internal sealed class ReflectionUnionCaseShape<TUnionCase, TUnion>(IUnionTypeShape unionType, string name, int tag, int index, ReflectionTypeShapeProvider provider) : IUnionCaseShape<TUnionCase, TUnion>
+internal sealed class ReflectionUnionCaseShape<TUnionCase, TUnion>(IUnionTypeShape unionType, string name, int tag, bool isTagSpecified, int index, ReflectionTypeShapeProvider provider) : IUnionCaseShape<TUnionCase, TUnion>
     where TUnionCase : TUnion
 {
     public ITypeShape<TUnionCase> Type => _type ??= typeof(TUnionCase) == typeof(TUnion) ? (ITypeShape<TUnionCase>)unionType.BaseType : provider.GetShape<TUnionCase>();
@@ -10,6 +10,7 @@ internal sealed class ReflectionUnionCaseShape<TUnionCase, TUnion>(IUnionTypeSha
 
     public string Name { get; } = name;
     public int Tag { get; } = tag;
+    public bool IsTagSpecified { get; } = isTagSpecified;
     public int Index { get; } = index;
 
     ITypeShape IUnionCaseShape.Type => Type;

--- a/src/PolyType/SourceGenModel/SourceGenUnionCaseShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenUnionCaseShape.cs
@@ -25,6 +25,9 @@ public sealed class SourceGenUnionCaseShape<TUnionCase, TUnion> : IUnionCaseShap
     /// </summary>
     public required int Tag { get; init; }
 
+    /// <inheritdoc/>
+    public required bool IsTagSpecified { get; init; }
+
     /// <summary>
     /// Gets the unique index corresponding to the current union case.
     /// </summary>


### PR DESCRIPTION
This allows a serializer to know whether they can consider the Tag property to be a 'stable' input into the serialized schema.