### PR TITLE
Skip code coverage of test projects themselves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: build
 		--results-directory $(ARTIFACT_PATH)/testResults \
 		--collect "Code Coverage;Format=cobertura" \
 		--logger "trx" \
-		 --settings test.runsettings \
+		--settings test.runsettings \
 		-- \
 		RunConfiguration.CollectSourceInformation=true
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ test: build
 		--results-directory $(ARTIFACT_PATH)/testResults \
 		--collect "Code Coverage;Format=cobertura" \
 		--logger "trx" \
+		 --settings test.runsettings \
 		-- \
 		RunConfiguration.CollectSourceInformation=true
 

--- a/test.runsettings
+++ b/test.runsettings
@@ -1,0 +1,11 @@
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage">
+        <Configuration>
+          <ExcludeByFile>**/tests/**/*.cs</ExcludeByFile>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
Two issues:

1. This doesn't work.
2. If it did work, it would remove all coverage of source generated code.