### PR TITLE
Fix NotImplementedException thrown for `IDictionary<K, V>` with a comparer

### DIFF
--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Dictionary.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Dictionary.cs
@@ -122,6 +122,8 @@ public partial class TypeDataModelGenerator
                 INamedTypeSymbol dictOfTKeyTValue = KnownSymbols.DictionaryOfTKeyTValue!.Construct(keyType, valueType);
                 constructionStrategy = CollectionModelConstructionStrategy.Mutable;
                 factoryMethod = dictOfTKeyTValue.Constructors.FirstOrDefault(ctor => ctor is { DeclaredAccessibility: Accessibility.Public, Parameters: [] });
+                factoryMethodWithComparer = dictOfTKeyTValue.Constructors.FirstOrDefault(ctor =>
+                    ctor is { DeclaredAccessibility: Accessibility.Public, Parameters: [{ } only] } && ClassifyConstructorParameter(only, keyType, valueType) is CollectionConstructorParameterType.Comparer or CollectionConstructorParameterType.EqualityComparer);
             }
             else if (SymbolEqualityComparer.Default.Equals(namedType, KnownSymbols.IDictionary))
             {

--- a/src/PolyType/ReflectionProvider/MemberAccessors/IReflectionMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/IReflectionMemberAccessor.cs
@@ -21,10 +21,20 @@ internal interface IReflectionMemberAccessor
     Func<T, TResult> CreateFuncDelegate<T, TResult>(ConstructorInfo ctorInfo);
     Func<T1, T2, TResult> CreateFuncDelegate<T1, T2, TResult>(ConstructorInfo ctorInfo);
     SpanConstructor<T, TResult> CreateSpanConstructorDelegate<T, TResult>(ConstructorInfo ctorInfo);
-    SpanConstructor<TElement, TResult> CreateSpanConstructorWithLeadingECDelegate<TElement, TKey, TResult>(ConstructorInfo ctorInfo, IEqualityComparer<TKey> comparer);
-    SpanConstructor<TElement, TResult> CreateSpanConstructorWithTrailingECDelegate<TElement, TKey, TResult>(ConstructorInfo ctorInfo, IEqualityComparer<TKey> comparer);
-    SpanConstructor<TElement, TResult> CreateSpanConstructorWithLeadingCDelegate<TElement, TKey, TResult>(ConstructorInfo ctorInfo, IComparer<TKey> comparer);
-    SpanConstructor<TElement, TResult> CreateSpanConstructorWithTrailingCDelegate<TElement, TKey, TResult>(ConstructorInfo ctorInfo, IComparer<TKey> comparer);
+
+    /// <summary>
+    /// Creates a delegate that takes a comparer and returns a keyed collection constructor delegate.
+    /// </summary>
+    /// <typeparam name="TElement">The type of element stored in the collection.</typeparam>
+    /// <typeparam name="TCompare">The type of the key in the collection.</typeparam>
+    /// <typeparam name="TResult">The type of collection.</typeparam>
+    /// <param name="ctorInfo">The collection constructor that takes two parameters.</param>
+    /// <param name="signatureStyle">The signature of the constructor, indicating which type of comparer is taken and the parameter order.</param>
+    /// <returns>
+    /// The delegate that constructs delegates. The argument to this delegate should be an instance of <see cref="IEqualityComparer{T}"/> or <see cref="IComparer{T}"/>,
+    /// in accordance with <paramref name="signatureStyle"/>.
+    /// </returns>
+    Func<object, SpanConstructor<TElement, TResult>> CreateSpanConstructorDelegate<TElement, TCompare, TResult>(ConstructorInfo ctorInfo, ConstructionWithComparer signatureStyle);
 
     Getter<TUnion, int> CreateGetUnionCaseIndex<TUnion>(DerivedTypeInfo[] derivedTypeInfos);
 }

--- a/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionEmitMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionEmitMemberAccessor.cs
@@ -738,33 +738,25 @@ internal sealed class ReflectionEmitMemberAccessor : IReflectionMemberAccessor
     public SpanConstructor<T, TResult> CreateSpanConstructorDelegate<T, TResult>(ConstructorInfo ctorInfo)
         => CreateDelegate<SpanConstructor<T, TResult>>(EmitConstructor(ctorInfo));
 
