### PR TITLE
Ensure all lazily-initialized properties return only one value

### DIFF
--- a/src/PolyType/ReflectionProvider/ReflectionUnionCaseShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionUnionCaseShape.cs
@@ -5,8 +5,27 @@ namespace PolyType.ReflectionProvider;
 internal sealed class ReflectionUnionCaseShape<TUnionCase, TUnion>(IUnionTypeShape unionType, DerivedTypeInfo derivedTypeInfo, ReflectionTypeShapeProvider provider) : IUnionCaseShape<TUnionCase, TUnion>
     where TUnionCase : TUnion
 {
-    public ITypeShape<TUnionCase> Type => _type ??= typeof(TUnionCase) == typeof(TUnion) ? (ITypeShape<TUnionCase>)unionType.BaseType : provider.GetShape<TUnionCase>();
+    private readonly object _syncObject = new();
     private ITypeShape<TUnionCase>? _type;
+
+    public ITypeShape<TUnionCase> Type
+    {
+        get
+        {
+            if (_type is null)
+            {
+                lock (_syncObject)
+                {
+                    if (_type is null)
+                    {
+                        _type = typeof(TUnionCase) == typeof(TUnion) ? (ITypeShape<TUnionCase>)unionType.BaseType : provider.GetShape<TUnionCase>();
+                    }
+                }
+            }
+
+            return _type;
+        }
+    }
 
     public string Name => derivedTypeInfo.Name;
     public int Tag => derivedTypeInfo.Tag;

--- a/src/PolyType/ReflectionProvider/ReflectionUnionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionUnionTypeShape.cs
@@ -10,16 +10,60 @@ namespace PolyType.ReflectionProvider;
 internal sealed class ReflectionUnionTypeShape<TUnion>(DerivedTypeInfo[] derivedTypeInfos, ReflectionTypeShapeProvider provider)
     : ReflectionTypeShape<TUnion>(provider), IUnionTypeShape<TUnion>
 {
+    private readonly object _syncObject = new();
+
     public override TypeShapeKind Kind => TypeShapeKind.Union;
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitUnion(this, state);
 
-    public ITypeShape<TUnion> BaseType => _baseType ??= (ITypeShape<TUnion>)Provider.CreateTypeShapeCore(typeof(TUnion), allowUnionShapes: false);
+    public ITypeShape<TUnion> BaseType
+    {
+        get
+        {
+            if (_baseType is null)
+            {
+                lock (_syncObject)
+                {
+                    return _baseType ??= (ITypeShape<TUnion>)Provider.CreateTypeShapeCore(typeof(TUnion), allowUnionShapes: false);
+                }
+            }
+
+            return _baseType;
+        }
+    }
+
     private ITypeShape<TUnion>? _baseType;
 
-    public IReadOnlyList<IUnionCaseShape> UnionCases => _unionCases ??= CreateUnionCaseShapes().AsReadOnlyList();
+    public IReadOnlyList<IUnionCaseShape> UnionCases
+    {
+        get
+        {
+            if (_unionCases is null)
+            {
+                lock (_syncObject)
+                {
+                    return _unionCases ??= CreateUnionCaseShapes().AsReadOnlyList();
+                }
+            }
+
+            return _unionCases;
+        }
+    }
+
     private IReadOnlyList<IUnionCaseShape>? _unionCases;
 
-    public Getter<TUnion, int> GetGetUnionCaseIndex() => _unionCaseIndexReader ??= Provider.MemberAccessor.CreateGetUnionCaseIndex<TUnion>(derivedTypeInfos);
+    public Getter<TUnion, int> GetGetUnionCaseIndex()
+    {
+        if (_unionCaseIndexReader is null)
+        {
+            lock (_syncObject)
+            {
+                return _unionCaseIndexReader ??= Provider.MemberAccessor.CreateGetUnionCaseIndex<TUnion>(derivedTypeInfos);
+            }
+        }
+
+        return _unionCaseIndexReader;
+    }
+
     private Getter<TUnion, int>? _unionCaseIndexReader;
 
     ITypeShape IUnionTypeShape.BaseType => BaseType;


### PR DESCRIPTION
The lack of thread-safety here lead to multiple values being returned, which caused malfunctions in [one of PolyType's consumers][1].

Other occurrences of this problem already have been known to cause test instability within this repo, and those that surfaced were fixed. In this PR I went through _all_ the lazily initialized properties in all the shape implementations to ensure that I got them all.

[1]: https://github.com/AArnott/Nerdbank.MessagePack/issues/429#issuecomment-2942402813