### PR TITLE
Generate associated types from more than just object type shapes

### DIFF
--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Object.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Object.cs
@@ -97,7 +97,6 @@ public partial class TypeDataModelGenerator
         ImmutableArray<PropertyDataModel> properties = requirements.HasFlag(TypeShapeRequirements.Properties) ? MapProperties(namedType, ref ctx) : ImmutableArray<PropertyDataModel>.Empty;
         ImmutableArray<ConstructorDataModel> constructors = requirements.HasFlag(TypeShapeRequirements.Constructor) ? MapConstructors(namedType, properties, ref ctx) : ImmutableArray<ConstructorDataModel>.Empty;
         ImmutableArray<DerivedTypeModel> derivedTypes = IncludeDerivedTypes(type, ref ctx, requirements);
-        IncludeAssociatedShapes(type, associatedTypes, ref ctx);
 
         model = new ObjectDataModel
         {

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.cs
@@ -201,6 +201,7 @@ public partial class TypeDataModelGenerator
     {
         TypeDataModelGenerationStatus status;
 
+        IncludeAssociatedShapes(type, associatedTypes, ref ctx);
         switch (requestedKind)
         {
             // If the configuration specifies an explicit kind, try to resolve that or fall back to no shape.

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
@@ -22,6 +22,7 @@ internal sealed partial class SourceFormatter
                     AddKeyValuePairFunc = {{FormatAddKeyValuePairFunc(dictionaryShapeModel)}},
                     EnumerableConstructorFunc = {{FormatEnumerableConstructorFunc(dictionaryShapeModel)}},
                     SpanConstructorFunc = {{FormatSpanConstructorFunc(dictionaryShapeModel)}},
+                    AssociatedTypeShapes = {{FormatAssociatedTypeShapes(dictionaryShapeModel)}},
                     Provider = this,
                 };
             }

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
@@ -23,6 +23,7 @@ internal sealed partial class SourceFormatter
                     AddElementFunc = {{FormatAddElementFunc(enumerableShapeModel)}},
                     IsAsyncEnumerable = {{FormatBool(enumerableShapeModel.Kind is EnumerableKind.AsyncEnumerableOfT)}},
                     Rank = {{enumerableShapeModel.Rank}},
+                    AssociatedTypeShapes = {{FormatAssociatedTypeShapes(enumerableShapeModel)}},
                     Provider = this,
                };
             }

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Object.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Object.cs
@@ -44,28 +44,6 @@ internal sealed partial class SourceFormatter
     private static string FormatNullOrThrowPartial(string? stringExpr, bool missing)
         => missing ? "() => throw new global::System.NotImplementedException(\"This shape is not fully implemented.\")" : FormatNull(stringExpr);
 
-    private string FormatAssociatedTypeShapes(ObjectShapeModel objectShapeModel)
-    {
-        AssociatedTypeId[] associatedTypeShapes = [..
-            from associatedType in objectShapeModel.AssociatedTypes
-            select associatedType.Key];
-        if (associatedTypeShapes.Length == 0)
-        {
-            return "null";
-        }
-
-        StringBuilder builder = new();
-        builder.Append("static associatedType => associatedType switch { ");
-        foreach (AssociatedTypeId associatedType in associatedTypeShapes)
-        {
-            builder.Append($"\"{associatedType.Open}\" or \"{associatedType.Closed}\" => {provider.ProviderDeclaration.Id.FullyQualifiedName}.{ProviderSingletonProperty}.{GetShapeModel(associatedType.ClosedTypeId).SourceIdentifier}, ");
-        }
-
-        builder.Append("_ => null }");
-
-        return builder.ToString();
-    }
-
     private static void FormatMemberAccessors(SourceWriter writer, ObjectShapeModel objectShapeModel)
     {
         foreach (PropertyShapeModel property in objectShapeModel.Properties)

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
@@ -5,6 +5,7 @@ using PolyType.SourceGenerator.Model;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
+using System.Text;
 
 namespace PolyType.SourceGenerator;
 
@@ -172,5 +173,27 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
         };
 
         return $"global::PolyType.Abstractions.CollectionComparerOptions.{kind}";