-    private delegate TDeclaringType SpanECConstructor<TElement, TKey, TDeclaringType>(ReadOnlySpan<TElement> span, IEqualityComparer<TKey> comparer);
-    private delegate TDeclaringType ECSpanConstructor<TElement, TKey, TDeclaringType>(IEqualityComparer<TKey> comparer, ReadOnlySpan<TElement> span);
-    private delegate TDeclaringType SpanCConstructor<TElement, TKey, TDeclaringType>(ReadOnlySpan<TElement> span, IComparer<TKey> comparer);
-    private delegate TDeclaringType CSpanConstructor<TElement, TKey, TDeclaringType>(IComparer<TKey> comparer, ReadOnlySpan<TElement> span);
-
-    public SpanConstructor<TElement, TResult> CreateSpanConstructorWithLeadingECDelegate<TElement, TCompare, TResult>(ConstructorInfo ctorInfo, IEqualityComparer<TCompare> comparer)
+    public Func<object, SpanConstructor<TElement, TResult>> CreateSpanConstructorDelegate<TElement, TCompare, TResult>(ConstructorInfo ctorInfo, ConstructionWithComparer signatureStyle)
     {
-        var ctor = CreateDelegate<ECSpanConstructor<TElement, TCompare, TResult>>(EmitConstructor(ctorInfo));
-        return new(span => ctor(comparer, span));
-    }
-
-    public SpanConstructor<TElement, TResult> CreateSpanConstructorWithTrailingECDelegate<TElement, TCompare, TResult>(ConstructorInfo ctorInfo, IEqualityComparer<TCompare> comparer)
-    {
-        var ctor = CreateDelegate<SpanECConstructor<TElement, TCompare, TResult>>(EmitConstructor(ctorInfo));
-        return new(span => ctor(span, comparer));
-    }
-
-    public SpanConstructor<TElement, TResult> CreateSpanConstructorWithLeadingCDelegate<TElement, TCompare, TResult>(ConstructorInfo ctorInfo, IComparer<TCompare> comparer)
-    {
-        var ctor = CreateDelegate<CSpanConstructor<TElement, TCompare, TResult>>(EmitConstructor(ctorInfo));
-        return new(span => ctor(comparer, span));
-    }
-
-    public SpanConstructor<TElement, TResult> CreateSpanConstructorWithTrailingCDelegate<TElement, TCompare, TResult>(ConstructorInfo ctorInfo, IComparer<TCompare> comparer)
-    {
-        var ctor = CreateDelegate<SpanCConstructor<TElement, TCompare, TResult>>(EmitConstructor(ctorInfo));
-        return new(span => ctor(span, comparer));
+        switch (signatureStyle)
+        {
+            case ConstructionWithComparer.ValuesEqualityComparer:
+                var spanEC = CreateDelegate<SpanECConstructor<TElement, TCompare, TResult>>(EmitConstructor(ctorInfo));
+                return comparer => values => spanEC(values, (IEqualityComparer<TCompare>)comparer);
+            case ConstructionWithComparer.EqualityComparerValues:
+                var ecSpan = CreateDelegate<ECSpanConstructor<TElement, TCompare, TResult>>(EmitConstructor(ctorInfo));
+                return comparer => values => ecSpan((IEqualityComparer<TCompare>)comparer, values);
+            case ConstructionWithComparer.ValuesComparer:
+                var spanC = CreateDelegate<SpanCConstructor<TElement, TCompare, TResult>>(EmitConstructor(ctorInfo));
+                return comparer => values => spanC(values, (IComparer<TCompare>)comparer);
+            case ConstructionWithComparer.ComparerValues:
+                var cSpan = CreateDelegate<CSpanConstructor<TElement, TCompare, TResult>>(EmitConstructor(ctorInfo));
+                return comparer => values => cSpan((IComparer<TCompare>)comparer, values);
+            default:
+                throw new NotSupportedException();
+        }
     }
 
     private static DynamicMethod EmitConstructor(ConstructorInfo ctorInfo)

--- a/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionMemberAccessor.cs
@@ -379,25 +379,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
         throw new NotSupportedException();
     }
 
