### PR TITLE
Prevent external implementations of the shape interfaces

### DIFF
--- a/src/PolyType.SourceGenerator/Analyzers/OnlySanctionedShapesAnalyzer.cs
+++ b/src/PolyType.SourceGenerator/Analyzers/OnlySanctionedShapesAnalyzer.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using PolyType.SourceGenerator.Helpers;
+using System.Collections.Immutable;
+
+namespace PolyType.SourceGenerator.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class OnlySanctionedShapesAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Parser.UnsanctionedShape);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            if (context.Compilation.AssemblyName is "PolyType")
+            {
+                // We only forbid implementations *outside* our own assembly.
+                return;
+            }
+
+            INamedTypeSymbol? noImplAttribute = context.Compilation.GetTypeByMetadataName("PolyType.InternalImplementationsOnlyAttribute");
+            if (noImplAttribute is null)
+            {
+                return;
+            }
+
+            context.RegisterSymbolStartAction(
+                context =>
+                {
+                    INamedTypeSymbol type = (INamedTypeSymbol)context.Symbol;
+                    var violatingInterfaces = type.Interfaces.Where(iface => iface.HasAttribute(noImplAttribute)).ToArray();
+                    if (violatingInterfaces is [])
+                    {
+                        return;
+                    }
+
+                    context.RegisterSyntaxNodeAction(
+                        context =>
+                        {
+                            var baseTypeSyntax = (SimpleBaseTypeSyntax)context.Node;
+                            SymbolInfo info = context.SemanticModel.GetSymbolInfo(baseTypeSyntax.Type, context.CancellationToken);
+                            if (violatingInterfaces.FirstOrDefault(i => SymbolEqualityComparer.Default.Equals(info.Symbol, i)) is { } violator)
+                            {
+                                // We found a violation.
+                                context.ReportDiagnostic(Diagnostic.Create(
+                                    Parser.UnsanctionedShape,
+                                    baseTypeSyntax.GetLocation(),
+                                    type.GetFullyQualifiedName(),
+                                    violator.GetFullyQualifiedName()));
+                            }
+                        },
+                        SyntaxKind.SimpleBaseType);
+                },
+                SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
@@ -134,4 +134,12 @@ public sealed partial class Parser
         category: "Usage",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    internal static DiagnosticDescriptor UnsanctionedShape { get; } = new DiagnosticDescriptor(
+        id: "PT0019",
+        title: "No external shape implementations.",
+        messageFormat: "The type \"{0}\" implements \"{1}\", which is a reserved interface that should only be implemented by PolyType itself.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/PolyType/Abstractions/IConstructorShape.cs
+++ b/src/PolyType/Abstractions/IConstructorShape.cs
@@ -5,6 +5,7 @@ namespace PolyType.Abstractions;
 /// <summary>
 /// Provides a strongly typed shape model for a given .NET constructor.
 /// </summary>
+[InternalImplementationsOnly]
 public interface IConstructorShape
 {
     /// <summary>
@@ -45,6 +46,7 @@ public interface IConstructorShape
 /// </summary>
 /// <typeparam name="TDeclaringType">The declaring type of the underlying constructor.</typeparam>
 /// <typeparam name="TArgumentState">The state type used for aggregating constructor arguments.</typeparam>
+[InternalImplementationsOnly]
 public interface IConstructorShape<TDeclaringType, TArgumentState> : IConstructorShape
 {
     /// <summary>

--- a/src/PolyType/Abstractions/IDictionaryTypeShape.cs
+++ b/src/PolyType/Abstractions/IDictionaryTypeShape.cs
@@ -9,6 +9,7 @@ namespace PolyType.Abstractions;
 /// Typically covers types implementing interfaces such as <see cref="IDictionary{TKey, TValue}"/>,
 /// <see cref="IReadOnlyDictionary{TKey, TValue}"/> or <see cref="IDictionary"/>.
 /// </remarks>
+[InternalImplementationsOnly]
 public interface IDictionaryTypeShape : ITypeShape
 {
     /// <summary>
@@ -48,6 +49,7 @@ public interface IDictionaryTypeShape : ITypeShape
 /// Typically covers types implementing interfaces such as <see cref="IDictionary{TKey, TValue}"/>,
 /// <see cref="IReadOnlyDictionary{TKey, TValue}"/> or <see cref="IDictionary"/>.
 /// </remarks>
+[InternalImplementationsOnly]
 public interface IDictionaryTypeShape<TDictionary, TKey, TValue> : ITypeShape<TDictionary>, IDictionaryTypeShape
     where TKey : notnull
 {

--- a/src/PolyType/Abstractions/IEnumTypeShape.cs
+++ b/src/PolyType/Abstractions/IEnumTypeShape.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Provides a strongly typed shape model for a .NET enum.
 /// </summary>
+[InternalImplementationsOnly]
 public interface IEnumTypeShape : ITypeShape
 {
     /// <summary>
@@ -16,6 +17,7 @@ public interface IEnumTypeShape : ITypeShape
 /// </summary>
 /// <typeparam name="TEnum">The type of .NET enum.</typeparam>
 /// <typeparam name="TUnderlying">The underlying type used to represent the enum.</typeparam>
+[InternalImplementationsOnly]
 public interface IEnumTypeShape<TEnum, TUnderlying> : ITypeShape<TEnum>, IEnumTypeShape
     where TEnum : struct, Enum
 {

--- a/src/PolyType/Abstractions/IEnumerableTypeShape.cs
+++ b/src/PolyType/Abstractions/IEnumerableTypeShape.cs
@@ -8,6 +8,7 @@ namespace PolyType.Abstractions;
 /// <remarks>
 /// Typically covers all types implementing <see cref="IEnumerable{T}"/> or <see cref="IEnumerable"/>.
 /// </remarks>
+[InternalImplementationsOnly]
 public interface IEnumerableTypeShape : ITypeShape
 {
     /// <summary>
@@ -60,6 +61,7 @@ public interface IEnumerableTypeShape : ITypeShape
 ///
 /// For non-generic collections, <typeparamref name="TElement"/> is instantiated to <see cref="object"/>.
 /// </remarks>
+[InternalImplementationsOnly]
 public interface IEnumerableTypeShape<TEnumerable, TElement> : ITypeShape<TEnumerable>, IEnumerableTypeShape
 {
     /// <summary>

--- a/src/PolyType/Abstractions/IObjectTypeShape.cs
+++ b/src/PolyType/Abstractions/IObjectTypeShape.cs
@@ -3,6 +3,7 @@ namespace PolyType.Abstractions;
 /// <summary>
 /// Provides a strongly typed shape model for a .NET object.
 /// </summary>
+[InternalImplementationsOnly]
 public interface IObjectTypeShape : ITypeShape
 {
     /// <summary>
@@ -34,4 +35,5 @@ public interface IObjectTypeShape : ITypeShape
 /// Provides a strongly typed shape model for a .NET object.
 /// </summary>
 /// <typeparam name="T">The type of .NET object.</typeparam>
+[InternalImplementationsOnly]
 public interface IObjectTypeShape<T> : ITypeShape<T>, IObjectTypeShape;

--- a/src/PolyType/Abstractions/IOptionalTypeShape.cs
+++ b/src/PolyType/Abstractions/IOptionalTypeShape.cs
@@ -6,6 +6,7 @@
 /// <remarks>
 /// Examples of optional types include <see cref="Nullable{T}"/> or the F# option types.
 /// </remarks>
+[InternalImplementationsOnly]
 public interface IOptionalTypeShape : ITypeShape
 {
     /// <summary>
@@ -22,6 +23,7 @@ public interface IOptionalTypeShape : ITypeShape
 /// <remarks>
 /// Examples of optional types include <see cref="Nullable{T}"/> or the F# option types.
 /// </remarks>
+[InternalImplementationsOnly]
 public interface IOptionalTypeShape<TOptional, TElement> : ITypeShape<TOptional>, IOptionalTypeShape
 {
     /// <summary>

--- a/src/PolyType/Abstractions/IParameterShape.cs
+++ b/src/PolyType/Abstractions/IParameterShape.cs
@@ -7,6 +7,7 @@ namespace PolyType.Abstractions;
 /// Provides a strongly typed shape model for a given .NET method parameter,
 /// representing either an actual parameter or a member initializer.
 /// </summary>
+[InternalImplementationsOnly]
 public interface IParameterShape
 {
     /// <summary>
@@ -88,6 +89,7 @@ public interface IParameterShape
 /// </summary>
 /// <typeparam name="TArgumentState">The state type used for aggregating method arguments.</typeparam>
 /// <typeparam name="TParameterType">The type of the underlying method parameter.</typeparam>
+[InternalImplementationsOnly]
 public interface IParameterShape<TArgumentState, TParameterType> : IParameterShape
 {
     /// <summary>

--- a/src/PolyType/Abstractions/IPropertyShape.cs
+++ b/src/PolyType/Abstractions/IPropertyShape.cs
@@ -6,6 +6,7 @@ namespace PolyType.Abstractions;
 /// <summary>
 /// Provides a strongly typed shape model for a given .NET instance property or field.
 /// </summary>
+[InternalImplementationsOnly]
 public interface IPropertyShape
 {
     /// <summary>
@@ -91,6 +92,7 @@ public interface IPropertyShape
 /// </summary>
 /// <typeparam name="TDeclaringType">The declaring type of the underlying property.</typeparam>
 /// <typeparam name="TPropertyType">The property type of the underlying property.</typeparam>
+[InternalImplementationsOnly]
 public interface IPropertyShape<TDeclaringType, TPropertyType> : IPropertyShape
 {
     /// <summary>

--- a/src/PolyType/Abstractions/ISurrogateTypeShape.cs
+++ b/src/PolyType/Abstractions/ISurrogateTypeShape.cs
@@ -3,6 +3,7 @@ namespace PolyType.Abstractions;
 /// <summary>
 /// Provides a strongly typed shape model for a .NET type that employs a surrogate type.
 /// </summary>
+[InternalImplementationsOnly]
 public interface ISurrogateTypeShape : ITypeShape
 {
     /// <summary>
@@ -16,6 +17,7 @@ public interface ISurrogateTypeShape : ITypeShape
 /// </summary>
 /// <typeparam name="T">The type the shape describes.</typeparam>
 /// <typeparam name="TSurrogate">The surrogate type being specified by the shape.</typeparam>
+[InternalImplementationsOnly]
 public interface ISurrogateTypeShape<T, TSurrogate> : ITypeShape<T>, ISurrogateTypeShape
 {
     /// <summary>

--- a/src/PolyType/Abstractions/ITypeShape.cs
+++ b/src/PolyType/Abstractions/ITypeShape.cs
@@ -5,6 +5,7 @@ namespace PolyType.Abstractions;
 /// <summary>
 /// Provides a strongly typed shape model for a given .NET type.
 /// </summary>
+[InternalImplementationsOnly]
 public interface ITypeShape
 {
     /// <summary>
@@ -66,4 +67,5 @@ public interface ITypeShape
 /// Provides a strongly typed shape model for a given .NET type.
 /// </summary>
 /// <typeparam name="T">The type that the shape describes.</typeparam>
+[InternalImplementationsOnly]
 public interface ITypeShape<T> : ITypeShape;

--- a/src/PolyType/Abstractions/IUnionCaseShape.cs
+++ b/src/PolyType/Abstractions/IUnionCaseShape.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Provides a strongly typed shape model for a union case in a discriminated union type.
 /// </summary>
+[InternalImplementationsOnly]
 public interface IUnionCaseShape
 {
     /// <summary>
@@ -56,6 +57,7 @@ public interface IUnionCaseShape
 /// </summary>
 /// <typeparam name="TUnionCase">The type of the union case.</typeparam>
 /// <typeparam name="TUnion">The type of the underlying union.</typeparam>
+[InternalImplementationsOnly]
 public interface IUnionCaseShape<TUnionCase, TUnion> : IUnionCaseShape
     where TUnionCase : TUnion
 {

--- a/src/PolyType/Abstractions/IUnionTypeShape.cs
+++ b/src/PolyType/Abstractions/IUnionTypeShape.cs
@@ -7,6 +7,7 @@
 /// Typically reserved for classes or interfaces that specify derived types via the <see cref="DerivedTypeShapeAttribute"/>
 /// but can also include F# discriminated unions.
 /// </remarks>
+[InternalImplementationsOnly]
 public interface IUnionTypeShape : ITypeShape
 {
     /// <summary>
@@ -31,6 +32,7 @@ public interface IUnionTypeShape : ITypeShape
 /// Typically reserved for classes or interfaces that specify derived types via the <see cref="DerivedTypeShapeAttribute"/>
 /// but can also include F# discriminated unions.
 /// </remarks>
+[InternalImplementationsOnly]
 public interface IUnionTypeShape<TUnion> : ITypeShape<TUnion>, IUnionTypeShape
 {
     /// <summary>

--- a/src/PolyType/InternalImplementationsOnlyAttribute.cs
+++ b/src/PolyType/InternalImplementationsOnlyAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace PolyType;
+
+/// <summary>
+/// Marks an interface as being disallowed for implementation outside PolyType.dll,
+/// as enforced by an analyzer we define.
+/// </summary>
+[AttributeUsage(AttributeTargets.Interface)]
+internal sealed class InternalImplementationsOnlyAttribute : Attribute
+{
+}

--- a/tests/PolyType.SourceGenerator.UnitTests/Analyzers/OnlySanctionedShapesAnalyzerTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/Analyzers/OnlySanctionedShapesAnalyzerTests.cs
@@ -1,0 +1,42 @@
+﻿using PolyType.SourceGenerator.Analyzers;
+
+namespace PolyType.SourceGenerator.UnitTests.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Xunit;
+using VerifyCS = CodeFixVerifier<OnlySanctionedShapesAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+public class OnlySanctionedShapesAnalyzerTests
+{
+    [Fact]
+    public async Task NoViolations()
+    {
+        string source = /* lang=c#-test */ """
+            class Foo { }
+            """;
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ImplementationOnClass()
+    {
+        string source = /* lang=c#-test */ """
+            using System;
+            using System.Reflection;
+            using PolyType;
+            using PolyType.Abstractions;
+
+            class Foo : {|PT0019:ITypeShape|}
+            {
+                public Type Type => throw new NotImplementedException();
+                public TypeShapeKind Kind => throw new NotImplementedException();
+                public ITypeShapeProvider Provider => throw new NotImplementedException();
+                public ICustomAttributeProvider AttributeProvider => throw new NotImplementedException();
+                public object Accept(TypeShapeVisitor visitor, object state = null) => throw new NotImplementedException();
+                public ITypeShape GetAssociatedTypeShape(Type associatedType) => throw new NotImplementedException();
+                public object Invoke(ITypeShapeFunc func, object state = null) => throw new NotImplementedException();
+            }
+            """;
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+}

--- a/tests/PolyType.Tests/Utilities/AggregatingTypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/Utilities/AggregatingTypeShapeProviderTests.cs
@@ -164,6 +164,7 @@ public class AggregatingTypeShapeProviderTests
     }
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Usage", "PT0019:No external shape implementations.", Justification = "Our own tests")]
     private class MockTypeShape<T> : ITypeShape<T>
     {
         public Type Type => throw new NotImplementedException();


### PR DESCRIPTION
This ensures that we can add/remove members from it without fear of binary breaking changes.

Closes #171
Closes #176