### PR TITLE
Add population support for collection types that explicitly implement collection interfaces.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -188,3 +188,6 @@ dotnet_diagnostic.CA1510.severity = none # incompatible with multitargeting proj
 
 # SA1134: Attributes should not share line
 dotnet_diagnostic.SA1134.severity = none
+
+# CA1010: Generic interface should also be implemented
+dotnet_diagnostic.CA1010.severity = none

--- a/src/PolyType.Roslyn/KnownSymbols.cs
+++ b/src/PolyType.Roslyn/KnownSymbols.cs
@@ -135,6 +135,12 @@ public class KnownSymbols(Compilation compilation)
     private Option<INamedTypeSymbol?> _DictionaryOfTKeyTValue;
 
     /// <summary>
+    /// The type symbol for <see cref="ICollection{T}"/>.
+    /// </summary>
+    public INamedTypeSymbol? ICollectionOfT => GetOrResolveType("System.Collections.Generic.ICollection`1", ref _ICollectionOfT);
+    private Option<INamedTypeSymbol?> _ICollectionOfT;
+
+    /// <summary>
     /// The type symbol for <see cref="System.Collections.IList"/>.
     /// </summary>
     public INamedTypeSymbol? IList => GetOrResolveType("System.Collections.IList", ref _IList);

--- a/src/PolyType.Roslyn/Model/DictionaryDataModel.cs
+++ b/src/PolyType.Roslyn/Model/DictionaryDataModel.cs
@@ -45,6 +45,11 @@ public sealed class DictionaryDataModel : TypeDataModel
     /// and declares either an <see cref="IEqualityComparer{T}"/> or <see cref="IComparer{T}"/> parameter.
     /// </summary>
     public required IMethodSymbol? FactoryMethodWithComparer { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the dictionary type only exposes an indexer via an explicit interface implementation of either <see cref="IDictionary{TKey, TValue}"/> or <see cref="IDictionary"/>.
+    /// </summary>
+    public required bool IndexerIsExplicitInterfaceImplementation { get; init; }
 }
 
 /// <summary>

--- a/src/PolyType.Roslyn/Model/EnumerableDataModel.cs
+++ b/src/PolyType.Roslyn/Model/EnumerableDataModel.cs
@@ -52,6 +52,11 @@ public sealed class EnumerableDataModel : TypeDataModel
     /// If the enumerable is an array, the rank of the array.
     /// </summary>
     public required int Rank { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the enumerable type only exposes an add method via an explicit interface implementation of either <see cref="ICollection{T}"/> or <see cref="ICollection"/>.
+    /// </summary>
+    public required bool AddMethodIsExplicitInterfaceImplementation { get; init; }
 }
 
 /// <summary>

--- a/src/PolyType.SourceGenerator/Model/DictionaryShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/DictionaryShapeModel.cs
@@ -16,4 +16,5 @@ public sealed record DictionaryShapeModel : TypeShapeModel
     public required bool IsTupleEnumerableFactory { get; init; }
     public required bool CtorRequiresDictionaryConversion { get; init; }
     public required bool KeyValueTypesContainNullableAnnotations { get; init; }
+    public required bool IndexerIsExplicitInterfaceImplementation { get; init; }
 }

--- a/src/PolyType.SourceGenerator/Model/EnumerableShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/EnumerableShapeModel.cs
@@ -16,4 +16,5 @@ public sealed record EnumerableShapeModel : TypeShapeModel
     public required string? StaticFactoryWithComparerMethod { get; init; }
     public required bool CtorRequiresListConversion { get; init; }
     public required bool ElementTypeContainsNullableAnnotations { get; init; }
+    public required bool AddMethodIsExplicitInterfaceImplementation { get; init; }
 }

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -94,6 +94,7 @@ public sealed partial class Parser
                 Kind = enumerableModel.EnumerableKind,
                 Rank = enumerableModel.Rank,
                 ElementTypeContainsNullableAnnotations = enumerableModel.ElementType.ContainsNullabilityAnnotations(),
+                AddMethodIsExplicitInterfaceImplementation = enumerableModel.AddMethodIsExplicitInterfaceImplementation,
                 AssociatedTypes = associatedTypes,
             },
 
@@ -136,6 +137,7 @@ public sealed partial class Parser
                 KeyValueTypesContainNullableAnnotations =
                     dictionaryModel.KeyType.ContainsNullabilityAnnotations() ||
                     dictionaryModel.ValueType.ContainsNullabilityAnnotations(),
