### PR TITLE
Add support for types implementing `IAsyncEnumerable<T>`

### DIFF
--- a/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
@@ -1,5 +1,6 @@
 ﻿using PolyType.Abstractions;
 using PolyType.Examples.CborSerializer.Converters;
+using PolyType.Examples.Utilities;
 
 namespace PolyType.Examples.CborSerializer;
 
@@ -83,7 +84,7 @@ public static partial class CborSerializer
         public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state)
         {
             CborConverter<TElement> elementConverter = GetOrAddConverter(enumerableShape.ElementType);
-            Func<TEnumerable, IEnumerable<TElement>> getEnumerable = enumerableShape.GetGetEnumerable();
+            Func<TEnumerable, IEnumerable<TElement>> getEnumerable = enumerableShape.GetGetPotentiallyBlockingEnumerable();
 
             return enumerableShape.ConstructionStrategy switch
             {

--- a/src/PolyType.Examples/CborSerializer/Converters/CborDictionaryConverter.cs
+++ b/src/PolyType.Examples/CborSerializer/Converters/CborDictionaryConverter.cs
@@ -122,7 +122,7 @@ internal sealed class CborEnumerableConstructorDictionaryConverter<TDictionary, 
     : CborImmutableDictionaryConverter<TDictionary, TKey, TValue>(keyConverter, valueConverter, getDictionary)
 {
     private protected override TDictionary Construct(PooledList<KeyValuePair<TKey, TValue>> buffer)
-        => constructor(buffer.ExchangeToArraySegment());
+        => constructor(buffer.ToArray());
 }
 
 internal sealed class CborSpanConstructorDictionaryConverter<TDictionary, TKey, TValue>(

--- a/src/PolyType.Examples/CborSerializer/Converters/CborEnumerableConverter.cs
+++ b/src/PolyType.Examples/CborSerializer/Converters/CborEnumerableConverter.cs
@@ -112,7 +112,7 @@ internal sealed class CborEnumerableConstructorEnumerableConverter<TEnumerable, 
     : CborImmutableEnumerableConverter<TEnumerable, TElement>(elementConverter, getEnumerable)
 {
     private protected override TEnumerable Construct(PooledList<TElement> buffer)
-        => constructor(buffer.ExchangeToArraySegment());
+        => constructor(buffer.ToArray());
 }
 
 internal sealed class CborSpanConstructorEnumerableConverter<TEnumerable, TElement>(

--- a/src/PolyType.Examples/Cloner/Cloner.Builder.cs
+++ b/src/PolyType.Examples/Cloner/Cloner.Builder.cs
@@ -138,7 +138,8 @@ public static partial class Cloner
         public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? _)
         {
             var elementCloner = GetOrAddCloner(enumerableShape.ElementType);
-            Func<TEnumerable, IEnumerable<TElement>> getEnumerable = enumerableShape.GetGetEnumerable();
+            Func<TEnumerable, IEnumerable<TElement>> getEnumerable = enumerableShape.GetGetPotentiallyBlockingEnumerable();
+
             switch (enumerableShape.ConstructionStrategy)
             {
                 case CollectionConstructionStrategy.Mutable:

--- a/src/PolyType.Examples/Counter/Counter.Builder.cs
+++ b/src/PolyType.Examples/Counter/Counter.Builder.cs
@@ -1,4 +1,5 @@
 ﻿using PolyType.Abstractions;
+using PolyType.Examples.Utilities;
 using PolyType.Utilities;
 
 namespace PolyType.Examples.Counter;
@@ -66,7 +67,7 @@ public static partial class Counter
 
         public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state)
         {
-            Func<TEnumerable, IEnumerable<TElement>> enumerableGetter = enumerableShape.GetGetEnumerable();
+            Func<TEnumerable, IEnumerable<TElement>> enumerableGetter = enumerableShape.GetGetPotentiallyBlockingEnumerable();
             Func<TElement, long> elementTypeCounter = GetOrAddCounter(enumerableShape.ElementType);
             return new Func<TEnumerable, long>(enumerable =>
             {

--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonDictionaryConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonDictionaryConverter.cs
@@ -178,7 +178,7 @@ internal sealed class JsonEnumerableConstructorDictionaryConverter<TDictionary, 
     where TKey : notnull
 {
     private protected override TDictionary Construct(PooledList<KeyValuePair<TKey, TValue>> buffer)
-        => constructor(buffer.ExchangeToArraySegment());
+        => constructor(buffer.ToArray());
 }
 
 internal sealed class JsonSpanConstructorDictionaryConverter<TDictionary, TKey, TValue>(

--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonEnumerableConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonEnumerableConverter.cs
@@ -14,7 +14,7 @@ internal class JsonEnumerableConverter<TEnumerable, TElement>(JsonConverter<TEle
 {
     private static readonly bool s_isIList = typeof(IList<TElement>).IsAssignableFrom(typeof(TEnumerable));
     private protected readonly JsonConverter<TElement> _elementConverter = elementConverter;
-    private readonly Func<TEnumerable, IEnumerable<TElement>> _getEnumerable = typeShape.GetGetEnumerable();
+    private readonly Func<TEnumerable, IEnumerable<TElement>> _getEnumerable = typeShape.GetGetPotentiallyBlockingEnumerable();
 
     public override TEnumerable? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -140,7 +140,7 @@ internal sealed class JsonEnumerableConstructorEnumerableConverter<TEnumerable, 
     : JsonImmutableEnumerableConverter<TEnumerable, TElement>(elementConverter, typeShape)
 {
     private protected override TEnumerable Construct(PooledList<TElement> buffer)
-        => enumerableConstructor(buffer.ExchangeToArraySegment());
+        => enumerableConstructor(buffer.ToArray());
 }
 
 internal sealed class JsonSpanConstructorEnumerableConverter<TEnumerable, TElement>(

--- a/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
+++ b/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
@@ -3,6 +3,7 @@ using PolyType.Utilities;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using PolyType.Examples.Utilities;
 
 namespace PolyType.Examples.ObjectMapper;
 
@@ -241,7 +242,8 @@ public static partial class Mapper
             public override object? VisitEnumerable<TTargetEnumerable, TTargetElement>(IEnumerableTypeShape<TTargetEnumerable, TTargetElement> enumerableShape, object? state)
             {
                 var sourceEnumerable = (IEnumerableTypeShape<TSourceEnumerable, TSourceElement>)state!;
-                var sourceGetEnumerable = sourceEnumerable.GetGetEnumerable();
+                var sourceGetEnumerable = sourceEnumerable.GetGetPotentiallyBlockingEnumerable();
+
                 var elementMapper = baseVisitor.GetOrAddMapper(sourceEnumerable.ElementType, enumerableShape.ElementType);
 
                 switch (enumerableShape.ConstructionStrategy)

--- a/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.Builder.cs
+++ b/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.Builder.cs
@@ -85,7 +85,7 @@ public static partial class PrettyPrinter
 
         public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state)
         {
-            Func<TEnumerable, IEnumerable<TElement>> enumerableGetter = enumerableShape.GetGetEnumerable();
+            Func<TEnumerable, IEnumerable<TElement>> enumerableGetter = enumerableShape.GetGetPotentiallyBlockingEnumerable();
             PrettyPrinter<TElement> elementPrinter = GetOrAddPrettyPrinter(enumerableShape.ElementType);
             bool valuesArePrimitives = s_defaultPrinters.ContainsKey(typeof(TElement));
 

--- a/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
+++ b/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
@@ -203,7 +203,7 @@ public partial class RandomGenerator
                             buffer.Add(elementGenerator(random, elementSize));
                         }
 
-                        return enumerableCtor(buffer.ExchangeToArraySegment());
+                        return enumerableCtor(buffer.ToArray());
                     });
 
                 case CollectionConstructionStrategy.Span:

--- a/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.Builder.cs
+++ b/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.Builder.cs
@@ -96,7 +96,7 @@ public static partial class StructuralEqualityComparer
             return new EnumerableEqualityComparer<TEnumerable, TElement>
             {
                 ElementComparer = GetOrAddEqualityComparer(enumerableShape.ElementType),
-                GetEnumerable = enumerableShape.GetGetEnumerable()
+                GetEnumerable = enumerableShape.GetGetPotentiallyBlockingEnumerable(),
             };
         }
 

--- a/src/PolyType.Examples/Utilities/PooledList.cs
+++ b/src/PolyType.Examples/Utilities/PooledList.cs
@@ -22,7 +22,7 @@ public struct PooledList<T> : IDisposable
     }
 
     /// <summary>Gets the current element count of the list.</summary>
-    public readonly int Count { get; }
+    public readonly int Count => _count;
 
     /// <summary>Appends a value to the list.</summary>
     public void Add(T value)
@@ -65,13 +65,12 @@ public struct PooledList<T> : IDisposable
     /// <summary>Gets the current list contents as a span.</summary>
     public readonly ReadOnlySpan<T> AsSpan() => _values.AsSpan(0, _count);
 
-    /// <summary>Moves the current context as an array segment, removing the buffer from the list itself.</summary>
-    public ArraySegment<T> ExchangeToArraySegment()
+    /// <summary>Copies the contents of the list into a new array.</summary>
+    public readonly T[] ToArray()
     {
-        ArraySegment<T> segment = new(_values, 0, _count);
-        _values = [];
-        _count = 0;
-        return segment;
+        T[] array = new T[_count];
+        _values.AsSpan(0, _count).CopyTo(array);
+        return array;
     }
 
     /// <summary>Disposes of the list, returning any unused buffers to the pool.</summary>

--- a/src/PolyType.Examples/Validation/Validator.Builder.cs
+++ b/src/PolyType.Examples/Validation/Validator.Builder.cs
@@ -1,6 +1,7 @@
 ﻿using PolyType.Abstractions;
 using PolyType.Utilities;
 using System.Diagnostics;
+using PolyType.Examples.Utilities;
 
 namespace PolyType.Examples.Validation;
 
@@ -117,7 +118,7 @@ public static partial class Validator
                 return null; // Nothing to validate for this type.
             }
 
-            Func<TEnumerable, IEnumerable<TElement>> getEnumerable = enumerableShape.GetGetEnumerable();
+            Func<TEnumerable, IEnumerable<TElement>> getEnumerable = enumerableShape.GetGetPotentiallyBlockingEnumerable();
             return new Validator<TEnumerable>((TEnumerable? enumerable, List<string> path, ref List<string>? errors) =>
             {
                 if (enumerable is null)

--- a/src/PolyType.Examples/XmlSerializer/Converters/XmlDictionaryConverter.cs
+++ b/src/PolyType.Examples/XmlSerializer/Converters/XmlDictionaryConverter.cs
@@ -145,7 +145,7 @@ internal sealed class XmlEnumerableConstructorDictionaryConverter<TDictionary, T
     where TKey : notnull
 {
     private protected override TDictionary Construct(PooledList<KeyValuePair<TKey, TValue>> buffer)
-        => constructor(buffer.ExchangeToArraySegment());
+        => constructor(buffer.ToArray());
 }
 
 internal sealed class XmlSpanConstructorDictionaryConverter<TDictionary, TKey, TValue>(

--- a/src/PolyType.Examples/XmlSerializer/Converters/XmlEnumerableConverter.cs
+++ b/src/PolyType.Examples/XmlSerializer/Converters/XmlEnumerableConverter.cs
@@ -124,7 +124,7 @@ internal sealed class XmlEnumerableConstructorEnumerableConverter<TEnumerable, T
     : XmlImmutableEnumerableConverter<TEnumerable, TElement>(elementConverter, getEnumerable)
 {
     private protected override TEnumerable Construct(PooledList<TElement> buffer)
-        => enumerableConstructor(buffer.ExchangeToArraySegment());
+        => enumerableConstructor(buffer.ToArray());
 }
 
 internal sealed class XmlSpanConstructorEnumerableConverter<TEnumerable, TElement>(

--- a/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
+++ b/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
@@ -1,4 +1,5 @@
 ﻿using PolyType.Abstractions;
+using PolyType.Examples.Utilities;
 using PolyType.Examples.XmlSerializer.Converters;
 using PolyType.Utilities;
 
@@ -74,7 +75,7 @@ public static partial class XmlSerializer
         public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state)
         {
             XmlConverter<TElement> elementConverter = GetOrAddConverter(enumerableShape.ElementType);
-            Func<TEnumerable, IEnumerable<TElement>> getEnumerable = enumerableShape.GetGetEnumerable();
+            Func<TEnumerable, IEnumerable<TElement>> getEnumerable = enumerableShape.GetGetPotentiallyBlockingEnumerable();
 
             return enumerableShape.ConstructionStrategy switch
             {

--- a/src/PolyType.Roslyn/KnownSymbols.cs
+++ b/src/PolyType.Roslyn/KnownSymbols.cs
@@ -67,6 +67,12 @@ public class KnownSymbols(Compilation compilation)
     /// </summary>
     public INamedTypeSymbol IEnumerable => _IEnumerable ??= Compilation.GetSpecialType(SpecialType.System_Collections_IEnumerable);
     private INamedTypeSymbol? _IEnumerable;
+    
+    /// <summary>
+    /// The type symbol for IAsyncEnumerable{T}.
+    /// </summary>
+    public INamedTypeSymbol? IAsyncEnumerableOfT => GetOrResolveType("System.Collections.Generic.IAsyncEnumerable`1", ref _IAsyncEnumerableOfT);
+    private Option<INamedTypeSymbol?> _IAsyncEnumerableOfT;
 
     /// <summary>
     /// The type symbol for <see cref="Span{T}"/>.

--- a/src/PolyType.Roslyn/Model/EnumerableDataModel.cs
+++ b/src/PolyType.Roslyn/Model/EnumerableDataModel.cs
@@ -89,4 +89,8 @@ public enum EnumerableKind
     /// An array of rank > 1.
     /// </summary>
     MultiDimensionalArrayOfT,
+    /// <summary>
+    /// An IAsyncEnumerable{T} type.
+    /// </summary>
+    AsyncEnumerableOfT,
 }

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enumerable.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enumerable.cs
@@ -19,12 +19,12 @@ public partial class TypeDataModelGenerator
         }
 
         int rank = 1;
-        EnumerableKind kind = EnumerableKind.None;
+        EnumerableKind kind;
         CollectionModelConstructionStrategy constructionStrategy = CollectionModelConstructionStrategy.None;
-        ITypeSymbol? elementType = null;
+        ITypeSymbol? elementType;
         IMethodSymbol? addElementMethod = null;
-        //INamedTypeSymbol? implementationType = null;
         IMethodSymbol? factoryMethod = null;
+        INamedTypeSymbol? asyncEnumerableOfT = null;
 
         if (type is IArrayTypeSymbol array)
         {
@@ -65,9 +65,11 @@ public partial class TypeDataModelGenerator
             kind = EnumerableKind.ReadOnlyMemoryOfT;
             elementType = namedType.TypeArguments[0];
         }
-        else if (type.GetCompatibleGenericBaseType(KnownSymbols.IEnumerableOfT) is { } enumerableOfT)
+        else if ((
+            type.GetCompatibleGenericBaseType(KnownSymbols.IEnumerableOfT) ?? 
+            (asyncEnumerableOfT = type.GetCompatibleGenericBaseType(KnownSymbols.IAsyncEnumerableOfT))) is { } enumerableOfT)
         {
-            kind = EnumerableKind.IEnumerableOfT;
+            kind = asyncEnumerableOfT is not null ? EnumerableKind.AsyncEnumerableOfT : EnumerableKind.IEnumerableOfT;
             elementType = enumerableOfT.TypeArguments[0];
 
             if (KnownSymbols.Compilation.TryGetCollectionBuilderAttribute(namedType, elementType, out IMethodSymbol? builderMethod, CancellationToken))

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
@@ -19,6 +19,7 @@ internal sealed partial class SourceFormatter
                     SpanConstructorFunc = {{FormatSpanConstructorFunc(enumerableShapeModel)}},
                     GetEnumerableFunc = {{FormatGetEnumerableFunc(enumerableShapeModel)}},
                     AddElementFunc = {{FormatAddElementFunc(enumerableShapeModel)}},
+                    IsAsyncEnumerable = {{FormatBool(enumerableShapeModel.Kind is EnumerableKind.AsyncEnumerableOfT)}},
                     Rank = {{enumerableShapeModel.Rank}},
                     Provider = this,
                };
@@ -36,6 +37,7 @@ internal sealed partial class SourceFormatter
                 EnumerableKind.ReadOnlyMemoryOfT => $"static obj => global::System.Runtime.InteropServices.MemoryMarshal.ToEnumerable(obj{suppressSuffix})",
                 EnumerableKind.IEnumerable => $"static obj => global::System.Linq.Enumerable.Cast<object>(obj{suppressSuffix})",
                 EnumerableKind.MultiDimensionalArrayOfT => $"static obj => global::System.Linq.Enumerable.Cast<{enumerableType.ElementType.FullyQualifiedName}>(obj{suppressSuffix})",
+                EnumerableKind.AsyncEnumerableOfT => $"static obj => throw new global::System.InvalidOperationException(\"Sync enumeration of IAsyncEnumerable instances is not supported.\")",
                 _ => throw new ArgumentException(enumerableType.Kind.ToString()),
             };
         }

--- a/src/PolyType/Abstractions/IEnumerableTypeShape.cs
+++ b/src/PolyType/Abstractions/IEnumerableTypeShape.cs
@@ -27,6 +27,16 @@ public interface IEnumerableTypeShape : ITypeShape
     /// Gets the rank of the enumerable, if a multidimensional array.
     /// </summary>
     int Rank { get; }
+
+    /// <summary>
+    /// Indicates whether the underlying type is an IAsyncEnumerable or not.
+    /// </summary>
+    /// <remarks>
+    /// Calling <see cref="IEnumerableTypeShape{TEnumerable, TElement}.GetGetEnumerable"/> on async enumerable instances
+    /// will result in an exception being thrown to prevent accidental sync-over-async. Users should manually cast
+    /// instances to IAsyncEnumerable and enumerate elements asynchronously.
+    /// </remarks>
+    bool IsAsyncEnumerable { get; }
 }
 
 /// <summary>

--- a/src/PolyType/Abstractions/IEnumerableTypeShape.cs
+++ b/src/PolyType/Abstractions/IEnumerableTypeShape.cs
@@ -29,7 +29,7 @@ public interface IEnumerableTypeShape : ITypeShape
     int Rank { get; }
 
     /// <summary>
-    /// Indicates whether the underlying type is an IAsyncEnumerable or not.
+    /// Indicates whether the underlying type is an IAsyncEnumerable.
     /// </summary>
     /// <remarks>
     /// Calling <see cref="IEnumerableTypeShape{TEnumerable, TElement}.GetGetEnumerable"/> on async enumerable instances

--- a/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
@@ -26,6 +26,7 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
     public virtual CollectionConstructionStrategy ConstructionStrategy => _constructionStrategy ??= DetermineConstructionStrategy();
     public virtual int Rank => 1;
+    public virtual bool IsAsyncEnumerable => false;
     public abstract Func<TEnumerable, IEnumerable<TElement>> GetGetEnumerable();
 
     public sealed override TypeShapeKind Kind => TypeShapeKind.Enumerable;
@@ -327,4 +328,14 @@ internal sealed class MemoryTypeShape<TElement>(ReflectionTypeShapeProvider prov
     public override CollectionConstructionStrategy ConstructionStrategy => CollectionConstructionStrategy.Span;
     public override Func<Memory<TElement>, IEnumerable<TElement>> GetGetEnumerable() => static memory => MemoryMarshal.ToEnumerable((ReadOnlyMemory<TElement>)memory);
     public override SpanConstructor<TElement, Memory<TElement>> GetSpanConstructor() => static span => span.ToArray();
+}
+
+[RequiresUnreferencedCode(ReflectionTypeShapeProvider.RequiresUnreferencedCodeMessage)]
+[RequiresDynamicCode(ReflectionTypeShapeProvider.RequiresDynamicCodeMessage)]
+internal sealed class ReflectionAsyncEnumerableShape<TEnumerable, TElement>(ReflectionTypeShapeProvider provider)
+    : ReflectionEnumerableTypeShape<TEnumerable, TElement>(provider)
+{
+    public override bool IsAsyncEnumerable => true;
+    public override Func<TEnumerable, IEnumerable<TElement>> GetGetEnumerable() =>
+        static _ => throw new InvalidOperationException("Sync enumeration of IAsyncEnumerable instances is not supported.");
 }

--- a/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
@@ -20,6 +20,11 @@ public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : Source
     public required int Rank { get; init; }
 
     /// <summary>
+    /// Indicates whether the underlying type is an IAsyncEnumerable or not.
+    /// </summary>
+    public required bool IsAsyncEnumerable { get; init; }
+
+    /// <summary>
     /// Gets the function that retrieves an enumerable from an instance of the collection.
     /// </summary>
     public required Func<TEnumerable, IEnumerable<TElement>> GetEnumerableFunc { get; init; }


### PR DESCRIPTION
Extends the `IEnumerableTypeShape` type to include support for types implementing `IAsyncEnumerable<T>`. Note that this is a breaking change cc @AArnott 