### PR TITLE
Use LineSpan.Path instead of SourceTree?.FilePath when trimming Location

### DIFF
--- a/src/PolyType.Roslyn/Helpers/RoslynHelpers.cs
+++ b/src/PolyType.Roslyn/Helpers/RoslynHelpers.cs
@@ -342,7 +342,9 @@ internal static class RoslynHelpers
     /// </summary>
     public static Location GetLocationTrimmed(this Location location)
     {
-        return Location.Create(location.SourceTree?.FilePath ?? string.Empty, location.SourceSpan, location.GetLineSpan().Span);
+        var lineSpan = location.GetLineSpan();
+
+        return Location.Create(lineSpan.Path ?? string.Empty, location.SourceSpan, lineSpan.Span);
     }
 
     public static ICollection<ITypeSymbol> GetSortedTypeHierarchy(this ITypeSymbol type)


### PR DESCRIPTION
If the Location is created without referencing the SourceTree, the previous implementation of GetLocationTrimmed lost the file path resulting in diagnostic messages without clickable file paths.

This might not be relevant for this project (yet), but I'm copying the code for my own SourceGenerator and ran into this issue when adding diagnostics for AdditionalFiles where created the location using `Location.Create` instead of getting it from syntax.

PS: I'm pretty new to Roslyn, so I don't know whether the lineSpan always have the path, [but the implementation of `Location.GetDebuggerDisplay`](https://github.com/dotnet/roslyn/blob/2be1e63fe1dc06aebce86413911d4e603ffc84af/src/Compilers/Core/Portable/Diagnostic/Location.cs#L144) seems to indicate that it usually does.