### PR TITLE
Throw when attempting to call constructors accepting span in reflection without emit.

### DIFF
--- a/src/PolyType/ReflectionProvider/CollectionConstructionInfo.cs
+++ b/src/PolyType/ReflectionProvider/CollectionConstructionInfo.cs
@@ -15,24 +15,14 @@ internal sealed class NoCollectionConstructorInfo() : CollectionConstructorInfo(
     public static NoCollectionConstructorInfo Instance { get; } = new();
 }
 
-internal sealed class MutableCollectionConstructorInfo(
+internal sealed class MethodCollectionConstructorInfo(
     MethodBase factory,
     CollectionConstructorParameter[] signature,
     CollectionComparerOptions comparerOptions,
-    MethodInfo addMethod)
-    : CollectionConstructorInfo(CollectionConstructionStrategy.Mutable, comparerOptions)
-{
-    public MethodBase DefaultConstructor { get; } = factory;
-    public CollectionConstructorParameter[] Signature { get; } = signature;
-    public MethodInfo AddMethod { get; } = addMethod;
-}
-
-internal sealed class ParameterizedCollectionConstructorInfo(
-    MethodBase factory,
-    CollectionConstructorParameter[] signature,
-    CollectionComparerOptions comparerOptions)
-    : CollectionConstructorInfo(CollectionConstructionStrategy.Parameterized, comparerOptions)
+    MethodInfo? addMethod)
+    : CollectionConstructorInfo(addMethod is null ? CollectionConstructionStrategy.Parameterized : CollectionConstructionStrategy.Mutable, comparerOptions)
 {
     public MethodBase Factory { get; } = factory;
     public CollectionConstructorParameter[] Signature { get; } = signature;
+    public MethodInfo? AddMethod { get; } = addMethod;
 }

--- a/src/PolyType/ReflectionProvider/MemberAccessors/IReflectionMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/IReflectionMemberAccessor.cs
@@ -21,8 +21,10 @@ internal interface IReflectionMemberAccessor
     TDelegate CreateFuncDelegate<TDelegate>(ConstructorInfo ctorInfo) where TDelegate : Delegate;
     Func<T, TResult> CreateFuncDelegate<T, TResult>(ConstructorInfo ctorInfo);
     Func<T1, T2, TResult> CreateFuncDelegate<T1, T2, TResult>(ConstructorInfo ctorInfo);
-    MutableCollectionConstructor<TKey, TCollection> CreateMutableCollectionConstructor<TKey, TElement, TCollection>(MutableCollectionConstructorInfo constructorInfo);
-    ParameterizedCollectionConstructor<TKey, TElement, TCollection> CreateParameterizedCollectionConstructor<TKey, TElement, TCollection>(ParameterizedCollectionConstructorInfo constructorInfo);
+
+    bool IsCollectionConstructorSupported(MethodBase method, CollectionConstructorParameter[] signature);
+    MutableCollectionConstructor<TKey, TCollection> CreateMutableCollectionConstructor<TKey, TElement, TCollection>(MethodCollectionConstructorInfo constructorInfo);
+    ParameterizedCollectionConstructor<TKey, TElement, TCollection> CreateParameterizedCollectionConstructor<TKey, TElement, TCollection>(MethodCollectionConstructorInfo constructorInfo);
 
     Getter<TUnion, int> CreateGetUnionCaseIndex<TUnion>(DerivedTypeInfo[] derivedTypeInfos);
 }

--- a/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionEmitMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionEmitMemberAccessor.cs
@@ -953,12 +953,14 @@ internal sealed class ReflectionEmitMemberAccessor : IReflectionMemberAccessor
         }
     }
 
