### PR TITLE
Fix bug in source generation around generic ctor parameter with default value

### DIFF
--- a/src/PolyType.Roslyn/Helpers/RoslynHelpers.cs
+++ b/src/PolyType.Roslyn/Helpers/RoslynHelpers.cs
@@ -464,7 +464,7 @@ internal static class RoslynHelpers
 
         string literalExpr = parameter.ExplicitDefaultValue switch
         {
-            null => "null!",
+            null => parameter.Type.IsNullable() ? "null!" : "default",
             false => "false",
             true => "true",
 

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
@@ -181,6 +181,38 @@ public static class CompilationTests
     }
 
     [Fact]
+    public static void CtorWithNullableGenericParameterAndDefault()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            public record GenericClass<T>(T? Value = default);
+
+            [GenerateShape<GenericClass<int>>]
+            public partial class Witness;
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void CtorWithNullableGenericParameterAndDefault_ValueConstrained()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            public record GenericClass<T>(T? Value = default) where T : struct;
+
+            [GenerateShape<GenericClass<int>>]
+            public partial class Witness;
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public static void ClassWithSetsRequiredMembersConstructor_NoErrors()
     {
         Compilation compilation = CompilationHelpers.CreateCompilation("""


### PR DESCRIPTION
Fixes a code gen bug where generic type parameters that are set to `default` are assigned `null` by generated code, even when the generic type argument is a value type.

```
        51:                 ArgumentStateConstructorFunc = static () => null!,
        70:                 DefaultValue = null!,
```