-    public SpanConstructor<TElement, TResult> CreateSpanConstructorWithLeadingECDelegate<TElement, TKey, TResult>(ConstructorInfo ctorInfo, IEqualityComparer<TKey> comparer)
-    {
-        Debug.Fail("Should not be called if not using Reflection.Emit");
-        throw new NotSupportedException();
-    }
-
-    public SpanConstructor<TElement, TResult> CreateSpanConstructorWithTrailingECDelegate<TElement, TKey, TResult>(ConstructorInfo ctorInfo, IEqualityComparer<TKey> comparer)
-    {
-        Debug.Fail("Should not be called if not using Reflection.Emit");
-        throw new NotSupportedException();
-    }
-
-    public SpanConstructor<TElement, TResult> CreateSpanConstructorWithLeadingCDelegate<TElement, TKey, TResult>(ConstructorInfo ctorInfo, IComparer<TKey> comparer)
-    {
-        Debug.Fail("Should not be called if not using Reflection.Emit");
-        throw new NotSupportedException();
-    }
-
-    public SpanConstructor<TElement, TResult> CreateSpanConstructorWithTrailingCDelegate<TElement, TKey, TResult>(ConstructorInfo ctorInfo, IComparer<TKey> comparer)
+    public Func<object, SpanConstructor<TElement, TResult>> CreateSpanConstructorDelegate<TElement, TCompare, TResult>(ConstructorInfo ctorInfo, ConstructionWithComparer signatureStyle)
     {
         Debug.Fail("Should not be called if not using Reflection.Emit");
         throw new NotSupportedException();

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShape.cs
@@ -60,6 +60,27 @@ internal abstract class ReflectionTypeShape<T>(ReflectionTypeShapeProvider provi
             _ => null,
         };
 
+    protected static Func<object, SpanConstructor<TElement, TResult>> CreateSpanMethodDelegate<TElement, TCompare, TResult>(MethodInfo methodInfo, ConstructionWithComparer signatureStyle)
+    {
+        switch (signatureStyle)
+        {
+            case ConstructionWithComparer.ValuesEqualityComparer:
+                var ctor = methodInfo.CreateDelegate<SpanECConstructor<TElement, TCompare, TResult>>();
+                return comparer => values => ctor(values, (IEqualityComparer<TCompare>)comparer);
+            case ConstructionWithComparer.EqualityComparerValues:
+                var ctor2 = methodInfo.CreateDelegate<ECSpanConstructor<TElement, TCompare, TResult>>();
+                return comparer => values => ctor2((IEqualityComparer<TCompare>)comparer, values);
+            case ConstructionWithComparer.ValuesComparer:
+                var ctor3 = methodInfo.CreateDelegate<SpanCConstructor<TElement, TCompare, TResult>>();
+                return comparer => values => ctor3(values, (IComparer<TCompare>)comparer);
+            case ConstructionWithComparer.ComparerValues:
+                var ctor4 = methodInfo.CreateDelegate<CSpanConstructor<TElement, TCompare, TResult>>();
+                return comparer => values => ctor4((IComparer<TCompare>)comparer, values);
+            default:
+                throw new NotSupportedException();
+        }
+    }
+
     protected (ConstructionWithComparer, ConstructorInfo?) FindComparerConstructorOverload(ConstructorInfo? nonComparerOverload)
     {
         var (comparer, overload) = FindComparerConstructionOverload(nonComparerOverload);

--- a/tests/PolyType.Tests/CollectionsWithComparersTests.cs
+++ b/tests/PolyType.Tests/CollectionsWithComparersTests.cs
@@ -17,6 +17,9 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     public void Dictionary() => this.AssertDefaultDictionary<Dictionary<int, bool>, int, bool>(new EvenOddEqualityComparer(), d => d.Comparer);
 
     [Fact]
+    public void IDictionary() => this.AssertDefaultDictionary<IDictionary<int, bool>, int, bool>(new EvenOddEqualityComparer(), d => ((Dictionary<int, bool>)d).Comparer);
+
+    [Fact]
     public void SortedDictionary() => this.AssertDefaultDictionary<SortedDictionary<int, bool>, int, bool>(new ReverseComparer(), d => d.Comparer);
 
     [Fact]
@@ -238,6 +241,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
         Assert.SkipWhen(providerUnderTest is ReflectionProviderUnderTest { Kind: ProviderKind.ReflectionNoEmit }, "Reflection (no-emit) does not support span collections.");
         IDictionaryTypeShape<T, K, V> shape = this.GetDictionaryShape<T, K, V>();
         Assert.Equal(CollectionComparerOptions.Comparer, shape.ComparerOptions);
+        Assert.Equal(CollectionConstructionStrategy.Span, shape.ConstructionStrategy);
         return shape.GetSpanConstructor(new() { Comparer = comparer })(values);
     }
 
@@ -247,6 +251,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
         Assert.SkipWhen(providerUnderTest is ReflectionProviderUnderTest { Kind: ProviderKind.ReflectionNoEmit }, "Reflection (no-emit) does not support span collections.");
         IDictionaryTypeShape<T, K, V> shape = this.GetDictionaryShape<T, K, V>();
         Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.ComparerOptions);
+        Assert.Equal(CollectionConstructionStrategy.Span, shape.ConstructionStrategy);
         return shape.GetSpanConstructor(new() { EqualityComparer = equalityComparer })(values);
     }
 
@@ -391,6 +396,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     }
 
     [GenerateShape<Dictionary<int, bool>>]
+    [GenerateShape<IDictionary<int, bool>>]
     [GenerateShape<SortedDictionary<int, bool>>]
     [GenerateShape<ImmutableDictionary<int, bool>>]
     [GenerateShape<ImmutableSortedDictionary<int, bool>>]


### PR DESCRIPTION
As part of this, I simplify some code and reuse more delegates to reduce GC pressure. I also noticed through an added test that sourcegen and reflection shape providers produced diverging construction strategies for IDictionary. I unified them (to the mutable strategy rather than span, since that works on non-Emit reflection and is probably faster in most or all cases).