+                IndexerIsExplicitInterfaceImplementation = dictionaryModel.IndexerIsExplicitInterfaceImplementation,
                 AssociatedTypes = associatedTypes,
             },
 

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
@@ -67,10 +67,14 @@ internal sealed partial class SourceFormatter
             string suppressSuffix = dictionaryType.KeyValueTypesContainNullableAnnotations ? "!" : "";
             return dictionaryType switch
             {
-                { ConstructionStrategy: CollectionConstructionStrategy.Mutable, ImplementationTypeFQN: null }
+                { ConstructionStrategy: CollectionConstructionStrategy.Mutable, ImplementationTypeFQN: null, IndexerIsExplicitInterfaceImplementation: false }
                     => $"static (ref {dictionaryType.Type.FullyQualifiedName} dict, global::System.Collections.Generic.KeyValuePair<{dictionaryType.KeyType.FullyQualifiedName}, {dictionaryType.ValueType.FullyQualifiedName}> kvp) => dict[kvp.Key{suppressSuffix}] = kvp.Value{suppressSuffix}",
                 { ConstructionStrategy: CollectionConstructionStrategy.Mutable, ImplementationTypeFQN: { } implementationTypeFQN }
                     => $"static (ref {dictionaryType.Type.FullyQualifiedName} dict, global::System.Collections.Generic.KeyValuePair<{dictionaryType.KeyType.FullyQualifiedName}, {dictionaryType.ValueType.FullyQualifiedName}> kvp) => (({implementationTypeFQN})dict)[kvp.Key{suppressSuffix}] = kvp.Value{suppressSuffix}",
+                { ConstructionStrategy: CollectionConstructionStrategy.Mutable, IndexerIsExplicitInterfaceImplementation: true, Kind: DictionaryKind.IDictionary }
+                    => $"static (ref {dictionaryType.Type.FullyQualifiedName} dict, global::System.Collections.Generic.KeyValuePair<{dictionaryType.KeyType.FullyQualifiedName}, {dictionaryType.ValueType.FullyQualifiedName}> kvp) => ((global::System.Collections.IDictionary)dict{suppressSuffix})[kvp.Key{suppressSuffix}] = kvp.Value{suppressSuffix}",
+                { ConstructionStrategy: CollectionConstructionStrategy.Mutable, IndexerIsExplicitInterfaceImplementation: true, Kind: DictionaryKind.IDictionaryOfKV }
+                    => $"static (ref {dictionaryType.Type.FullyQualifiedName} dict, global::System.Collections.Generic.KeyValuePair<{dictionaryType.KeyType.FullyQualifiedName}, {dictionaryType.ValueType.FullyQualifiedName}> kvp) => ((global::System.Collections.Generic.IDictionary<{dictionaryType.KeyType.FullyQualifiedName}, {dictionaryType.ValueType.FullyQualifiedName}>)dict{suppressSuffix})[kvp.Key{suppressSuffix}] = kvp.Value{suppressSuffix}",
                 _ => "null",
             };
         }

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
@@ -8,6 +8,13 @@ internal sealed partial class SourceFormatter
 {
     private void FormatDictionaryTypeShapeFactory(SourceWriter writer, string methodName, DictionaryShapeModel dictionaryShapeModel)
     {
+        bool requiresCS8631Suppression = dictionaryShapeModel.KeyValueTypesContainNullableAnnotations && dictionaryShapeModel.Kind is DictionaryKind.IDictionaryOfKV;
+        if (requiresCS8631Suppression)
+        {
+            // Need to emit a call to CollectionHelpers.AsReadOnlyDictionary<TDictionary, TKey, TValue>(...) which creates a nullability warning on the type parameters
+            writer.WriteLine("#pragma warning disable CS8631 // Nullability of type argument doesn't match constraint type.", disableIndentation: true);
+        }
+
         writer.WriteLine($$"""
             private global::PolyType.Abstractions.ITypeShape<{{dictionaryShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
             {
@@ -27,6 +34,11 @@ internal sealed partial class SourceFormatter
                 };
             }
             """, trimNullAssignmentLines: true);
+
+        if (requiresCS8631Suppression)
+        {             
+            writer.WriteLine("#pragma warning restore CS8631 // Nullability of type argument doesn't match constraint type.", disableIndentation: true);
+        }
 
         static string FormatGetDictionaryFunc(DictionaryShapeModel dictionaryType)
         {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
@@ -61,10 +61,14 @@ internal sealed partial class SourceFormatter
             string suppressSuffix = enumerableType.ElementTypeContainsNullableAnnotations ? "!" : "";
             return enumerableType switch
             {
-                { AddElementMethod: { } addMethod, ImplementationTypeFQN: null } =>
+                { AddElementMethod: { } addMethod, ImplementationTypeFQN: null, AddMethodIsExplicitInterfaceImplementation: false } =>
                     $"static (ref {enumerableType.Type.FullyQualifiedName} obj, {enumerableType.ElementType.FullyQualifiedName} value) => obj.{addMethod}(value{suppressSuffix})",
                 { AddElementMethod: { } addMethod, ImplementationTypeFQN: { } implTypeFQN } =>
                     $"static (ref {enumerableType.Type.FullyQualifiedName} obj, {enumerableType.ElementType.FullyQualifiedName} value) => (({implTypeFQN})obj).{addMethod}(value{suppressSuffix})",
+                { AddElementMethod: { } addMethod, AddMethodIsExplicitInterfaceImplementation: true, Kind: EnumerableKind.IEnumerableOfT } =>
+                    $"static (ref {enumerableType.Type.FullyQualifiedName} obj, {enumerableType.ElementType.FullyQualifiedName} value) => ((global::System.Collections.Generic.ICollection<{enumerableType.ElementType.FullyQualifiedName}>)obj{suppressSuffix}).{addMethod}(value{suppressSuffix})",
+                { AddElementMethod: { } addMethod, AddMethodIsExplicitInterfaceImplementation: true, Kind: EnumerableKind.IEnumerable } =>
+                    $"static (ref {enumerableType.Type.FullyQualifiedName} obj, {enumerableType.ElementType.FullyQualifiedName} value) => ((global::System.Collections.IList)obj{suppressSuffix}).{addMethod}(value{suppressSuffix})",
                 _ => "null",
             };
         }

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
+using System.Dynamic;
 using System.Globalization;
 using System.Numerics;
 using System.Reflection;
@@ -602,6 +603,11 @@ public static class TestTypes
         yield return TestCase.Create(FSharpSingleCaseStructUnion.NewCase(42), isUnion: true, provider: p);
         yield return TestCase.Create(GenericFSharpStructUnion<string>.NewA("str"), additionalValues: [GenericFSharpStructUnion<string>.B, GenericFSharpStructUnion<string>.NewC(42)], isUnion: true, provider: p);
         yield return TestCase.Create(FSharpExpr.True, additionalValues: [FSharpExpr.False, FSharpExpr.Y], isUnion: true, provider: p);
+
+        ExpandoObject expando = new();
+        IDictionary<string, object?> expandoDict = expando;
+        expandoDict["hi"] = 3;
+        yield return TestCase.Create(expando, p);
     }
 }
 
