### PR TITLE
Fix source gen reporting of required-by-attribute properties

### DIFF
--- a/src/PolyType.Roslyn/Model/PropertyDataModel.cs
+++ b/src/PolyType.Roslyn/Model/PropertyDataModel.cs
@@ -14,7 +14,7 @@ public readonly struct PropertyDataModel
     public PropertyDataModel(IPropertySymbol property)
     {
         PropertySymbol = property;
-        IsRequired = property.IsRequired();
+        IsRequiredBySyntax = property.IsRequired();
     }
 
     /// <summary>
@@ -23,7 +23,7 @@ public readonly struct PropertyDataModel
     public PropertyDataModel(IFieldSymbol field)
     {
         PropertySymbol = field;
-        IsRequired = field.IsRequired();
+        IsRequiredBySyntax = field.IsRequired();
     }
 
     /// <summary>
@@ -97,7 +97,12 @@ public readonly struct PropertyDataModel
     /// <summary>
     /// Whether the property or field is declared with the <see langword="required" /> modifier.
     /// </summary>
-    public bool IsRequired { get; init; }
+    public bool IsRequiredBySyntax { get; init; }
+
+    /// <summary>
+    /// Whether the property or field is considered required by policy (e.g. syntax, overridden by attribute).
+    /// </summary>
+    public bool? IsRequiredByPolicy { get; init; }
 
     /// <summary>
     /// Whether the property is init-only.

--- a/src/PolyType.SourceGenerator/Model/PropertyShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/PropertyShapeModel.cs
@@ -22,7 +22,8 @@ public sealed record PropertyShapeModel
     public required bool IsGetterNonNullable { get; init; }
     public required bool IsSetterNonNullable { get; init; }
 
-    public required bool IsRequired { get; init; }
+    public required bool IsRequiredBySyntax { get; init; }
+    public required bool? IsRequiredByPolicy { get; init; }
     
     /// <summary>
     /// Whether the property type or type parameters of the

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -164,6 +164,26 @@ public sealed partial class Parser : TypeDataModelGenerator
         return base.IncludeField(field);
     }
 
+    protected override bool? IsRequiredByPolicy(IPropertySymbol member)
+    {
+        if (member.GetAttribute(_knownSymbols.PropertyShapeAttribute) is AttributeData fieldAttribute && fieldAttribute.TryGetNamedArgument("IsRequired", out bool isRequiredValue))
+        {
+            return  isRequiredValue;
+        }
+
+        return base.IsRequiredByPolicy(member);
+    }
+
+    protected override bool? IsRequiredByPolicy(IFieldSymbol member)
+    {
+        if (member.GetAttribute(_knownSymbols.PropertyShapeAttribute) is AttributeData fieldAttribute && fieldAttribute.TryGetNamedArgument("IsRequired", out bool isRequiredValue))
+        {
+            return isRequiredValue;
+        }
+
+        return base.IsRequiredByPolicy(member);
+    }
+
     // Resolve constructors with the [ConstructorShape] attribute.
     protected override IEnumerable<IMethodSymbol> ResolveConstructors(ITypeSymbol type, ImmutableArray<PropertyDataModel> properties)
     {

--- a/src/PolyType/Abstractions/IParameterShape.cs
+++ b/src/PolyType/Abstractions/IParameterShape.cs
@@ -44,7 +44,8 @@ public interface IParameterShape
     /// </summary>
     /// <remarks>
     /// A parameter is reported as required if it is either a
-    /// parameter without a default value or related to a property declared with the <see langword="required" /> modifier.
+    /// parameter without a default value or related to a property declared with the <see langword="required" /> modifier
+    /// where the constructor is not annotated with <see cref="SetsRequiredMembersAttribute"/>.
     /// This value will switch to the value set by <see cref="PropertyShapeAttribute.IsRequired"/>
     /// or <see cref="ParameterShapeAttribute.IsRequired"/> (successively) if they are set.
     /// </remarks>

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
@@ -267,6 +267,25 @@ public static class CompilationTests
     }
 
     [Fact]
+    public static void IsRequiredProperty()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+            #nullable enable
+
+            [GenerateShape]
+            public partial class Foo
+            {
+                [PropertyShape(IsRequired = true)]
+                public string? PropA { get; set; }
+            }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public static void MultiplePartialContextDeclarations_NoErrors()
     {
         Compilation compilation = CompilationHelpers.CreateCompilation("""

--- a/tests/PolyType.Tests/IsRequiredTests.cs
+++ b/tests/PolyType.Tests/IsRequiredTests.cs
@@ -76,7 +76,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     public partial class HasPropertyRequiredByAttribute
     {
         [PropertyShape(IsRequired = true)]
-        public bool RequiredProperty { get; init; }
+        public bool RequiredProperty { get; set; }
     }
 
     [Fact]


### PR DESCRIPTION
This gets non-default source-generation constructor paths to be used in the absence of any `required` or `init` properties, when there _are_ properties annotated with `PropertyShapeAttribute.IsRequired` = `true`.