### PR TITLE
Rename `SupportedComparers` to `SupportedComparer`

### DIFF
--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
@@ -23,7 +23,7 @@ internal sealed partial class SourceFormatter
                     KeyType = {{GetShapeModel(dictionaryShapeModel.KeyType).SourceIdentifier}},
                     ValueType = {{GetShapeModel(dictionaryShapeModel.ValueType).SourceIdentifier}},
                     GetDictionaryFunc = {{FormatGetDictionaryFunc(dictionaryShapeModel)}},
-                    SupportedComparers = {{FormatComparerOptions(dictionaryShapeModel.ConstructionComparer)}},
+                    SupportedComparer = {{FormatComparerOptions(dictionaryShapeModel.ConstructionComparer)}},
                     ConstructionStrategy = {{FormatCollectionConstructionStrategy(dictionaryShapeModel.ConstructionStrategy)}},
                     MutableConstructorFunc = {{FormatDefaultConstructorFunc(dictionaryShapeModel)}},
                     AddKeyValuePairFunc = {{FormatAddKeyValuePairFunc(dictionaryShapeModel)}},

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
@@ -18,7 +18,7 @@ internal sealed partial class SourceFormatter
                     MutableConstructorFunc = {{FormatMutableConstructorFunc(enumerableShapeModel)}},
                     EnumerableConstructorFunc = {{FormatEnumerableConstructorFunc(enumerableShapeModel)}},
                     SpanConstructorFunc = {{FormatSpanConstructorFunc(enumerableShapeModel)}},
-                    SupportedComparers = {{FormatComparerOptions(enumerableShapeModel.ConstructionComparer)}},
+                    SupportedComparer = {{FormatComparerOptions(enumerableShapeModel.ConstructionComparer)}},
                     GetEnumerableFunc = {{FormatGetEnumerableFunc(enumerableShapeModel)}},
                     AddElementFunc = {{FormatAddElementFunc(enumerableShapeModel)}},
                     IsAsyncEnumerable = {{FormatBool(enumerableShapeModel.Kind is EnumerableKind.AsyncEnumerableOfT)}},

--- a/src/PolyType/Abstractions/CollectionConstructionOptions.cs
+++ b/src/PolyType/Abstractions/CollectionConstructionOptions.cs
@@ -9,7 +9,7 @@
 /// Construction of any particular collection type may ignore any or all of these properties.
 /// To predict whether a collection will use a particular comparer property, check the
 /// <see cref="CollectionComparerOptions"/> enum, as defined by either
-/// <see cref="IEnumerableTypeShape.SupportedComparers"/> or <see cref="IDictionaryTypeShape.SupportedComparers"/>.
+/// <see cref="IEnumerableTypeShape.SupportedComparer"/> or <see cref="IDictionaryTypeShape.SupportedComparer"/>.
 /// </para>
 /// </remarks>
 public readonly struct CollectionConstructionOptions<TKey>

--- a/src/PolyType/Abstractions/IDictionaryTypeShape.cs
+++ b/src/PolyType/Abstractions/IDictionaryTypeShape.cs
@@ -36,7 +36,7 @@ public interface IDictionaryTypeShape : ITypeShape
     /// <summary>
     /// Gets the kind of custom comparer (if any) that this collection may be initialized with.
     /// </summary>
-    CollectionComparerOptions SupportedComparers { get; }
+    CollectionComparerOptions SupportedComparer { get; }
 }
 
 /// <summary>

--- a/src/PolyType/Abstractions/IEnumerableTypeShape.cs
+++ b/src/PolyType/Abstractions/IEnumerableTypeShape.cs
@@ -27,7 +27,7 @@ public interface IEnumerableTypeShape : ITypeShape
     /// <summary>
     /// Gets the kind of custom comparer (if any) that this collection may be initialized with.
     /// </summary>
-    CollectionComparerOptions SupportedComparers { get; }
+    CollectionComparerOptions SupportedComparer { get; }
 
     /// <summary>
     /// Gets the dimensionality of the collection type.

--- a/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
@@ -27,7 +27,7 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
     private EnumerableCollectionConstructor<TElement, TElement, TEnumerable>? _enumerableCtorDelegate;
     private SpanCollectionConstructor<TElement, TElement, TEnumerable>? _spanCtorDelegate;
 
