### PR TITLE
Add spelling exclusion dictionary

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,7 @@
 ﻿# MSBuild project files
+[*]
+spelling_exclusion_path = exclusion.dic
+
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj,msbuildproj,props,targets}]
 indent_size = 2
 indent_style = space

--- a/PolyType.sln
+++ b/PolyType.sln
@@ -47,6 +47,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		Dockerfile = Dockerfile
+		exclusion.dic = exclusion.dic
 		global.json = global.json
 		key.snk = key.snk
 		LICENSE = LICENSE

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -1,0 +1,9 @@
+cbor
+ctors
+deconstructor
+impl
+infos
+kvps
+ldfld
+netstandard
+unloadability


### PR DESCRIPTION
Prevents false positive spelling errors in the VS editor, avoiding blue squiggles under terms, and blue dots in the scrollbar.