### PR TITLE
Produce reference assemblies for all projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,7 @@
     <AssemblyOriginatorKeyFile>$(RepoRoot)\key.snk</AssemblyOriginatorKeyFile>
     <VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).$(TargetFramework).$(OS).trx</VSTestLogger>
     <VSTestResultsDirectory>$(MSBuildThisFileDirectory)/artifacts/TestResults</VSTestResultsDirectory>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">


### PR DESCRIPTION
This improves incremental build compilation within the solution, for `netstandard2.0` projects/configurations in particular. It's enabled by default from `net5.0` onwards, but is worth turning on for earlier targets.

I don't believe it impacts any packaged artifacts. It should only speed up builds within this repo.