### PR TITLE
Rename `IConstructorParameterShape` to `IParameterShape`

### DIFF
--- a/docs/core-abstractions.md
+++ b/docs/core-abstractions.md
@@ -478,15 +478,15 @@ class MyPocoConstructorShape : IConstructorShape<MyPoco, (int, string)>
 }
 ```
 
-The two delegates define the means for creating a default instance of the mutable state token and constructing an instance of the declaring type from a populated token, respectively. Separately, there needs to be a mechanism for populating the state token which is achieved using the `IConstructorParameterShape` interface:
+The two delegates define the means for creating a default instance of the mutable state token and constructing an instance of the declaring type from a populated token, respectively. Separately, there needs to be a mechanism for populating the state token which is achieved using the `IParameterShape` interface:
 
 ```C#
 public partial interface IConstructorShape<TDeclaringType, TArgumentState> : IConstructorShape
 {
-    IReadOnlyList<IConstructorParameterShape> Parameters { get; }
+    IReadOnlyList<IParameterShape> Parameters { get; }
 }
 
-public partial interface IConstructorParameterShape<TArgumentState, TParameterType> : IConstructorParameterShape
+public partial interface IParameterShape<TArgumentState, TParameterType> : IParameterShape
 {
     ITypeShape<TParameterType> ParameterType { get; }
     Setter<TArgumentState, TParameterType> GetSetter();
@@ -494,7 +494,7 @@ public partial interface IConstructorParameterShape<TArgumentState, TParameterTy
 
 public abstract partial class TypeShapeVisitor
 {
-    object? VisitConstructor<TArgumentState, TParameterType>(IConstructorParameterShape<TArgumentState, TParameterType> shape, object? state = null);
+    object? VisitConstructor<TArgumentState, TParameterType>(IParameterShape<TArgumentState, TParameterType> shape, object? state = null);
 }
 ```
 
@@ -531,7 +531,7 @@ class EmptyConstructorVisitor : TypeShapeVisitor
         });
     }
 
-    public override object? VisitConstructorParameter<TArgumentState, TParameter>(IConstructorParameterShape<TArgumentState, TParameter> parameter, object? _)
+    public override object? VisitParameter<TArgumentState, TParameter>(IParameterShape<TArgumentState, TParameter> parameter, object? _)
     {
         var parameterFactory = (Func<TParameter>)parameter.ParameterType.Accept(this);
         Setter<TArgumentState, TParameter> setter = parameter.GetSetter();

--- a/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
@@ -72,7 +72,7 @@ public static partial class CborSerializer
                 properties);
         }
 
-        public override object? VisitConstructorParameter<TArgumentState, TParameterType>(IConstructorParameterShape<TArgumentState, TParameterType> parameter, object? state)
+        public override object? VisitParameter<TArgumentState, TParameterType>(IParameterShape<TArgumentState, TParameterType> parameter, object? state)
         {
             CborConverter<TParameterType> paramConverter = GetOrAddConverter(parameter.ParameterType);
             return new CborPropertyConverter<TArgumentState, TParameterType>(parameter, paramConverter);

--- a/src/PolyType.Examples/CborSerializer/Converters/CborPropertyConverter.cs
+++ b/src/PolyType.Examples/CborSerializer/Converters/CborPropertyConverter.cs
@@ -9,7 +9,7 @@ internal abstract class CborPropertyConverter<TDeclaringType>(string name)
     public string Name { get; } = name;
     public abstract bool HasGetter { get; }
     public abstract bool HasSetter { get; }
-    public bool IsConstructorParameter { get; private protected init; }
+    public bool IsParameter { get; private protected init; }
 
     public abstract void Write(CborWriter writer, ref TDeclaringType value);
     public abstract void Read(CborReader reader, ref TDeclaringType value);
@@ -37,12 +37,12 @@ internal sealed class CborPropertyConverter<TDeclaringType, TPropertyType> : Cbo
         }
     }
 
-    public CborPropertyConverter(IConstructorParameterShape<TDeclaringType, TPropertyType> parameter, CborConverter<TPropertyType> propertyConverter)
+    public CborPropertyConverter(IParameterShape<TDeclaringType, TPropertyType> parameter, CborConverter<TPropertyType> propertyConverter)
     : base(parameter.Name)
     {
         _propertyConverter = propertyConverter;
         _setter = parameter.GetSetter();
-        IsConstructorParameter = parameter.Kind is ConstructorParameterKind.ConstructorParameter;
+        IsParameter = parameter.Kind is ParameterKind.MethodParameter;
     }
 
     public override bool HasGetter => _getter != null;

--- a/src/PolyType.Examples/Cloner/Cloner.Builder.cs
+++ b/src/PolyType.Examples/Cloner/Cloner.Builder.cs
@@ -76,7 +76,7 @@ public static partial class Cloner
                 .Select(param =>
                 {
                     // Use case-insensitive comparison for constructor parameters, but case-sensitive for members.
-                    StringComparison comparison = param.Kind is ConstructorParameterKind.ConstructorParameter
+                    StringComparison comparison = param.Kind is ParameterKind.MethodParameter
                         ? StringComparison.OrdinalIgnoreCase
                         : StringComparison.Ordinal;
                     
@@ -122,7 +122,7 @@ public static partial class Cloner
         {
             public override object? VisitProperty<TDeclaringType, TPropertyType>(IPropertyShape<TDeclaringType, TPropertyType> propertyShape, object? state)
             {
-                var parameterShape = (IConstructorParameterShape<TArgumentState, TPropertyType>)state!;
+                var parameterShape = (IParameterShape<TArgumentState, TPropertyType>)state!;
                 var elementCloner = parent.GetOrAddCloner(propertyShape.PropertyType);
                 var getter = propertyShape.GetGetter();
                 var setter = parameterShape.GetSetter();

--- a/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
+++ b/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
@@ -107,7 +107,7 @@ public static partial class ConfigurationBinderTS
             return new PropertyBinder<TDeclaringType>((ref TDeclaringType obj, IConfigurationSection section) => setter(ref obj, propertyTypeBinder(section)!));
         }
 
-        public override object? VisitConstructorParameter<TArgumentState, TParameterType>(IConstructorParameterShape<TArgumentState, TParameterType> parameterShape, object? state = null)
+        public override object? VisitParameter<TArgumentState, TParameterType>(IParameterShape<TArgumentState, TParameterType> parameterShape, object? state = null)
         {
             Func<IConfiguration, TParameterType?> parameterTypeBinder = GetOrAddBinder(parameterShape.ParameterType);
             Setter<TArgumentState, TParameterType> setter = parameterShape.GetSetter();

--- a/src/PolyType.Examples/JsonSchema/JsonSchemaGenerator.cs
+++ b/src/PolyType.Examples/JsonSchema/JsonSchemaGenerator.cs
@@ -131,8 +131,8 @@ public static class JsonSchemaGenerator
                     if (objectShape.Properties is not [])
                     {
                         IConstructorShape? ctor = objectShape.Constructor;
-                        Dictionary<string, IConstructorParameterShape>? ctorParams = ctor?.Parameters
-                            .Where(p => p.Kind is ConstructorParameterKind.ConstructorParameter || p.IsRequired)
+                        Dictionary<string, IParameterShape>? ctorParams = ctor?.Parameters
+                            .Where(p => p.Kind is ParameterKind.MethodParameter || p.IsRequired)
                             .ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
 
                         JsonObject properties = new();
@@ -141,7 +141,7 @@ public static class JsonSchemaGenerator
                         Push("properties");
                         foreach (IPropertyShape prop in objectShape.Properties)
                         {
-                            IConstructorParameterShape? associatedParameter = null;
+                            IParameterShape? associatedParameter = null;
                             ctorParams?.TryGetValue(prop.Name, out associatedParameter);
 
                             bool isNonNullable = 

--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonPropertyConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonPropertyConverter.cs
@@ -11,7 +11,7 @@ internal abstract class JsonPropertyConverter<TDeclaringType>(string name)
     public JsonEncodedText EncodedName { get; } = JsonEncodedText.Encode(name);
     public abstract bool HasGetter { get; }
     public abstract bool HasSetter { get; }
-    public bool IsConstructorParameter { get; private protected init; }
+    public bool IsParameter { get; private protected init; }
 
     public abstract void Read(ref Utf8JsonReader reader, ref TDeclaringType declaringType, JsonSerializerOptions options);
     public abstract void Write(Utf8JsonWriter writer, ref TDeclaringType declaringType, JsonSerializerOptions options);
@@ -43,13 +43,13 @@ internal sealed class JsonPropertyConverter<TDeclaringType, TPropertyType> : Jso
         }
     }
 
-    public JsonPropertyConverter(IConstructorParameterShape<TDeclaringType, TPropertyType> parameter, JsonConverter<TPropertyType> propertyConverter)
+    public JsonPropertyConverter(IParameterShape<TDeclaringType, TPropertyType> parameter, JsonConverter<TPropertyType> propertyConverter)
         : base(parameter.Name)
     {
         _propertyTypeConverter = propertyConverter;
         _setterDisallowsNull = parameter.IsNonNullable;
         _setter = parameter.GetSetter();
-        IsConstructorParameter = parameter.Kind is ConstructorParameterKind.ConstructorParameter;
+        IsParameter = parameter.Kind is ParameterKind.MethodParameter;
     }
 
     public override bool HasGetter => _getter != null;

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
@@ -68,7 +68,7 @@ public static partial class JsonSerializerTS
                 properties);
         }
 
-        public override object? VisitConstructorParameter<TArgumentState, TParameter>(IConstructorParameterShape<TArgumentState, TParameter> parameter, object? state)
+        public override object? VisitParameter<TArgumentState, TParameter>(IParameterShape<TArgumentState, TParameter> parameter, object? state)
         {
             JsonConverter<TParameter> paramConverter = GetOrAddConverter(parameter.ParameterType);
             return new JsonPropertyConverter<TArgumentState, TParameter>(parameter, paramConverter);

--- a/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
+++ b/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
@@ -65,11 +65,11 @@ public static partial class Mapper
 
         public override object? VisitProperty<TSource, TSourceProperty>(IPropertyShape<TSource, TSourceProperty> sourceGetter, object? state = null)
         {
-            DebugExt.Assert(state is IPropertyShape or IConstructorParameterShape);
+            DebugExt.Assert(state is IPropertyShape or IParameterShape);
             var visitor = new PropertyScopedVisitor<TSource, TSourceProperty>(this);
             return state is IPropertyShape targetProp
                 ? targetProp.Accept(visitor, sourceGetter)
-                : ((IConstructorParameterShape)state).Accept(visitor, state: sourceGetter);
+                : ((IParameterShape)state).Accept(visitor, state: sourceGetter);
         }
 
         public override object? VisitOptional<TOptional, TElement>(IOptionalTypeShape<TOptional, TElement> optionalShape, object? state)
@@ -141,7 +141,7 @@ public static partial class Mapper
                         .Select(targetParam =>
                         {
                             // Use case-insensitive comparison for constructor parameters, but case-sensitive for members.
-                            StringComparison comparison = targetParam.Kind is ConstructorParameterKind.ConstructorParameter
+                            StringComparison comparison = targetParam.Kind is ParameterKind.MethodParameter
                                 ? StringComparison.OrdinalIgnoreCase
                                 : StringComparison.Ordinal;
 
@@ -195,7 +195,7 @@ public static partial class Mapper
                 });
             }
 
-            public override object? VisitConstructorParameter<TArgumentState, TTargetParameter>(IConstructorParameterShape<TArgumentState, TTargetParameter> targetParameter, object? state)
+            public override object? VisitParameter<TArgumentState, TTargetParameter>(IParameterShape<TArgumentState, TTargetParameter> targetParameter, object? state)
             {
                 var sourceProperty = (IPropertyShape<TSource, TSourceProperty>)state!;
                 var propertyTypeMapper = baseVisitor.GetOrAddMapper(sourceProperty.PropertyType, targetParameter.ParameterType);

--- a/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
+++ b/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
@@ -105,7 +105,7 @@ public partial class RandomGenerator
             }
         }
 
-        public override object? VisitConstructorParameter<TArgumentState, TParameter>(IConstructorParameterShape<TArgumentState, TParameter> parameter, object? state)
+        public override object? VisitParameter<TArgumentState, TParameter>(IParameterShape<TArgumentState, TParameter> parameter, object? state)
         {
             Setter<TArgumentState, TParameter> setter = parameter.GetSetter();
             RandomGenerator<TParameter> parameterGenerator = GetOrAddGenerator(parameter.ParameterType);

--- a/src/PolyType.Examples/XmlSerializer/Converters/XmlPropertyConverter.cs
+++ b/src/PolyType.Examples/XmlSerializer/Converters/XmlPropertyConverter.cs
@@ -9,7 +9,7 @@ internal abstract class XmlPropertyConverter<TDeclaringType>(string name)
     public string Name { get; } = XmlConvert.EncodeLocalName(name);
     public abstract bool HasGetter { get; }
     public abstract bool HasSetter { get; }
-    public bool IsConstructorParameter { get; private protected init; }
+    public bool IsParameter { get; private protected init; }
 
     public abstract void Write(XmlWriter writer, ref TDeclaringType value);
     public abstract void Read(XmlReader reader, ref TDeclaringType value);
@@ -37,12 +37,12 @@ internal sealed class XmlPropertyConverter<TDeclaringType, TPropertyType> : XmlP
         }
     }
 
-    public XmlPropertyConverter(IConstructorParameterShape<TDeclaringType, TPropertyType> parameter, XmlConverter<TPropertyType> propertyConverter)
+    public XmlPropertyConverter(IParameterShape<TDeclaringType, TPropertyType> parameter, XmlConverter<TPropertyType> propertyConverter)
     : base(parameter.Name)
     {
         _propertyConverter = propertyConverter;
         _setter = parameter.GetSetter();
-        IsConstructorParameter = parameter.Kind is ConstructorParameterKind.ConstructorParameter;
+        IsParameter = parameter.Kind is ParameterKind.MethodParameter;
     }
 
     public override bool HasGetter => _getter != null;

--- a/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
+++ b/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
@@ -65,7 +65,7 @@ public static partial class XmlSerializer
                 properties);
         }
 
-        public override object? VisitConstructorParameter<TArgumentState, TParameterType>(IConstructorParameterShape<TArgumentState, TParameterType> parameter, object? state)
+        public override object? VisitParameter<TArgumentState, TParameterType>(IParameterShape<TArgumentState, TParameterType> parameter, object? state)
         {
             XmlConverter<TParameterType> paramConverter = GetOrAddConverter(parameter.ParameterType);
             return new XmlPropertyConverter<TArgumentState, TParameterType>(parameter, paramConverter);

--- a/src/PolyType.Roslyn/Model/ConstructorDataModel.cs
+++ b/src/PolyType.Roslyn/Model/ConstructorDataModel.cs
@@ -21,7 +21,7 @@ public readonly struct ConstructorDataModel
     /// <summary>
     /// The parameters of the constructor.
     /// </summary>
-    public required ImmutableArray<ConstructorParameterDataModel> Parameters { get; init; }
+    public required ImmutableArray<ParameterDataModel> Parameters { get; init; }
 
     /// <summary>
     /// The members that could or should be initialized in conjunction with this constructor.

--- a/src/PolyType.Roslyn/Model/ParameterDataModel.cs
+++ b/src/PolyType.Roslyn/Model/ParameterDataModel.cs
@@ -6,7 +6,7 @@ namespace PolyType.Roslyn;
 /// <summary>
 /// A constructor parameter data model wrapping an <see cref="IParameterSymbol"/>.
 /// </summary>
-public readonly struct ConstructorParameterDataModel
+public readonly struct ParameterDataModel
 {
     /// <summary>
     /// The parameter symbol that this model represents.

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Object.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Object.cs
@@ -194,7 +194,7 @@ public partial class TypeDataModelGenerator
     {
         Debug.Assert(constructor.MethodKind is MethodKind.Constructor || constructor.IsStatic);
 
-        var parameters = new List<ConstructorParameterDataModel>();
+        var parameters = new List<ParameterDataModel>();
         TypeDataModelGenerationContext scopedCtx = ctx;
         foreach (IParameterSymbol parameter in constructor.Parameters)
         {
@@ -210,7 +210,7 @@ public partial class TypeDataModelGenerator
                 return null;
             }
 
-            ConstructorParameterDataModel parameterModel = MapConstructorParameter(parameter);
+            ParameterDataModel parameterModel = MapParameter(parameter);
             parameters.Add(parameterModel);
         }
 
@@ -265,9 +265,9 @@ public partial class TypeDataModelGenerator
         };
     }
 
-    private static ConstructorParameterDataModel MapConstructorParameter(IParameterSymbol parameter)
+    private static ParameterDataModel MapParameter(IParameterSymbol parameter)
     {
-        return new ConstructorParameterDataModel
+        return new ParameterDataModel
         {
             Parameter = parameter
         };

--- a/src/PolyType.SourceGenerator/Model/ConstructorShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/ConstructorShapeModel.cs
@@ -8,9 +8,9 @@ public sealed record ConstructorShapeModel
     public required bool IsPublic { get; init; }
     public required bool IsAccessible { get; init; }
     public required bool CanUseUnsafeAccessors { get; init; }
-    public required ImmutableEquatableArray<ConstructorParameterShapeModel> Parameters { get; init; }
-    public required ImmutableEquatableArray<ConstructorParameterShapeModel> RequiredMembers { get; init; }
-    public required ImmutableEquatableArray<ConstructorParameterShapeModel> OptionalMembers { get; init; }
+    public required ImmutableEquatableArray<ParameterShapeModel> Parameters { get; init; }
+    public required ImmutableEquatableArray<ParameterShapeModel> RequiredMembers { get; init; }
+    public required ImmutableEquatableArray<ParameterShapeModel> OptionalMembers { get; init; }
     public required OptionalMemberFlagsType OptionalMemberFlagsType { get; init; }
     public required string? StaticFactoryName { get; init; }
     public required bool StaticFactoryIsProperty { get; init; }

--- a/src/PolyType.SourceGenerator/Model/ParameterShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/ParameterShapeModel.cs
@@ -2,7 +2,7 @@
 
 namespace PolyType.SourceGenerator.Model;
 
-public sealed record ConstructorParameterShapeModel
+public sealed record ParameterShapeModel
 {
     public required string Name { get; init; }
     public required string UnderlyingMemberName { get; init; }
@@ -25,7 +25,7 @@ public sealed record ConstructorParameterShapeModel
 
 public enum ParameterKind
 {
-    ConstructorParameter,
+    MethodParameter,
     RequiredMember,
     OptionalMember
 }

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -363,8 +363,8 @@ public sealed partial class Parser
     private ConstructorShapeModel MapConstructor(ObjectDataModel objectModel, TypeId declaringTypeId, ConstructorDataModel constructor, bool isFSharpUnionCase)
     {
         int position = constructor.Parameters.Length;
-        List<ConstructorParameterShapeModel>? requiredMembers = null;
-        List<ConstructorParameterShapeModel>? optionalMembers = null;
+        List<ParameterShapeModel>? requiredMembers = null;
+        List<ParameterShapeModel>? optionalMembers = null;
 
         bool isAccessibleConstructor = IsAccessibleSymbol(constructor.Constructor);
         bool isParameterizedConstructor = position > 0 || constructor.MemberInitializers.Any(p => p.IsRequired || p.IsInitOnly);
@@ -378,7 +378,7 @@ public sealed partial class Parser
         {
             ParsePropertyShapeAttribute(propertyModel.PropertySymbol, out string propertyName, out _);
 
-            var memberInitializer = new ConstructorParameterShapeModel
+            var memberInitializer = new ParameterShapeModel
             {
                 ParameterType = CreateTypeId(propertyModel.PropertyType),
                 DeclaringType = SymbolEqualityComparer.Default.Equals(propertyModel.DeclaringType, objectModel.Type)
@@ -425,7 +425,7 @@ public sealed partial class Parser
                 ? declaringTypeId
                 : CreateTypeId(constructor.DeclaringType),
 
-            Parameters = constructor.Parameters.Select(p => MapConstructorParameter(objectModel, declaringTypeId, p, isFSharpUnionCase)).ToImmutableEquatableArray(),
+            Parameters = constructor.Parameters.Select(p => MapParameter(objectModel, declaringTypeId, p, isFSharpUnionCase)).ToImmutableEquatableArray(),
             RequiredMembers = requiredMembers?.ToImmutableEquatableArray() ?? [],
             OptionalMembers = optionalMembers?.ToImmutableEquatableArray() ?? [],
             OptionalMemberFlagsType = (optionalMembers?.Count ?? 0) switch
@@ -457,7 +457,7 @@ public sealed partial class Parser
         };
     }
 
-    private ConstructorParameterShapeModel MapConstructorParameter(ObjectDataModel objectModel, TypeId declaringTypeId, ConstructorParameterDataModel parameter, bool isFSharpUnionCase)
+    private ParameterShapeModel MapParameter(ObjectDataModel objectModel, TypeId declaringTypeId, ParameterDataModel parameter, bool isFSharpUnionCase)
     {
         string name = parameter.Parameter.Name;
 
@@ -500,14 +500,14 @@ public sealed partial class Parser
             }
         }
 
-        return new ConstructorParameterShapeModel
+        return new ParameterShapeModel
         {
             Name = name,
             UnderlyingMemberName = parameter.Parameter.Name,
             Position = parameter.Parameter.Ordinal,
             DeclaringType = declaringTypeId,
             ParameterType = CreateTypeId(parameter.Parameter.Type),
-            Kind = ParameterKind.ConstructorParameter,
+            Kind = ParameterKind.MethodParameter,
             RefKind = parameter.Parameter.RefKind,
             IsRequired = !parameter.HasDefaultValue,
             IsAccessible = true,
@@ -561,10 +561,10 @@ public sealed partial class Parser
             };
         }
 
-        static ConstructorParameterShapeModel MapTupleConstructorParameter(TypeId typeId, PropertyDataModel tupleElement, int position)
+        static ParameterShapeModel MapTupleConstructorParameter(TypeId typeId, PropertyDataModel tupleElement, int position)
         {
             string name = $"Item{position + 1}";
-            return new ConstructorParameterShapeModel
+            return new ParameterShapeModel
             {
                 Name = name,
                 UnderlyingMemberName = name,
@@ -572,7 +572,7 @@ public sealed partial class Parser
                 ParameterType = CreateTypeId(tupleElement.PropertyType),
                 DeclaringType = typeId,
                 HasDefaultValue = false,
-                Kind = ParameterKind.ConstructorParameter,
+                Kind = ParameterKind.MethodParameter,
                 RefKind = RefKind.None,
                 IsRequired = true,
                 IsAccessible = true,

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -485,7 +485,7 @@ public sealed partial class Parser : TypeDataModelGenerator
         {
             Constructor = unionCaseInfo.Constructor,
             Parameters = parameters
-                .Select(p => new ConstructorParameterDataModel { Parameter = p })
+                .Select(p => new ParameterDataModel { Parameter = p })
                 .ToImmutableArray(),
             MemberInitializers = ImmutableArray<PropertyDataModel>.Empty,
         };

--- a/src/PolyType/Abstractions/IConstructorShape.cs
+++ b/src/PolyType/Abstractions/IConstructorShape.cs
@@ -29,7 +29,7 @@ public interface IConstructorShape
     /// Includes all formal parameters of the underlying constructor,
     /// as well as any member that can be specified in a member initializer expression.
     /// </remarks>
-    IReadOnlyList<IConstructorParameterShape> Parameters { get; }
+    IReadOnlyList<IParameterShape> Parameters { get; }
 
     /// <summary>
     /// Accepts an <see cref="TypeShapeVisitor"/> for strongly-typed traversal.

--- a/src/PolyType/Abstractions/IParameterShape.cs
+++ b/src/PolyType/Abstractions/IParameterShape.cs
@@ -4,30 +4,30 @@ using System.Reflection;
 namespace PolyType.Abstractions;
 
 /// <summary>
-/// Provides a strongly typed shape model for a given .NET constructor parameter,
-/// representing either an actual constructor parameter or a member initializer.
+/// Provides a strongly typed shape model for a given .NET method parameter,
+/// representing either an actual parameter or a member initializer.
 /// </summary>
-public interface IConstructorParameterShape
+public interface IParameterShape
 {
     /// <summary>
-    /// Gets the 0-indexed position of the current constructor parameter.
+    /// Gets the 0-indexed position of the current method parameter.
     /// </summary>
     int Position { get; }
 
     /// <summary>
-    /// Gets the shape of the constructor parameter type.
+    /// Gets the shape of the method parameter type.
     /// </summary>
     ITypeShape ParameterType { get; }
 
     /// <summary>
-    /// Gets the name of the constructor parameter.
+    /// Gets the name of the method parameter.
     /// </summary>
     string Name { get; }
 
     /// <summary>
     /// Gets specifies the kind of the current parameter.
     /// </summary>
-    ConstructorParameterKind Kind { get; }
+    ParameterKind Kind { get; }
 
     /// <summary>
     /// Gets a value indicating whether the parameter has a default value.
@@ -44,7 +44,7 @@ public interface IConstructorParameterShape
     /// </summary>
     /// <remarks>
     /// A parameter is reported as required if it is either a
-    /// constructor parameter without a default value or a required property.
+    /// parameter without a default value or a required property.
     /// </remarks>
     bool IsRequired { get; }
 
@@ -80,15 +80,15 @@ public interface IConstructorParameterShape
 }
 
 /// <summary>
-/// Provides a strongly typed shape model for a given .NET constructor parameter,
-/// representing either an actual constructor parameter or a required or init-only property.
+/// Provides a strongly typed shape model for a given .NET method parameter,
+/// representing either an actual method parameter or a required or init-only property.
 /// </summary>
-/// <typeparam name="TArgumentState">The state type used for aggregating constructor arguments.</typeparam>
-/// <typeparam name="TParameterType">The type of the underlying constructor parameter.</typeparam>
-public interface IConstructorParameterShape<TArgumentState, TParameterType> : IConstructorParameterShape
+/// <typeparam name="TArgumentState">The state type used for aggregating method arguments.</typeparam>
+/// <typeparam name="TParameterType">The type of the underlying method parameter.</typeparam>
+public interface IParameterShape<TArgumentState, TParameterType> : IParameterShape
 {
     /// <summary>
-    /// Gets the shape of the constructor parameter type.
+    /// Gets the shape of the method parameter type.
     /// </summary>
     new ITypeShape<TParameterType> ParameterType { get; }
 

--- a/src/PolyType/Abstractions/ParameterKind.cs
+++ b/src/PolyType/Abstractions/ParameterKind.cs
@@ -1,14 +1,14 @@
 ﻿namespace PolyType.Abstractions;
 
 /// <summary>
-/// Specifies the kind of constructor parameter.
+/// Specifies the kind of method parameter.
 /// </summary>
-public enum ConstructorParameterKind
+public enum ParameterKind
 {
     /// <summary>
-    /// Represents a constructor parameter.
+    /// Represents a method parameter.
     /// </summary>
-    ConstructorParameter,
+    MethodParameter,
 
     /// <summary>
     /// Represents a member initializer.

--- a/src/PolyType/Abstractions/TypeShapeVisitor.cs
+++ b/src/PolyType/Abstractions/TypeShapeVisitor.cs
@@ -32,7 +32,7 @@ public abstract class TypeShapeVisitor
         => ThrowNotImplementedException();
 
     /// <summary>
-    /// Visits an <see cref="IConstructorParameterShape{TDeclaringType, TArgumentState}"/> instance.
+    /// Visits an <see cref="IParameterShape{TArgumentState,TParameterType}"/> instance.
     /// </summary>
     /// <typeparam name="TDeclaringType">The declaring type of the visited constructor.</typeparam>
     /// <typeparam name="TArgumentState">The constructor argument state type used for aggregating constructor arguments.</typeparam>
@@ -43,14 +43,14 @@ public abstract class TypeShapeVisitor
         => ThrowNotImplementedException();
 
     /// <summary>
-    /// Visits an <see cref="IConstructorParameterShape{TArgumentState, TParameterType}"/> instance.
+    /// Visits an <see cref="IParameterShape{TArgumentState,TParameterType}"/> instance.
     /// </summary>
     /// <typeparam name="TArgumentState">The constructor argument state type used for aggregating constructor arguments.</typeparam>
     /// <typeparam name="TParameterType">The type of the visited constructor parameter.</typeparam>
     /// <param name="parameterShape">The parameter shape to visit.</param>
     /// <param name="state">Defines user-provided state.</param>
     /// <returns>The result produced by the visitor.</returns>
-    public virtual object? VisitConstructorParameter<TArgumentState, TParameterType>(IConstructorParameterShape<TArgumentState, TParameterType> parameterShape, object? state = null)
+    public virtual object? VisitParameter<TArgumentState, TParameterType>(IParameterShape<TArgumentState, TParameterType> parameterShape, object? state = null)
         => ThrowNotImplementedException();
 
     /// <summary>

--- a/src/PolyType/ReflectionProvider/ReflectionConstructorShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionConstructorShape.cs
@@ -11,7 +11,7 @@ internal sealed class ReflectionConstructorShape<TDeclaringType, TArgumentState>
     IConstructorShapeInfo ctorInfo) :
     IConstructorShape<TDeclaringType, TArgumentState>
 {
-    private IReadOnlyList<IConstructorParameterShape>? _parameters;
+    private IReadOnlyList<IParameterShape>? _parameters;
     private Func<TArgumentState>? _argumentStateConstructor;
     private Constructor<TArgumentState, TDeclaringType>? _parameterizedConstructor;
     private Func<TDeclaringType>? _defaultConstructor;
@@ -22,7 +22,7 @@ internal sealed class ReflectionConstructorShape<TDeclaringType, TArgumentState>
     IObjectTypeShape IConstructorShape.DeclaringType => DeclaringType;
     object? IConstructorShape.Accept(TypeShapeVisitor visitor, object? state) => visitor.VisitConstructor(this, state);
 
-    public IReadOnlyList<IConstructorParameterShape> Parameters => _parameters ??= GetParameters().AsReadOnlyList();
+    public IReadOnlyList<IParameterShape> Parameters => _parameters ??= GetParameters().AsReadOnlyList();
 
     public Func<TArgumentState> GetArgumentStateConstructor()
     {
@@ -57,11 +57,11 @@ internal sealed class ReflectionConstructorShape<TDeclaringType, TArgumentState>
         return _defaultConstructor ??= provider.MemberAccessor.CreateDefaultConstructor<TDeclaringType>(ctorInfo);
     }
 
-    private IEnumerable<IConstructorParameterShape> GetParameters()
+    private IEnumerable<IParameterShape> GetParameters()
     {
         for (int i = 0; i < ctorInfo.Parameters.Length; i++)
         {
-            yield return provider.CreateConstructorParameter(typeof(TArgumentState), ctorInfo, i);
+            yield return provider.CreateParameter(typeof(TArgumentState), ctorInfo, i);
         }
     }
 }

--- a/src/PolyType/ReflectionProvider/ReflectionParameterShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionParameterShape.cs
@@ -4,14 +4,14 @@ using System.Reflection;
 
 namespace PolyType.ReflectionProvider;
 
-internal sealed class ReflectionConstructorParameterShape<TArgumentState, TParameter> : IConstructorParameterShape<TArgumentState, TParameter>
+internal sealed class ReflectionParameterShape<TArgumentState, TParameter> : IParameterShape<TArgumentState, TParameter>
 {
     private readonly ReflectionTypeShapeProvider _provider;
     private readonly IConstructorShapeInfo _ctorInfo;
     private readonly IParameterShapeInfo _parameterInfo;
     private Setter<TArgumentState, TParameter>? _setter;
 
-    public ReflectionConstructorParameterShape(
+    public ReflectionParameterShape(
         ReflectionTypeShapeProvider provider,
         IConstructorShapeInfo ctorInfo,
         IParameterShapeInfo parameterInfo,
@@ -29,16 +29,16 @@ internal sealed class ReflectionConstructorParameterShape<TArgumentState, TParam
 
     public int Position { get; }
     public string Name => _parameterInfo.Name;
-    public ConstructorParameterKind Kind => _parameterInfo.Kind;
+    public ParameterKind Kind => _parameterInfo.Kind;
     public bool HasDefaultValue => _parameterInfo.HasDefaultValue;
     public bool IsRequired => _parameterInfo.IsRequired;
     public bool IsNonNullable => _parameterInfo.IsNonNullable;
     public bool IsPublic => _parameterInfo.IsPublic;
     public TParameter? DefaultValue => (TParameter?)_parameterInfo.DefaultValue;
-    object? IConstructorParameterShape.DefaultValue => _parameterInfo.DefaultValue;
+    object? IParameterShape.DefaultValue => _parameterInfo.DefaultValue;
     public ICustomAttributeProvider? AttributeProvider => _parameterInfo.AttributeProvider;
-    ITypeShape IConstructorParameterShape.ParameterType => ParameterType;
-    object? IConstructorParameterShape.Accept(TypeShapeVisitor visitor, object? state) => visitor.VisitConstructorParameter(this, state);
+    ITypeShape IParameterShape.ParameterType => ParameterType;
+    object? IParameterShape.Accept(TypeShapeVisitor visitor, object? state) => visitor.VisitParameter(this, state);
 
     public Setter<TArgumentState, TParameter> GetSetter() =>
         _setter ??= _provider.MemberAccessor.CreateConstructorArgumentStateSetter<TArgumentState, TParameter>(_ctorInfo, Position);
@@ -48,7 +48,7 @@ internal interface IParameterShapeInfo
 {
     Type Type { get; }
     string Name { get; }
-    ConstructorParameterKind Kind { get; }
+    ParameterKind Kind { get; }
     ICustomAttributeProvider? AttributeProvider { get; }
     bool IsByRef { get; }
     bool IsRequired { get; }
@@ -83,7 +83,7 @@ internal sealed class MethodParameterShapeInfo : IParameterShapeInfo
 
     public Type Type { get; }
     public string Name { get; }
-    public ConstructorParameterKind Kind => ConstructorParameterKind.ConstructorParameter;
+    public ParameterKind Kind => ParameterKind.MethodParameter;
     public ICustomAttributeProvider? AttributeProvider => ParameterInfo;
     public bool IsByRef => ParameterInfo.ParameterType.IsByRef;
     public bool IsRequired => !ParameterInfo.HasDefaultValue;
@@ -120,5 +120,5 @@ internal sealed class MemberInitializerShapeInfo : IParameterShapeInfo
     public ICustomAttributeProvider? AttributeProvider => MemberInfo;
     public bool HasDefaultValue => false;
     public object? DefaultValue => null;
-    public ConstructorParameterKind Kind => ConstructorParameterKind.MemberInitializer;
+    public ParameterKind Kind => ParameterKind.MemberInitializer;
 }

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -439,11 +439,11 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
         return (IConstructorShape)Activator.CreateInstance(reflectionConstructorType, this, declaringType, ctorInfo)!;
     }
 
-    internal IConstructorParameterShape CreateConstructorParameter(Type constructorArgumentState, IConstructorShapeInfo ctorInfo, int position)
+    internal IParameterShape CreateParameter(Type constructorArgumentState, IConstructorShapeInfo ctorInfo, int position)
     {
         IParameterShapeInfo parameterInfo = ctorInfo.Parameters[position];
-        Type reflectionConstructorParameterType = typeof(ReflectionConstructorParameterShape<,>).MakeGenericType(constructorArgumentState, parameterInfo.Type);
-        return (IConstructorParameterShape)Activator.CreateInstance(reflectionConstructorParameterType, this, ctorInfo, parameterInfo, position)!;
+        Type constructorParameterType = typeof(ReflectionParameterShape<,>).MakeGenericType(constructorArgumentState, parameterInfo.Type);
+        return (IParameterShape)Activator.CreateInstance(constructorParameterType, this, ctorInfo, parameterInfo, position)!;
     }
 
     internal IUnionCaseShape CreateUnionCaseShape(IUnionTypeShape unionTypeShape, DerivedTypeInfo derivedTypeInfo)

--- a/src/PolyType/SourceGenModel/SourceGenConstructorShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenConstructorShape.cs
@@ -33,7 +33,7 @@ public sealed class SourceGenConstructorShape<TDeclaringType, TArgumentState> : 
     /// <summary>
     /// Gets the parameter shapes for the constructor.
     /// </summary>
-    public Func<IEnumerable<IConstructorParameterShape>>? GetParametersFunc { get; init; }
+    public Func<IEnumerable<IParameterShape>>? GetParametersFunc { get; init; }
 
     /// <summary>
     /// Gets the default constructor for the declaring type.
@@ -50,8 +50,8 @@ public sealed class SourceGenConstructorShape<TDeclaringType, TArgumentState> : 
     /// </summary>
     public Constructor<TArgumentState, TDeclaringType>? ParameterizedConstructorFunc { get; init; }
 
-    IReadOnlyList<IConstructorParameterShape> IConstructorShape.Parameters => _parameters ??= (GetParametersFunc?.Invoke()).AsReadOnlyList();
-    private IReadOnlyList<IConstructorParameterShape>? _parameters;
+    IReadOnlyList<IParameterShape> IConstructorShape.Parameters => _parameters ??= (GetParametersFunc?.Invoke()).AsReadOnlyList();
+    private IReadOnlyList<IParameterShape>? _parameters;
 
     Func<TDeclaringType> IConstructorShape<TDeclaringType, TArgumentState>.GetDefaultConstructor()
         => DefaultConstructorFunc ?? throw new InvalidOperationException("Constructor shape does not specify a default constructor.");

--- a/src/PolyType/SourceGenModel/SourceGenParameterShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenParameterShape.cs
@@ -8,7 +8,7 @@ namespace PolyType.SourceGenModel;
 /// </summary>
 /// <typeparam name="TArgumentState">The mutable constructor argument state type.</typeparam>
 /// <typeparam name="TParameter">The constructor parameter type.</typeparam>
-public sealed class SourceGenConstructorParameterShape<TArgumentState, TParameter> : IConstructorParameterShape<TArgumentState, TParameter>
+public sealed class SourceGenParameterShape<TArgumentState, TParameter> : IParameterShape<TArgumentState, TParameter>
 {
     /// <summary>
     /// Gets the position of the parameter in the constructor signature.
@@ -23,7 +23,7 @@ public sealed class SourceGenConstructorParameterShape<TArgumentState, TParamete
     /// <summary>
     /// Gets the kind of the parameter.
     /// </summary>
-    public required ConstructorParameterKind Kind { get; init; }
+    public required ParameterKind Kind { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether the parameter is required.
@@ -65,9 +65,9 @@ public sealed class SourceGenConstructorParameterShape<TArgumentState, TParamete
     /// </summary>
     public TParameter? DefaultValue { get; init; }
 
-    object? IConstructorParameterShape.DefaultValue => HasDefaultValue ? DefaultValue : null;
-    ITypeShape IConstructorParameterShape.ParameterType => ParameterType;
-    ICustomAttributeProvider? IConstructorParameterShape.AttributeProvider => AttributeProviderFunc?.Invoke();
-    object? IConstructorParameterShape.Accept(TypeShapeVisitor visitor, object? state) => visitor.VisitConstructorParameter(this, state);
-    Setter<TArgumentState, TParameter> IConstructorParameterShape<TArgumentState, TParameter>.GetSetter() => Setter;
+    object? IParameterShape.DefaultValue => HasDefaultValue ? DefaultValue : null;
+    ITypeShape IParameterShape.ParameterType => ParameterType;
+    ICustomAttributeProvider? IParameterShape.AttributeProvider => AttributeProviderFunc?.Invoke();
+    object? IParameterShape.Accept(TypeShapeVisitor visitor, object? state) => visitor.VisitParameter(this, state);
+    Setter<TArgumentState, TParameter> IParameterShape<TArgumentState, TParameter>.GetSetter() => Setter;
 }

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -171,7 +171,7 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
                 Assert.Same(constructor.GetArgumentStateConstructor(), constructor.GetArgumentStateConstructor());
 
                 TArgumentState argumentState = argumentStateCtor();
-                foreach (IConstructorParameterShape parameter in constructor.Parameters)
+                foreach (IParameterShape parameter in constructor.Parameters)
                 {
                     Assert.Equal(i++, parameter.Position);
                     argumentState = (TArgumentState)parameter.Accept(this, argumentState)!;
@@ -191,7 +191,7 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
             return null;
         }
 
-        public override object? VisitConstructorParameter<TArgumentState, TParameter>(IConstructorParameterShape<TArgumentState, TParameter> parameter, object? state)
+        public override object? VisitParameter<TArgumentState, TParameter>(IParameterShape<TArgumentState, TParameter> parameter, object? state)
         {
             var argState = (TArgumentState)state!;
             var setter = parameter.GetSetter();
@@ -598,7 +598,7 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
             bool hasSetsRequiredMembersAttribute = ctorInfo.SetsRequiredMembers();
 
             int i = 0;
-            foreach (IConstructorParameterShape ctorParam in constructor.Parameters)
+            foreach (IParameterShape ctorParam in constructor.Parameters)
             {
                 if (i < parameters.Length)
                 {
@@ -623,7 +623,7 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
                     Assert.Equal(hasDefaultValue, ctorParam.HasDefaultValue);
                     Assert.Equal(defaultValue, ctorParam.DefaultValue);
                     Assert.Equal(!hasDefaultValue, ctorParam.IsRequired);
-                    Assert.Equal(ConstructorParameterKind.ConstructorParameter, ctorParam.Kind);
+                    Assert.Equal(ParameterKind.MethodParameter, ctorParam.Kind);
                     Assert.True(ctorParam.IsPublic);
 
                     ParameterInfo paramInfo = Assert.IsAssignableFrom<ParameterInfo>(ctorParam.AttributeProvider);
@@ -644,7 +644,7 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
                     Assert.False(ctorParam.HasDefaultValue);
                     Assert.Null(ctorParam.DefaultValue);
                     Assert.Equal(!hasSetsRequiredMembersAttribute && memberInfo.IsRequired(), ctorParam.IsRequired);
-                    Assert.Equal(ConstructorParameterKind.MemberInitializer, ctorParam.Kind);
+                    Assert.Equal(ParameterKind.MemberInitializer, ctorParam.Kind);
 
                     if (memberInfo is PropertyInfo p)
                     {
@@ -703,7 +703,7 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
             ParameterInfo[] parameters = ctorInfo.GetParameters();
             Assert.True(parameters.Length <= constructor.Parameters.Count);
 
-            foreach (IConstructorParameterShape ctorParam in constructor.Parameters)
+            foreach (IParameterShape ctorParam in constructor.Parameters)
             {
                 if (ctorParam.AttributeProvider is ParameterInfo pInfo)
                 {

--- a/tests/PolyType.Tests/TypeShapeVisitorTests.cs
+++ b/tests/PolyType.Tests/TypeShapeVisitorTests.cs
@@ -38,7 +38,7 @@ public class TypeShapeVisitorTests(ITestOutputHelper logger)
     public void VisitConstructor() => AssertVisitor(v => v.VisitConstructor<object, object>(default!));
 
     [Fact]
-    public void VisitConstructorParameter() => AssertVisitor(v => v.VisitConstructorParameter<object, object>(default!));
+    public void VisitParameter() => AssertVisitor(v => v.VisitParameter<object, object>(default!));
 
     [Fact]
     public void VisitOptional() => AssertVisitor(v => v.VisitOptional<object, object>(default!));


### PR DESCRIPTION
Makes a breaking change in anticipation of #80.

cc @AArnott 