@@ -2060,7 +2066,7 @@ public partial class TypeWithRecordSurrogate(int value1, string value2)
 }
 
 [TypeShape(Marshaller = typeof(EnumMarshaller))]
-public enum EnumWithRecordSurrogate { A, B, C  }
+public enum EnumWithRecordSurrogate { A, B, C }
 public record EnumSurrogate(int Value);
 public sealed class EnumMarshaller : IMarshaller<EnumWithRecordSurrogate, EnumSurrogate>
 {
@@ -2553,4 +2559,5 @@ public partial class AsyncEnumerableClass(IEnumerable<int> values) : IAsyncEnume
 [GenerateShape<GenericFSharpStructUnion<string>>]
 [GenerateShape<FSharpResult<string, int>>]
 [GenerateShape<FSharpExpr>]
+[GenerateShape<ExpandoObject>]
 public partial class Witness;

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -165,12 +165,19 @@ public static class TestTypes
 #endif
         yield return TestCase.Create((IDictionary<int, int>)new Dictionary<int, int> { [42] = 42 }, p);
         yield return TestCase.Create((IReadOnlyDictionary<int, int>)new Dictionary<int, int> { [42] = 42 }, p);
+        yield return TestCase.Create(CreateExpandoObject([new("x", 1), new("y", "str")]), p);
 
         yield return TestCase.Create(new DerivedList { 1, 2, 1, 3 });
         yield return TestCase.Create(new DerivedDictionary { ["key"] = "value" });
 
         yield return TestCase.Create(new StructList<int> { 1, 2, 1, 3 }, p);
         yield return TestCase.Create(new StructDictionary<string, string> { ["key"] = "value" }, p);
+        yield return TestCase.Create(ExplicitlyImplementedList<int>.Create([1, 2, 1, 3]), p);
+        yield return TestCase.Create(ExplicitlyImplementedDictionary<string, string>.Create([new("key", "value")]), p);
+        yield return TestCase.Create(ExplicitlyImplementedIList.Create([null, false, 42, "value"]));
+        yield return TestCase.Create(ExplicitlyImplementedIDictionary.Create([new("key", "value")]));
+        yield return TestCase.Create(ExplicitlyImplementedIList.Create([null, true, 42, "string"]));
+        yield return TestCase.Create(ExplicitlyImplementedIDictionary.Create([new("key", 42)]));
         yield return TestCase.Create<CollectionWithBuilderAttribute>([1, 2, 1, 3]);
         yield return TestCase.Create((GenericCollectionWithBuilderAttribute<int>)[1, 2, 1, 3], p);
         yield return TestCase.Create(new CollectionWithEnumerableCtor([1, 2, 1, 3]));
@@ -603,11 +610,17 @@ public static class TestTypes
         yield return TestCase.Create(FSharpSingleCaseStructUnion.NewCase(42), isUnion: true, provider: p);
         yield return TestCase.Create(GenericFSharpStructUnion<string>.NewA("str"), additionalValues: [GenericFSharpStructUnion<string>.B, GenericFSharpStructUnion<string>.NewC(42)], isUnion: true, provider: p);
         yield return TestCase.Create(FSharpExpr.True, additionalValues: [FSharpExpr.False, FSharpExpr.Y], isUnion: true, provider: p);
+    }
 