-    public virtual CollectionComparerOptions SupportedComparers
+    public virtual CollectionComparerOptions SupportedComparer
     {
         get
         {
@@ -603,7 +603,7 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
     private NotSupportedException CreateUnsupportedConstructorException() => new NotSupportedException($"({_factory?.Signature}, {_factoryWithComparer?.Signature}) constructor is not supported for this type.");
 
     private object? GetRelevantComparer(CollectionConstructionOptions<TElement> collectionConstructionOptions)
-        => GetRelevantComparer<TElement>(collectionConstructionOptions, SupportedComparers);
+        => GetRelevantComparer<TElement>(collectionConstructionOptions, SupportedComparer);
 }
 
 [RequiresUnreferencedCode(ReflectionTypeShapeProvider.RequiresUnreferencedCodeMessage)]
@@ -631,7 +631,7 @@ internal sealed class ReflectionNonGenericEnumerableTypeShape<TEnumerable>(Refle
 internal sealed class ReflectionArrayTypeShape<TElement>(ReflectionTypeShapeProvider provider)
     : ReflectionEnumerableTypeShape<TElement[], TElement>(provider)
 {
-    public override CollectionComparerOptions SupportedComparers => CollectionComparerOptions.None;
+    public override CollectionComparerOptions SupportedComparer => CollectionComparerOptions.None;
     public override CollectionConstructionStrategy ConstructionStrategy => CollectionConstructionStrategy.Span;
     public override Func<TElement[], IEnumerable<TElement>> GetGetEnumerable() => static array => array;
     public override SpanCollectionConstructor<TElement, TElement, TElement[]> GetSpanCollectionConstructor() => static (ReadOnlySpan<TElement> span, in CollectionConstructionOptions<TElement> options) => span.ToArray();
@@ -643,7 +643,7 @@ internal sealed class MultiDimensionalArrayTypeShape<TEnumerable, TElement>(Refl
     : ReflectionEnumerableTypeShape<TEnumerable, TElement>(provider)
     where TEnumerable : IEnumerable
 {
-    public override CollectionComparerOptions SupportedComparers => CollectionComparerOptions.None;
+    public override CollectionComparerOptions SupportedComparer => CollectionComparerOptions.None;
     public override CollectionConstructionStrategy ConstructionStrategy => CollectionConstructionStrategy.None;
     public override int Rank => rank;
     public override Func<TEnumerable, IEnumerable<TElement>> GetGetEnumerable()
@@ -655,7 +655,7 @@ internal sealed class MultiDimensionalArrayTypeShape<TEnumerable, TElement>(Refl
 internal sealed class ReadOnlyMemoryTypeShape<TElement>(ReflectionTypeShapeProvider provider)
     : ReflectionEnumerableTypeShape<ReadOnlyMemory<TElement>, TElement>(provider)
 {
-    public override CollectionComparerOptions SupportedComparers => CollectionComparerOptions.None;
+    public override CollectionComparerOptions SupportedComparer => CollectionComparerOptions.None;
     public override CollectionConstructionStrategy ConstructionStrategy => CollectionConstructionStrategy.Span;
     public override Func<ReadOnlyMemory<TElement>, IEnumerable<TElement>> GetGetEnumerable() => static memory => MemoryMarshal.ToEnumerable(memory);
     public override SpanCollectionConstructor<TElement, TElement, ReadOnlyMemory<TElement>> GetSpanCollectionConstructor() => static (ReadOnlySpan<TElement> span, in CollectionConstructionOptions<TElement> options) => span.ToArray();
@@ -666,7 +666,7 @@ internal sealed class ReadOnlyMemoryTypeShape<TElement>(ReflectionTypeShapeProvi
 internal sealed class MemoryTypeShape<TElement>(ReflectionTypeShapeProvider provider)
     : ReflectionEnumerableTypeShape<Memory<TElement>, TElement>(provider)
 {
-    public override CollectionComparerOptions SupportedComparers => CollectionComparerOptions.None;
+    public override CollectionComparerOptions SupportedComparer => CollectionComparerOptions.None;
     public override CollectionConstructionStrategy ConstructionStrategy => CollectionConstructionStrategy.Span;
     public override Func<Memory<TElement>, IEnumerable<TElement>> GetGetEnumerable() => static memory => MemoryMarshal.ToEnumerable((ReadOnlyMemory<TElement>)memory);
     public override SpanCollectionConstructor<TElement, TElement, Memory<TElement>> GetSpanCollectionConstructor() => static (ReadOnlySpan<TElement> span, in CollectionConstructionOptions<TElement> options) => span.ToArray();
@@ -677,7 +677,7 @@ internal sealed class MemoryTypeShape<TElement>(ReflectionTypeShapeProvider prov
 internal sealed class ReflectionAsyncEnumerableShape<TEnumerable, TElement>(ReflectionTypeShapeProvider provider)
     : ReflectionEnumerableTypeShape<TEnumerable, TElement>(provider)
 {
-    public override CollectionComparerOptions SupportedComparers => CollectionComparerOptions.None;
+    public override CollectionComparerOptions SupportedComparer => CollectionComparerOptions.None;
     public override bool IsAsyncEnumerable => true;
     public override Func<TEnumerable, IEnumerable<TElement>> GetGetEnumerable() =>
         static _ => throw new InvalidOperationException("Sync enumeration of IAsyncEnumerable instances is not supported.");

--- a/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
@@ -32,7 +32,7 @@ public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : So
     public required CollectionConstructionStrategy ConstructionStrategy { get; init; }
 
     /// <inheritdoc/>
-    public required CollectionComparerOptions SupportedComparers { get; init; }
+    public required CollectionComparerOptions SupportedComparer { get; init; }
 
     /// <summary>
     /// Gets the function that constructs a default instance of the dictionary type.

--- a/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
@@ -30,7 +30,7 @@ public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : Source
     public required Func<TEnumerable, IEnumerable<TElement>> GetEnumerableFunc { get; init; }
 
     /// <inheritdoc/>
-    public required CollectionComparerOptions SupportedComparers { get; init; }
+    public required CollectionComparerOptions SupportedComparer { get; init; }
 
     /// <summary>
     /// Gets the construction strategy for the collection.

--- a/tests/PolyType.Tests/CollectionsWithComparersTests.cs
+++ b/tests/PolyType.Tests/CollectionsWithComparersTests.cs
@@ -130,10 +130,10 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     [Fact]
     public void NoComparerCollections()
     {
-        Assert.Equal(CollectionComparerOptions.None, this.GetEnumerableShape<ReadOnlyMemory<int>, int>().SupportedComparers);
-        Assert.Equal(CollectionComparerOptions.None, this.GetEnumerableShape<Memory<int>, int>().SupportedComparers);
-        Assert.Equal(CollectionComparerOptions.None, this.GetEnumerableShape<int[], int>().SupportedComparers);
-        Assert.Equal(CollectionComparerOptions.None, this.GetEnumerableShape<int[,], int>().SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.None, this.GetEnumerableShape<ReadOnlyMemory<int>, int>().SupportedComparer);
+        Assert.Equal(CollectionComparerOptions.None, this.GetEnumerableShape<Memory<int>, int>().SupportedComparer);
+        Assert.Equal(CollectionComparerOptions.None, this.GetEnumerableShape<int[], int>().SupportedComparer);
+        Assert.Equal(CollectionComparerOptions.None, this.GetEnumerableShape<int[,], int>().SupportedComparer);
     }
 
     private void AssertDefaultDictionary<T, K, V>(IComparer<K> comparer, Func<T, IComparer<K>> getComparer)
@@ -212,7 +212,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
         where K : notnull
     {
         IDictionaryTypeShape<T, K, V> shape = this.GetDictionaryShape<T, K, V>();
-        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparer);
         return shape.GetMutableCollectionConstructor()(new() { Comparer = comparer });
     }
 
@@ -220,7 +220,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
         where K : notnull
     {
         IDictionaryTypeShape<T, K, V> shape = this.GetDictionaryShape<T, K, V>();
-        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparer);
         return shape.GetMutableCollectionConstructor()(new() { EqualityComparer = equalityComparer });
     }
 
@@ -228,7 +228,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
         where K : notnull
     {
         IDictionaryTypeShape<T, K, V> shape = this.GetDictionaryShape<T, K, V>();
-        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparer);
         return shape.GetEnumerableCollectionConstructor()(values, new() { Comparer = comparer });
     }
 
@@ -236,7 +236,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
         where K : notnull
     {
         IDictionaryTypeShape<T, K, V> shape = this.GetDictionaryShape<T, K, V>();
-        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparer);
         return shape.GetEnumerableCollectionConstructor()(values, new() { EqualityComparer = equalityComparer });
     }
 
@@ -245,7 +245,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     {
         Assert.SkipWhen(providerUnderTest is ReflectionProviderUnderTest { Kind: ProviderKind.ReflectionNoEmit }, "Reflection (no-emit) does not support span collections.");
         IDictionaryTypeShape<T, K, V> shape = this.GetDictionaryShape<T, K, V>();
-        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparer);
         Assert.Equal(CollectionConstructionStrategy.Span, shape.ConstructionStrategy);
         return shape.GetSpanCollectionConstructor()(values, new() { Comparer = comparer });
     }
@@ -255,7 +255,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     {
         Assert.SkipWhen(providerUnderTest is ReflectionProviderUnderTest { Kind: ProviderKind.ReflectionNoEmit }, "Reflection (no-emit) does not support span collections.");
         IDictionaryTypeShape<T, K, V> shape = this.GetDictionaryShape<T, K, V>();
-        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparer);
         Assert.Equal(CollectionConstructionStrategy.Span, shape.ConstructionStrategy);
         return shape.GetSpanCollectionConstructor()(values, new() { EqualityComparer = equalityComparer });
     }
@@ -346,7 +346,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     private T CreateDefaultEnumerable<T, K>(IComparer<K>? comparer)
     {
         IEnumerableTypeShape<T, K> shape = this.GetEnumerableShape<T, K>();
-        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparer);
         Assert.Equal(CollectionConstructionStrategy.Mutable, shape.ConstructionStrategy);
         return shape.GetMutableCollectionConstructor()(new() { Comparer = comparer });
     }
@@ -354,7 +354,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     private T CreateDefaultEnumerable<T, K>(IEqualityComparer<K>? equalityComparer)
     {
         IEnumerableTypeShape<T, K> shape = this.GetEnumerableShape<T, K>();
-        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparer);
         Assert.Equal(CollectionConstructionStrategy.Mutable, shape.ConstructionStrategy);
         return shape.GetMutableCollectionConstructor()(new() { EqualityComparer = equalityComparer });
     }
@@ -363,7 +363,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     {
         IEnumerableTypeShape<T, K> shape = this.GetEnumerableShape<T, K>();
         Assert.Equal(CollectionConstructionStrategy.Enumerable, shape.ConstructionStrategy);
-        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparer);
         return shape.GetEnumerableCollectionConstructor()(values, new() { Comparer = comparer });
     }
 
@@ -371,7 +371,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     {
         IEnumerableTypeShape<T, K> shape = this.GetEnumerableShape<T, K>();
         Assert.Equal(CollectionConstructionStrategy.Enumerable, shape.ConstructionStrategy);
-        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparer);
         return shape.GetEnumerableCollectionConstructor()(values, new() { EqualityComparer = equalityComparer });
     }
 
@@ -380,7 +380,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
         Assert.SkipWhen(providerUnderTest is ReflectionProviderUnderTest { Kind: ProviderKind.ReflectionNoEmit }, "Reflection (no-emit) does not support span collections.");
         IEnumerableTypeShape<T, K> shape = this.GetEnumerableShape<T, K>();
         Assert.Equal(CollectionConstructionStrategy.Span, shape.ConstructionStrategy);
-        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparer);
         return shape.GetSpanCollectionConstructor()(values, new() { Comparer = comparer });
     }
 
@@ -389,7 +389,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
         Assert.SkipWhen(providerUnderTest is ReflectionProviderUnderTest { Kind: ProviderKind.ReflectionNoEmit }, "Reflection (no-emit) does not support span collections.");
         IEnumerableTypeShape<T, K> shape = this.GetEnumerableShape<T, K>();
         Assert.Equal(CollectionConstructionStrategy.Span, shape.ConstructionStrategy);
-        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparers);
+        Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparer);
         return shape.GetSpanCollectionConstructor()(values, new() { EqualityComparer = equalityComparer });
     }
 


### PR DESCRIPTION
This is a holdout from the Flags enum design of #187