-    public MutableCollectionConstructor<TKey, TDeclaringType> CreateMutableCollectionConstructor<TKey, TElement, TDeclaringType>(MutableCollectionConstructorInfo ctorInfo)
+    public bool IsCollectionConstructorSupported(MethodBase method, CollectionConstructorParameter[] signature) => true;
+
+    public MutableCollectionConstructor<TKey, TDeclaringType> CreateMutableCollectionConstructor<TKey, TElement, TDeclaringType>(MethodCollectionConstructorInfo ctorInfo)
     {
         // Only options parameter
         var dyn = CreateCollectionConstructorDelegate(
             "MutableCollectionCtor",
-            ctorInfo.DefaultConstructor,
+            ctorInfo.Factory,
             ctorInfo.Signature,
             keyType: typeof(TKey),
             elementType: typeof(TElement),
@@ -968,7 +970,7 @@ internal sealed class ReflectionEmitMemberAccessor : IReflectionMemberAccessor
         return CreateDelegate<MutableCollectionConstructor<TKey, TDeclaringType>>(dyn);
     }
 
-    public ParameterizedCollectionConstructor<TKey, TElement, TCollection> CreateParameterizedCollectionConstructor<TKey, TElement, TCollection>(ParameterizedCollectionConstructorInfo constructorInfo)
+    public ParameterizedCollectionConstructor<TKey, TElement, TCollection> CreateParameterizedCollectionConstructor<TKey, TElement, TCollection>(MethodCollectionConstructorInfo constructorInfo)
     {
         // (ReadOnlySpan<TElement> values, in CollectionConstructionOptions<TKey> options)
         var dyn = CreateCollectionConstructorDelegate(

--- a/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
@@ -1,13 +1,9 @@
-﻿using System.Collections;
-using System.Collections.ObjectModel;
+﻿using PolyType.Abstractions;
+using PolyType.SourceGenModel;
+using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Reflection;
-using System.Security.Cryptography;
-using System.Xml.Linq;
-using PolyType.Abstractions;
-using PolyType.SourceGenModel;
 
 namespace PolyType.ReflectionProvider;
 
@@ -51,8 +47,8 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
 
         Setter<TDictionary, KeyValuePair<TKey, TValue>> CreateAddKeyValuePair()
         {
-            DebugExt.Assert(_constructorInfo is MutableCollectionConstructorInfo);
-            return Provider.MemberAccessor.CreateDictionaryAddDelegate<TDictionary, TKey, TValue>(((MutableCollectionConstructorInfo)_constructorInfo).AddMethod);
+            DebugExt.Assert(_constructorInfo is MethodCollectionConstructorInfo { AddMethod: not null });
+            return Provider.MemberAccessor.CreateDictionaryAddDelegate<TDictionary, TKey, TValue>(((MethodCollectionConstructorInfo)_constructorInfo).AddMethod!);
         }
     }
 
@@ -68,8 +64,8 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
 
         MutableCollectionConstructor<TKey, TDictionary> CreateMutableCtor()
         {
-            DebugExt.Assert(_constructorInfo is MutableCollectionConstructorInfo);
-            return Provider.MemberAccessor.CreateMutableCollectionConstructor<TKey, TValue, TDictionary>((MutableCollectionConstructorInfo)_constructorInfo);
+            DebugExt.Assert(_constructorInfo is MethodCollectionConstructorInfo);
+            return Provider.MemberAccessor.CreateMutableCollectionConstructor<TKey, TValue, TDictionary>((MethodCollectionConstructorInfo)_constructorInfo);
         }
     }
 
@@ -84,8 +80,8 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
         return _spanCtorDelegate ?? ReflectionHelpers.ExchangeIfNull(ref _spanCtorDelegate, CreateParameterizedCtor());
         ParameterizedCollectionConstructor<TKey, KeyValuePair<TKey, TValue>, TDictionary> CreateParameterizedCtor()
         {
-            DebugExt.Assert(_constructorInfo is ParameterizedCollectionConstructorInfo);
-            return Provider.MemberAccessor.CreateParameterizedCollectionConstructor<TKey, KeyValuePair<TKey, TValue>, TDictionary>((ParameterizedCollectionConstructorInfo)_constructorInfo);
+            DebugExt.Assert(_constructorInfo is MethodCollectionConstructorInfo);
+            return Provider.MemberAccessor.CreateParameterizedCollectionConstructor<TKey, KeyValuePair<TKey, TValue>, TDictionary>((MethodCollectionConstructorInfo)_constructorInfo);
         }
     }
 