+    }
+
+    private string FormatAssociatedTypeShapes(TypeShapeModel objectShapeModel)
+    {
+        AssociatedTypeId[] associatedTypeShapes = [..
+            from associatedType in objectShapeModel.AssociatedTypes
+            select associatedType.Key];
+        if (associatedTypeShapes.Length == 0)
+        {
+            return "null";
+        }
+
+        StringBuilder builder = new();
+        builder.Append("static associatedType => associatedType switch { ");
+        foreach (AssociatedTypeId associatedType in associatedTypeShapes)
+        {
+            builder.Append($"\"{associatedType.Open}\" or \"{associatedType.Closed}\" => {provider.ProviderDeclaration.Id.FullyQualifiedName}.{ProviderSingletonProperty}.{GetShapeModel(associatedType.ClosedTypeId).SourceIdentifier}, ");
+        }
+
+        builder.Append("_ => null }");
+
+        return builder.ToString();
     }
 }

--- a/src/PolyType/SourceGenModel/SourceGenObjectTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenObjectTypeShape.cs
@@ -30,78 +30,11 @@ public sealed class SourceGenObjectTypeShape<TObject> : SourceGenTypeShape<TObje
     /// </summary>
     public Func<IConstructorShape>? CreateConstructorFunc { get; init; }
 
-    /// <summary>
-    /// Gets the shape of an associated type, by its name.
-    /// </summary>
-    public Func<string, ITypeShape?>? AssociatedTypeShapes { get; init; }
-
     /// <inheritdoc/>
     public override TypeShapeKind Kind => TypeShapeKind.Object;
 
     /// <inheritdoc/>
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitObject(this, state);
-
-    /// <inheritdoc/>
-    public override ITypeShape? GetAssociatedTypeShape(Type associatedType)
-    {
-        if (associatedType.IsGenericTypeDefinition && typeof(TObject).GenericTypeArguments.Length != associatedType.GetTypeInfo().GenericTypeParameters.Length)
-        {
-            throw new ArgumentException("Type is not a generic type definition or does not have an equal count of generic type parameters with this type shape.");
-        }
-
-        StringBuilder builder = new();
-        ConstructStableName(associatedType, builder);
-        return AssociatedTypeShapes?.Invoke(builder.ToString());
-    }
-
-    private static void ConstructStableName(Type type, StringBuilder builder)
-    {
-        // The string created here must match the string created in the source generator (Parser.CreateAssociatedTypeId).
-        if (type.DeclaringType is not null)
-        {
-            ConstructStableName(type.DeclaringType, builder);
-            builder.Append('+');
-        }
-        else if (!string.IsNullOrEmpty(type.Namespace))
-        {
-            builder.Append(type.Namespace);
-            builder.Append('.');
-        }
-
-        if (type.IsGenericType)
-        {
-            string nameNoArity = type.Name[..type.Name.IndexOf('`')];
-            builder.Append(nameNoArity);
-            builder.Append('<');
-            if (type.IsGenericTypeDefinition)
-            {
-                builder.Append(',', GetOwnGenericTypeParameterCount(type) - 1);
-            }
-            else
-            {
-                for (int i = 0; i < type.GenericTypeArguments.Length; i++)
-                {
-                    if (i > 0)
-                    {
-                        builder.Append(',');
-                    }
-
-                    ConstructStableName(type.GenericTypeArguments[i], builder);
-                }
-            }
-
-            builder.Append('>');
-        }
-        else
-        {
-            builder.Append(type.Name);
-        }
-
-        static int GetOwnGenericTypeParameterCount(Type type)
-            => type.DeclaringType?.IsGenericType is true
-                ? type.GetTypeInfo().GenericTypeParameters.Length - type.DeclaringType.GetTypeInfo().GenericTypeParameters.Length
-                : type.GetTypeInfo().GenericTypeParameters.Length;
-    }
 
     IReadOnlyList<IPropertyShape> IObjectTypeShape.Properties => _properties ??= (CreatePropertiesFunc?.Invoke()).AsReadOnlyList();
     private IReadOnlyList<IPropertyShape>? _properties;

