### PR TITLE
Fix CborCustomConverterTests tests

### DIFF
--- a/tests/PolyType.Tests/CborCustomConverterTests.cs
+++ b/tests/PolyType.Tests/CborCustomConverterTests.cs
@@ -54,7 +54,7 @@ public abstract partial class CborCustomConverterTests(ProviderUnderTest provide
     private CborConverter<T> GetConverterUnderTest<T>() =>
         CborSerializer.CreateConverter((ITypeShape<T>?)providerUnderTest.Provider.GetShape(typeof(T)) ?? throw new InvalidOperationException("Shape missing."));
 
-    public sealed class Reflection() : CborTests(RefectionProviderUnderTest.NoEmit);
-    public sealed class ReflectionEmit() : CborTests(RefectionProviderUnderTest.Emit);
-    public sealed class SourceGen() : CborTests(new SourceGenProviderUnderTest(Witness.ShapeProvider));
+    public sealed class Reflection() : CborCustomConverterTests(RefectionProviderUnderTest.NoEmit);
+    public sealed class ReflectionEmit() : CborCustomConverterTests(RefectionProviderUnderTest.Emit);
+    public sealed class SourceGen() : CborCustomConverterTests(new SourceGenProviderUnderTest(Witness.ShapeProvider));
 }


### PR DESCRIPTION
That class was simply re-running `CborTests` instead of its own one test.