### PR TITLE
Suppress CS0612 obsolete warnings

### DIFF
--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
@@ -102,6 +102,11 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
             """);
 #endif
 
+        writer.WriteLine("""
+            #pragma warning disable CS0612, CS0618 // Use of obsolete APIs is natural when we're emitting delegates for obsolete properties.
+
+            """);
+
         if (typeDeclaration.Namespace is string @namespace)
         {
             writer.WriteLine($"namespace {@namespace}");

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
@@ -1393,4 +1393,25 @@ public static class CompilationTests
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
         Assert.Empty(result.Diagnostics);
     }
+
+    [Fact]
+    public static void ObsoleteMembers()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using System;
+            using PolyType;
+
+            internal class MyObject
+            {
+                [Obsolete]
+                public int ObsoleteProperty { get; set; }
+            }
+
+            [GenerateShapeFor(typeof(MyObject))]
+            internal partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
+        Assert.Empty(result.Diagnostics);
+    }
 }


### PR DESCRIPTION
When emitting shapes for types with obsolete properties, CS0612 may be emitted from generated code, with no way to suppress it from the user's project. We should suppress these within the source generator.