-        ExpandoObject expando = new();
-        IDictionary<string, object?> expandoDict = expando;
-        expandoDict["hi"] = 3;
-        yield return TestCase.Create(expando, p);
+    private static ExpandoObject CreateExpandoObject(IEnumerable<KeyValuePair<string, object?>> values)
+    {
+        ExpandoObject obj = new();
+        IDictionary<string, object?> dictView = obj;
+        foreach (var kvp in values)
+        {
+            dictView[kvp.Key] = kvp.Value;
+        }
+        return obj;
     }
 }
 
@@ -657,6 +670,133 @@ public readonly struct StructDictionary<TKey, TValue> : IDictionary<TKey, TValue
     public bool TryGetValue(TKey key, out TValue value) => _dictionary.TryGetValue(key, out value!);
     public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _dictionary.GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => _dictionary.GetEnumerator();
+}
+
+public class ExplicitlyImplementedList<T> : IList<T>
+{
+    public static ExplicitlyImplementedList<T> Create(IEnumerable<T> values)
+    {
+        ExplicitlyImplementedList<T> list = new();
+        list._values.AddRange(values);
+        return list;
+    }
+
+    private readonly List<T> _values;
+    public ExplicitlyImplementedList() => _values = new();
+    T IList<T>.this[int index] { get => _values[index]; set => _values[index] = value; }
+    int ICollection<T>.Count => _values.Count;
+    bool ICollection<T>.IsReadOnly => false;
+    void ICollection<T>.Add(T item) => _values.Add(item);
+    void ICollection<T>.Clear() => _values.Clear();
+    bool ICollection<T>.Contains(T item) => _values.Contains(item);
+    void ICollection<T>.CopyTo(T[] array, int arrayIndex) => _values.CopyTo(array, arrayIndex);
+    int IList<T>.IndexOf(T item) => _values.IndexOf(item);
+    void IList<T>.Insert(int index, T item) => _values.Insert(index, item);
+    bool ICollection<T>.Remove(T item) => _values.Remove(item);
+    void IList<T>.RemoveAt(int index) => _values.RemoveAt(index);
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _values.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => _values.GetEnumerator();
+}
+
+public sealed class ExplicitlyImplementedDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    where TKey : notnull
+{
+    public static ExplicitlyImplementedDictionary<TKey, TValue> Create(IEnumerable<KeyValuePair<TKey, TValue>> values)
+    {
+        ExplicitlyImplementedDictionary<TKey, TValue> dictionary = new();
+        foreach (var kvp in values)
+        {
+            dictionary._dictionary.Add(kvp.Key, kvp.Value);
+        }
+        return dictionary;
+    }
+
+    private readonly Dictionary<TKey, TValue> _dictionary;
+    public ExplicitlyImplementedDictionary() => _dictionary = new();
+    TValue IDictionary<TKey, TValue>.this[TKey key] { get => _dictionary[key]; set => _dictionary[key] = value; }
+    ICollection<TKey> IDictionary<TKey, TValue>.Keys => _dictionary.Keys;
+    ICollection<TValue> IDictionary<TKey, TValue>.Values => _dictionary.Values;
+    int ICollection<KeyValuePair<TKey, TValue>>.Count => _dictionary.Count;
+    bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
+    void IDictionary<TKey, TValue>.Add(TKey key, TValue value) => _dictionary.Add(key, value);
+    void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item) => _dictionary.Add(item.Key, item.Value);
+    void ICollection<KeyValuePair<TKey, TValue>>.Clear() => _dictionary.Clear();
+    bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item) => _dictionary.Contains(item);
+    bool IDictionary<TKey, TValue>.ContainsKey(TKey key) => _dictionary.ContainsKey(key);
+    void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) => ((IDictionary<TKey, TValue>)_dictionary).CopyTo(array, arrayIndex);
+    bool IDictionary<TKey, TValue>.Remove(TKey key) => _dictionary.Remove(key);
+    bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item) => ((IDictionary<TKey, TValue>)_dictionary).Remove(item);
+    bool IDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value) => _dictionary.TryGetValue(key, out value!);
+    IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => _dictionary.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => _dictionary.GetEnumerator();
+}
+
+[GenerateShape]
+public sealed partial class ExplicitlyImplementedIList : IList
+{
+    public static ExplicitlyImplementedIList Create(IEnumerable<object?> values)
+    {
+        ExplicitlyImplementedIList list = new();
+        foreach (var value in values)
+        {
+            list._values.Add(value);
+        }
+        return list;
+    }
+    private readonly List<object?> _values;
+    public ExplicitlyImplementedIList() => _values = new();
+    object? IList.this[int index] { get => _values[index]; set => _values[index] = value; }
+    int ICollection.Count => _values.Count;
+    bool IList.IsFixedSize => false;
+    bool IList.IsReadOnly => false;
+    bool ICollection.IsSynchronized => false;
+    object ICollection.SyncRoot => _values;
+    int IList.Add(object? value)
+    {
+        _values.Add(value);
+        return _values.Count - 1;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => _values.GetEnumerator();
+    void IList.Clear() => _values.Clear();
+    bool IList.Contains(object? value) => throw new NotImplementedException();
+    void ICollection.CopyTo(Array array, int index) => throw new NotImplementedException();
+    int IList.IndexOf(object? value) => throw new NotImplementedException();
+    void IList.Insert(int index, object? value) => throw new NotImplementedException();
+    void IList.Remove(object? value) => throw new NotImplementedException();
+    void IList.RemoveAt(int index) => throw new NotImplementedException();
+}
+
+[GenerateShape]
+public sealed partial class ExplicitlyImplementedIDictionary : IDictionary
+{
+    public static ExplicitlyImplementedIDictionary Create(IEnumerable<KeyValuePair<object, object?>> values)
+    {
+        ExplicitlyImplementedIDictionary dictionary = new();
+        foreach (var kvp in values)
+        {
+            dictionary._dictionary.Add(kvp.Key, kvp.Value);
+        }
+        return dictionary;
+    }
+
+    private readonly Dictionary<object, object?> _dictionary;
+    public ExplicitlyImplementedIDictionary() => _dictionary = new();
+    object? IDictionary.this[object key] { get => _dictionary[key]; set => _dictionary[key] = value; }
+    void IDictionary.Add(object key, object? value) => _dictionary.Add(key, value);
+    IEnumerator IEnumerable.GetEnumerator() => _dictionary.GetEnumerator();
+    IDictionaryEnumerator IDictionary.GetEnumerator() => ((IDictionary)_dictionary).GetEnumerator();
+    void IDictionary.Clear() => _dictionary.Clear();
+    int ICollection.Count => _dictionary.Count;
+    bool IDictionary.IsFixedSize => throw new NotImplementedException();
+    bool IDictionary.IsReadOnly => throw new NotImplementedException();
+    bool ICollection.IsSynchronized => throw new NotImplementedException();
+    object ICollection.SyncRoot => throw new NotImplementedException();
+    ICollection IDictionary.Keys => throw new NotImplementedException();
+    ICollection IDictionary.Values => throw new NotImplementedException();
+    bool IDictionary.Contains(object? key) => throw new NotImplementedException();
+    void ICollection.CopyTo(Array array, int index) => throw new NotImplementedException();
+    void IDictionary.Remove(object? key) => throw new NotImplementedException();
 }
 
 [GenerateShape]
@@ -2430,6 +2570,8 @@ public partial class AsyncEnumerableClass(IEnumerable<int> values) : IAsyncEnume
 [GenerateShape<ArrayList>]
 [GenerateShape<StructList<int>>]
 [GenerateShape<StructDictionary<string, string>>]
+[GenerateShape<ExplicitlyImplementedList<int>>]
+[GenerateShape<ExplicitlyImplementedDictionary<string, string>>]
 [GenerateShape<GenericRecord<int>>]
 [GenerateShape<GenericRecord<string>>]
 [GenerateShape<GenericRecord<GenericRecord<bool>>>]

--- a/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
@@ -320,18 +320,40 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
             if (typeof(TEnumerable).GetConstructor([]) is ConstructorInfo defaultCtor)
             {
+                MethodInfo? addMethod = null;
                 foreach (MethodInfo methodInfo in typeof(TEnumerable).GetMethods(BindingFlags.Public | BindingFlags.Instance))
                 {
                     if (methodInfo.Name is "Add" or "Enqueue" or "Push" &&
                         methodInfo.GetParameters() is [ParameterInfo parameter] &&
                         parameter.ParameterType == typeof(TElement))
                     {
-                        _defaultCtor = defaultCtor;
-                        _addMethod = methodInfo;
-                        (_constructionComparer, _defaultCtorWithComparer) = FindComparerConstructorOverload(defaultCtor);
-                        _constructionStrategy = CollectionConstructionStrategy.Mutable;
-                        return;
+                        addMethod = methodInfo;
+                        break;
                     }
+                }
+
+                if (!typeof(TEnumerable).IsValueType)
+                {
+                    // If no Add method was found, check for potential explicit interface implementations.
+                    // Only do so if the type is not a value type, since this would force boxing otherwise.
+                    if (addMethod is null && typeof(ICollection<TElement>).IsAssignableFrom(typeof(TEnumerable)))
+                    {
+                        addMethod = typeof(ICollection<TElement>).GetMethod(nameof(ICollection<TElement>.Add));
+                    }
+
+                    if (addMethod is null && typeof(IList).IsAssignableFrom(typeof(TEnumerable)) && typeof(TElement) == typeof(object))
+                    {
+                        addMethod = typeof(IList).GetMethod(nameof(IList.Add));
+                    }
+                }
+
+                if (addMethod is not null)
+                {
+                    _defaultCtor = defaultCtor;
+                    _addMethod = addMethod;
+                    (_constructionComparer, _defaultCtorWithComparer) = FindComparerConstructorOverload(defaultCtor);
+                    _constructionStrategy = CollectionConstructionStrategy.Mutable;
+                    return;
                 }
             }
 

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationHelpers.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationHelpers.cs
@@ -77,6 +77,8 @@ public static class CompilationHelpers
             MetadataReference.CreateFromFile(GetAssemblyFromSharedFrameworkDirectory(IsMonoRuntime ? "Facades/netstandard.dll" : "netstandard.dll")),
             MetadataReference.CreateFromFile(typeof(System.Linq.Enumerable).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(System.Collections.Immutable.ImmutableArray).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Dynamic.ExpandoObject).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.ComponentModel.INotifyPropertyChanged).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(Microsoft.FSharp.Core.Unit).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(System.Drawing.Point).Assembly.Location),
 #if NET

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
@@ -491,6 +491,20 @@ public static class CompilationTests
     }
 
     [Fact]
+    public static void ExpandoObject()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [GenerateShape<System.Dynamic.ExpandoObject>]
+            partial class Witness;
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public static void IsRequiredProperty()
     {
         Compilation compilation = CompilationHelpers.CreateCompilation("""


### PR DESCRIPTION
The source generator compilation tests fail with `ExpandoObject`, but only in DEBUG builds where nullable annotations are checked. 

> 1>D:\source\PolyType\src\PolyType.TestCases\obj\Debug\net8.0\PolyType.SourceGenerator\PolyType.SourceGenerator.PolyTypeGenerator\PolyType.SourceGenerator.ShapeProvider.ExpandoObject.g.cs(21,51,21,175): error CS8631: The type 'System.Dynamic.ExpandoObject' cannot be used as type parameter 'TDictionary' in the generic type or method 'CollectionHelpers.AsReadOnlyDictionary<TDictionary, TKey, TValue>(TDictionary)'. Nullability of type argument 'System.Dynamic.ExpandoObject' doesn't match constraint type 'System.Collections.Generic.IDictionary<string, object>'.


Adding `ExpandoObject` to `TestTypes` revealed support limitations in your samples too, whose tests now fail.