### PR TITLE
Add copy constructor to `CollectionConstructionOptions<TKey>`

### DIFF
--- a/src/PolyType/Abstractions/CollectionConstructionOptions.cs
+++ b/src/PolyType/Abstractions/CollectionConstructionOptions.cs
@@ -15,6 +15,12 @@
 public readonly struct CollectionConstructionOptions<TKey>
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="CollectionConstructionOptions{TKey}"/> struct.
+    /// </summary>
+    /// <param name="copyFrom">A template to copy all properties from.</param>
+    public CollectionConstructionOptions(CollectionConstructionOptions<TKey> copyFrom) => this = copyFrom;
+
+    /// <summary>
     /// Gets an optional equality comparer for the keys or elements in the collection.
     /// </summary>
     public IEqualityComparer<TKey>? EqualityComparer { get; init; }

--- a/tests/PolyType.Tests/CollectionConstructionOptionsTests.cs
+++ b/tests/PolyType.Tests/CollectionConstructionOptionsTests.cs
@@ -1,0 +1,19 @@
+﻿namespace PolyType.Tests;
+
+public class CollectionConstructionOptionsTests
+{
+    [Fact]
+    public void CopyConstructor()
+    {
+        CollectionConstructionOptions<int> original = new()
+        {
+            EqualityComparer = EqualityComparer<int>.Default,
+            Comparer = Comparer<int>.Default,
+            Capacity = 10
+        };
+        CollectionConstructionOptions<int> copy = new(original);
+        Assert.Same(original.EqualityComparer, copy.EqualityComparer);
+        Assert.Same(original.Comparer, copy.Comparer);
+        Assert.Equal(original.Capacity, copy.Capacity);
+    }
+}


### PR DESCRIPTION
Without this, deserializers have to manually copy properties from a 'template' options struct which may have comparers in it into a local variable for the struct in order to set `Capacity`. Since all these properties are declared as `init`, one cannot simply copy the struct into a local and then change Capacity -- it must be done all at construction time, which is tedious. And when we add properties to this struct, all those deserializers will drop that added property during their manual copy.

With the new copy constructor, the following syntax becomes an option:

```cs
CollectionConstructionOptions<TKey> options = new(this.optionsTemplate)
{
   Capacity = count,
};
```

Alternative designs:

1. Use `record struct` so that C# users can say `this.optionsTemplate with { Capacity = count }`. This is the nicest syntax, but adds a lot of generated code to the output, and since this is a generic type, that can bloat the size of the final executable.
2. Change from a `readonly struct` to a mutable one, and the property accessors from `init` to `set`.