--- a/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
@@ -1,5 +1,4 @@
 ﻿using PolyType.Abstractions;
-using PolyType.SourceGenModel;
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -46,8 +45,8 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
         Setter<TEnumerable, TElement> CreateAddDelegate()
         {
-            DebugExt.Assert(ConstructorInfo is MutableCollectionConstructorInfo);
-            return Provider.MemberAccessor.CreateEnumerableAddDelegate<TEnumerable, TElement>(((MutableCollectionConstructorInfo)ConstructorInfo).AddMethod);
+            DebugExt.Assert(ConstructorInfo is MethodCollectionConstructorInfo { AddMethod: not null });
+            return Provider.MemberAccessor.CreateEnumerableAddDelegate<TEnumerable, TElement>(((MethodCollectionConstructorInfo)ConstructorInfo).AddMethod!);
         }
     }
 
@@ -63,8 +62,8 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
         MutableCollectionConstructor<TElement, TEnumerable> CreateDefaultConstructor()
         {
-            DebugExt.Assert(ConstructorInfo is MutableCollectionConstructorInfo);
-            return Provider.MemberAccessor.CreateMutableCollectionConstructor<TElement, TElement, TEnumerable>((MutableCollectionConstructorInfo)ConstructorInfo);
+            DebugExt.Assert(ConstructorInfo is MethodCollectionConstructorInfo);
+            return Provider.MemberAccessor.CreateMutableCollectionConstructor<TElement, TElement, TEnumerable>((MethodCollectionConstructorInfo)ConstructorInfo);
         }
     }
 
@@ -80,8 +79,8 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
         ParameterizedCollectionConstructor<TElement, TElement, TEnumerable> CreateParameterizedConstructor()
         {
-            DebugExt.Assert(ConstructorInfo is ParameterizedCollectionConstructorInfo);
-            return Provider.MemberAccessor.CreateParameterizedCollectionConstructor<TElement, TElement, TEnumerable>((ParameterizedCollectionConstructorInfo)ConstructorInfo);
+            DebugExt.Assert(ConstructorInfo is MethodCollectionConstructorInfo);
+            return Provider.MemberAccessor.CreateParameterizedCollectionConstructor<TElement, TElement, TEnumerable>((MethodCollectionConstructorInfo)ConstructorInfo);
         }
     }
 

--- a/tests/PolyType.Tests/ProviderUnderTest.cs
+++ b/tests/PolyType.Tests/ProviderUnderTest.cs
@@ -51,7 +51,7 @@ public sealed class SourceGenProviderUnderTest(SourceGenTypeShapeProvider source
 
 public sealed class ReflectionProviderUnderTest(ReflectionTypeShapeProviderOptions options) : ProviderUnderTest
 {
-    private static readonly ImmutableArray<Assembly> TypeShapeExtensionAssemblies = ImmutableArray.Create(typeof(TestCase).Assembly);
+    private static readonly ImmutableArray<Assembly> TypeShapeExtensionAssemblies = [typeof(TestCase).Assembly];
 
     public static ReflectionProviderUnderTest Emit { get; } = new(new() { UseReflectionEmit = true, TypeShapeExtensionAssemblies = TypeShapeExtensionAssemblies });
     public static ReflectionProviderUnderTest NoEmit { get; } = new(new() { UseReflectionEmit = false, TypeShapeExtensionAssemblies = TypeShapeExtensionAssemblies });


### PR DESCRIPTION
When reflection with emit disabled encounters types with unsupported span-based constructors, it will silently fall back to using no constructor at all. This PR updates that behavior so that the same metadata is always reported, with an exception being thrown if the constructor is invoked.