### PR TITLE
Discover associated types via attributes on members

### DIFF
--- a/src/PolyType.Roslyn/Model/TypeDataModel.cs
+++ b/src/PolyType.Roslyn/Model/TypeDataModel.cs
@@ -26,7 +26,7 @@ public class TypeDataModel
     /// <summary>
     /// The collection of associated types specified via TypeShapeAttribute.AssociatedTypes.
     /// </summary>
-    public ImmutableArray<AssociatedTypeModel> AssociatedTypes { get; init; } = ImmutableArray<AssociatedTypeModel>.Empty;
+    public ImmutableArray<AssociatedTypeModel> AssociatedTypes { get; set; } = ImmutableArray<AssociatedTypeModel>.Empty;
 
     /// <summary>
     /// Determines the type of <see cref="TypeDataModel"/> being used.

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Dictionary.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Dictionary.cs
@@ -6,7 +6,7 @@ namespace PolyType.Roslyn;
 
 public partial class TypeDataModelGenerator
 {
-    private bool TryMapDictionary(ITypeSymbol type, ImmutableArray<AssociatedTypeModel> associatedTypes, ref TypeDataModelGenerationContext ctx, out TypeDataModel? model, out TypeDataModelGenerationStatus status)
+    private bool TryMapDictionary(ITypeSymbol type, ref TypeDataModelGenerationContext ctx, out TypeDataModel? model, out TypeDataModelGenerationStatus status)
     {
         model = null;
         status = default;
@@ -153,7 +153,6 @@ public partial class TypeDataModelGenerator
             ConstructionStrategy = constructionStrategy,
             FactoryMethod = factoryMethod,
             FactoryMethodWithComparer = factoryMethodWithComparer,
-            AssociatedTypes = associatedTypes,
             IndexerIsExplicitInterfaceImplementation = indexerIsExplicitImplementation,
         };
 

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enum.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enum.cs
@@ -6,7 +6,7 @@ namespace PolyType.Roslyn;
 
 public partial class TypeDataModelGenerator
 {
-    private bool TryMapEnum(ITypeSymbol type, ImmutableArray<AssociatedTypeModel> associatedTypes, ref TypeDataModelGenerationContext ctx, out TypeDataModel? model, out TypeDataModelGenerationStatus status)
+    private bool TryMapEnum(ITypeSymbol type, ref TypeDataModelGenerationContext ctx, out TypeDataModel? model, out TypeDataModelGenerationStatus status)
     {
         if (type.TypeKind is not TypeKind.Enum)
         {
@@ -24,7 +24,6 @@ public partial class TypeDataModelGenerator
             Type = type,
             Depth = TypeShapeRequirements.Full,
             UnderlyingType = underlyingType,
-            AssociatedTypes = associatedTypes,
         };
         
         return true;

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enumerable.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enumerable.cs
@@ -7,7 +7,7 @@ namespace PolyType.Roslyn;
 
 public partial class TypeDataModelGenerator
 {
-    private bool TryMapEnumerable(ITypeSymbol type, ImmutableArray<AssociatedTypeModel> associatedTypes, ref TypeDataModelGenerationContext ctx, out TypeDataModel? model, out TypeDataModelGenerationStatus status)
+    private bool TryMapEnumerable(ITypeSymbol type, ref TypeDataModelGenerationContext ctx, out TypeDataModel? model, out TypeDataModelGenerationStatus status)
     {
         model = null;
         status = default;
@@ -223,7 +223,6 @@ public partial class TypeDataModelGenerator
             AddElementMethod = addElementMethod,
             FactoryMethod = factoryMethod,
             FactoryMethodWithComparer = factoryMethodWithComparer,
-            AssociatedTypes = associatedTypes,
             Rank = rank,
             AddMethodIsExplicitInterfaceImplementation = addMethodIsExplicitInterfaceImplementation,
         };

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Optional.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Optional.cs
@@ -5,7 +5,7 @@ namespace PolyType.Roslyn;
 
 public partial class TypeDataModelGenerator
 {
-    private bool TryMapOptional(ITypeSymbol type, ImmutableArray<AssociatedTypeModel> associatedTypes, ref TypeDataModelGenerationContext ctx, TypeShapeRequirements requirements, out TypeDataModel? model, out TypeDataModelGenerationStatus status)
+    private bool TryMapOptional(ITypeSymbol type, ref TypeDataModelGenerationContext ctx, TypeShapeRequirements requirements, out TypeDataModel? model, out TypeDataModelGenerationStatus status)
     {
         model = null;
         status = default;
@@ -27,7 +27,6 @@ public partial class TypeDataModelGenerator
             Type = type,
             Depth = TypeShapeRequirements.Full,
             ElementType = elementType,
-            AssociatedTypes = associatedTypes,
         };
 
         return true;

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Tuple.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Tuple.cs
@@ -19,7 +19,7 @@ public partial class TypeDataModelGenerator
     /// </remarks>
     protected virtual bool FlattenSystemTupleTypes => false;
 
-    private bool TryMapTuple(ITypeSymbol type, ImmutableArray<AssociatedTypeModel> associatedTypes, ref TypeDataModelGenerationContext ctx, out TypeDataModel? model, out TypeDataModelGenerationStatus status)
+    private bool TryMapTuple(ITypeSymbol type, ref TypeDataModelGenerationContext ctx, out TypeDataModel? model, out TypeDataModelGenerationStatus status)
     {
         status = default;
         model = null;
@@ -80,7 +80,6 @@ public partial class TypeDataModelGenerator
                 Depth = TypeShapeRequirements.Full,
                 Elements = elements.ToImmutableArray(),
                 IsValueTuple = false,
-                AssociatedTypes = associatedTypes,
             };
 
             status = TypeDataModelGenerationStatus.Success;

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -617,17 +617,12 @@ public sealed partial class Parser
 
     private readonly Dictionary<INamedTypeSymbol, CustomAttributeAssociatedTypeProvider> customAttributes = new(SymbolEqualityComparer.Default);
 
-    /// <summary>
-    /// Gets the associated types for a given type, as specified by 3rd party custom attributes.
-    /// </summary>
-    /// <param name="typeSymbol">The type whose associated types are sought.</param>
-    /// <param name="associatedTypes">The associated types for the given <paramref name="typeSymbol"/>.</param>
-    private void ParseCustomAssociatedTypeAttributes(
-        ITypeSymbol typeSymbol,
+    protected override void ParseCustomAssociatedTypeAttributes(
+        ISymbol symbol,
         out ImmutableArray<AssociatedTypeModel> associatedTypes)
     {
         associatedTypes = ImmutableArray<AssociatedTypeModel>.Empty;
-        foreach (AttributeData att in typeSymbol.GetAttributes())
+        foreach (AttributeData att in symbol.GetAttributes())
         {
             if (att.AttributeClass is null)
             {
@@ -681,13 +676,13 @@ public sealed partial class Parser
                         {
                             if (argValue.Value is INamedTypeSymbol namedType)
                             {
-                                yield return new AssociatedTypeModel(namedType, typeSymbol.ContainingAssembly, location, requirements);
+                                yield return new AssociatedTypeModel(namedType, symbol.ContainingAssembly, location, requirements);
                             }
                         }
                     }
                     else if (arg.Value is INamedTypeSymbol namedType)
                     {
-                        yield return new AssociatedTypeModel(namedType, typeSymbol.ContainingAssembly, location, requirements);
+                        yield return new AssociatedTypeModel(namedType, symbol.ContainingAssembly, location, requirements);
                     }
                 }
             }

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -431,7 +431,6 @@ public sealed partial class Parser : TypeDataModelGenerator
                 Depth = TypeShapeRequirements.Full,
                 SurrogateType = surrogateType,
                 MarshallerType = namedMarshaller,
-                AssociatedTypes = associatedTypes,
             };
         }
 
@@ -705,6 +704,8 @@ public sealed partial class Parser : TypeDataModelGenerator
 
         foreach (KeyValuePair<ITypeSymbol, TypeDataModel> entry in GeneratedModels)
         {
+            entry.Value.AssociatedTypes = AssociatedTypes.GetValueOrDefault(entry.Key, []);
+
             TypeId typeId = CreateTypeId(entry.Value.Type);
             if (results.ContainsKey(typeId))
             {

--- a/tests/PolyType.Tests/AssociatedTypesTests.cs
+++ b/tests/PolyType.Tests/AssociatedTypesTests.cs
@@ -166,6 +166,46 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
         AssertPartialShape(() => associatedShape.Properties);
     }
 
+    /// <summary>
+    /// Verifies that a property on <see cref="CustomTypeWithCustomConvertedMember"/>
+    /// with <see cref="MyConverterAttribute"/> applied will establish an associated type
+    /// between <see cref="GenericWrapper{T1}"/> and <see cref="GenericConverter{T}"/>
+    /// where <c>T</c> is <see cref="SpecialKey2"/>.
+    /// </summary>
+    [Fact]
+    public void AssociatedTypeAttribute_OnProperty()
+    {
+        // Assert that the associated type is available on its own.
+        IObjectTypeShape? associatedShape = (IObjectTypeShape<GenericConverter<SpecialKey2>>?)providerUnderTest.Provider.GetShape(typeof(GenericConverter<SpecialKey2>));
+        Assert.NotNull(associatedShape);
+
+        // Assert that it is available as an associated type of the original.
+        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericWrapper<SpecialKey2>));
+        Assert.NotNull(typeShape);
+        associatedShape = (IObjectTypeShape<GenericConverter<SpecialKey2>>?)typeShape.GetAssociatedTypeShape(typeof(GenericConverter<>));
+        Assert.NotNull(associatedShape);
+    }
+
+    /// <summary>
+    /// Verifies that a field on <see cref="CustomTypeWithCustomConvertedMember"/>
+    /// with <see cref="MyConverterAttribute"/> applied will establish an associated type
+    /// between <see cref="GenericWrapper{T1}"/> and <see cref="GenericConverter{T}"/>
+    /// where <c>T</c> is <see cref="SpecialKey3"/>.
+    /// </summary>
+    [Fact]
+    public void AssociatedTypeAttribute_OnField()
+    {
+        // Assert that the associated type is available on its own.
+        IObjectTypeShape? associatedShape = (IObjectTypeShape<GenericConverter<SpecialKey3>>?)providerUnderTest.Provider.GetShape(typeof(GenericConverter<SpecialKey3>));
+        Assert.NotNull(associatedShape);
+
+        // Assert that it is available as an associated type of the original.
+        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericWrapper<SpecialKey3>));
+        Assert.NotNull(typeShape);
+        associatedShape = (IObjectTypeShape<GenericConverter<SpecialKey3>>?)typeShape.GetAssociatedTypeShape(typeof(GenericConverter<>));
+        Assert.NotNull(associatedShape);
+    }
+
     [Fact]
     public void TypeShapeExtension_AssociatedShape()
     {
@@ -306,6 +346,8 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
         public class GenericNested<T2>;
     }
 
+    public class GenericConverter<T>;
+
     [GenerateShape<GenericDataType<int, string>>]
     [GenerateShape<GenericDataTypeFullAndPartialPaths<int, string>>]
     [GenerateShape<IEnumerable<SpecialKey>>]
@@ -316,6 +358,16 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [MyConverter(typeof(CustomTypeConverter))]
     [MyConverterNamedArg(Types = [typeof(CustomTypeConverter1), typeof(CustomTypeConverter2)])]
     internal partial class CustomTypeWithCustomConverter;
+
+    [GenerateShape]
+    internal partial class CustomTypeWithCustomConvertedMember
+    {
+        [MyConverter(typeof(GenericConverter<>))]
+        public GenericWrapper<SpecialKey2>? MyProperty { get; set; }
+
+        [MyConverter(typeof(GenericConverter<>))]
+        public GenericWrapper<SpecialKey3>? MyField;
+    }
 
     public class CustomTypeConverter { public string? MyProperty { get; set; } }
     public class CustomTypeConverter1 { public string? MyProperty { get; set; } }
@@ -334,6 +386,8 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     }
 
     internal class SpecialKey;
+    internal class SpecialKey2;
+    internal class SpecialKey3;
 
     public sealed class Reflection() : AssociatedTypesTests(ReflectionProviderUnderTest.NoEmit, partialShapesSupported: false);
     public sealed class ReflectionEmit() : AssociatedTypesTests(ReflectionProviderUnderTest.Emit, partialShapesSupported: false);


### PR DESCRIPTION
Previously, we supported 3rd party custom attributes that define associated types that appeared on types. With this change, we now recognize those attributes when they appear on properties and fields.

I had to rework the model for collecting associated types since we no longer know by the time we parse a type what the whole set of its associated types are.

Fixes #181