### PR TITLE
Move AssociatedTypeAttribute to Abstractions namespace

### DIFF
--- a/src/PolyType.Examples/CborSerializer/CborConverterAttribute.cs
+++ b/src/PolyType.Examples/CborSerializer/CborConverterAttribute.cs
@@ -1,4 +1,6 @@
-﻿namespace PolyType.Examples.CborSerializer;
+﻿using PolyType.Abstractions;
+
+namespace PolyType.Examples.CborSerializer;
 
 /// <summary>
 /// Identifies a custom converter for the type.

--- a/src/PolyType.SourceGenerator/PolyTypeKnownSymbols.cs
+++ b/src/PolyType.SourceGenerator/PolyTypeKnownSymbols.cs
@@ -17,7 +17,7 @@ public sealed class PolyTypeKnownSymbols(Compilation compilation) : KnownSymbols
     public INamedTypeSymbol? TypeShapeExtensionAttribute => GetOrResolveType("PolyType.TypeShapeExtensionAttribute", ref _TypeShapeExtensionAttribute);
     private Option<INamedTypeSymbol?> _TypeShapeExtensionAttribute;
 
-    public INamedTypeSymbol? AssociatedTypeAttributeAttribute => GetOrResolveType("PolyType.AssociatedTypeAttributeAttribute", ref _AssociatedTypeAttributeAttribute);
+    public INamedTypeSymbol? AssociatedTypeAttributeAttribute => GetOrResolveType("PolyType.Abstractions.AssociatedTypeAttributeAttribute", ref _AssociatedTypeAttributeAttribute);
     private Option<INamedTypeSymbol?> _AssociatedTypeAttributeAttribute;
 
     public INamedTypeSymbol? PropertyShapeAttribute => GetOrResolveType("PolyType.PropertyShapeAttribute", ref _PropertyShapeAttribute);

--- a/src/PolyType/Abstractions/AssociatedTypeAttributeAttribute.cs
+++ b/src/PolyType/Abstractions/AssociatedTypeAttributeAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace PolyType;
+﻿namespace PolyType.Abstractions;
 
 /// <summary>
 /// An attribute to apply to other attribute classes that accept one or more <see cref="Type"/> arguments


### PR DESCRIPTION
The `AssociatedTypeAttribute` is functionality for library implementors only, so it should be best hidden behing the "Abstractions" namespace.

FYI @AArnott 