--- a/src/PolyType/SourceGenModel/SourceGenTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenTypeShape.cs
@@ -1,5 +1,6 @@
 ﻿using PolyType.Abstractions;
 using System.Reflection;
+using System.Text;
 
 namespace PolyType.SourceGenModel;
 
@@ -23,6 +24,11 @@ public abstract class SourceGenTypeShape<T> : ITypeShape<T>
     ICustomAttributeProvider? ITypeShape.AttributeProvider => typeof(T);
 
     /// <summary>
+    /// Gets the shape of an associated type, by its name.
+    /// </summary>
+    public Func<string, ITypeShape?>? AssociatedTypeShapes { get; init; }
+
+    /// <summary>
     /// Accepts an <see cref="TypeShapeVisitor"/> for strongly-typed traversal.
     /// </summary>
     /// <param name="visitor">The visitor to accept.</param>
@@ -34,5 +40,64 @@ public abstract class SourceGenTypeShape<T> : ITypeShape<T>
     object? ITypeShape.Invoke(ITypeShapeFunc func, object? state) => func.Invoke(this, state);
 
     /// <inheritdoc/>
-    public virtual ITypeShape? GetAssociatedTypeShape(Type associatedType) => null;
+    public ITypeShape? GetAssociatedTypeShape(Type associatedType)
+    {
+        if (associatedType.IsGenericTypeDefinition && typeof(T).GenericTypeArguments.Length != associatedType.GetTypeInfo().GenericTypeParameters.Length)
+        {
+            throw new ArgumentException("Type is not a generic type definition or does not have an equal count of generic type parameters with this type shape.");
+        }
+
+        StringBuilder builder = new();
+        ConstructStableName(associatedType, builder);
+        return AssociatedTypeShapes?.Invoke(builder.ToString());
+    }
+
+    private static void ConstructStableName(Type type, StringBuilder builder)
+    {
+        // The string created here must match the string created in the source generator (Parser.CreateAssociatedTypeId).
+        if (type.DeclaringType is not null)
+        {
+            ConstructStableName(type.DeclaringType, builder);
+            builder.Append('+');
+        }
+        else if (!string.IsNullOrEmpty(type.Namespace))
+        {
+            builder.Append(type.Namespace);
+            builder.Append('.');
+        }
+
+        if (type.IsGenericType)
+        {
+            string nameNoArity = type.Name[..type.Name.IndexOf('`')];
+            builder.Append(nameNoArity);
+            builder.Append('<');
+            if (type.IsGenericTypeDefinition)
+            {
+                builder.Append(',', GetOwnGenericTypeParameterCount(type) - 1);
+            }
+            else
+            {
+                for (int i = 0; i < type.GenericTypeArguments.Length; i++)
+                {
+                    if (i > 0)
+                    {
+                        builder.Append(',');
+                    }
+
+                    ConstructStableName(type.GenericTypeArguments[i], builder);
+                }
+            }
+
+            builder.Append('>');
+        }
+        else
+        {
+            builder.Append(type.Name);
+        }
+
+        static int GetOwnGenericTypeParameterCount(Type type)
+            => type.DeclaringType?.IsGenericType is true
+                ? type.GetTypeInfo().GenericTypeParameters.Length - type.DeclaringType.GetTypeInfo().GenericTypeParameters.Length
+                : type.GetTypeInfo().GenericTypeParameters.Length;
+    }
 }


### PR DESCRIPTION
This allows associated types to be generated from enumerable and dictionary shapes, which were missing before.