### PR TITLE
Ensure tuple shapes always use parameterized constructors.

### DIFF
--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -527,42 +527,20 @@ public sealed partial class Parser
 
     private static ConstructorShapeModel MapTupleConstructor(TypeId typeId, TupleDataModel tupleModel)
     {
-        if (tupleModel.IsValueTuple)
+        return new ConstructorShapeModel
         {
-            // Return the default constructor for value tuples
-            return new ConstructorShapeModel
-            {
-                DeclaringType = typeId,
-                Parameters = [],
-                RequiredMembers = [],
-                OptionalMembers = [],
-                OptionalMemberFlagsType = OptionalMemberFlagsType.None,
-                StaticFactoryName = null,
-                StaticFactoryIsProperty = false,
-                ResultRequiresCast = false,
-                IsAccessible = true,
-                CanUseUnsafeAccessors = false,
-                IsPublic = true,
-            };
-        }
-        else
-        {
-            // Return the parameterized constructor for object tuples
-            return new ConstructorShapeModel
-            {
-                DeclaringType = typeId,
-                Parameters = tupleModel.Elements.Select((p, i) => MapTupleConstructorParameter(typeId, p, i)).ToImmutableEquatableArray(),
-                RequiredMembers = [],
-                OptionalMembers = [],
-                OptionalMemberFlagsType = OptionalMemberFlagsType.None,
-                StaticFactoryName = null,
-                StaticFactoryIsProperty = false,
-                ResultRequiresCast = false,
-                IsAccessible = true,
-                CanUseUnsafeAccessors = false,
-                IsPublic = true,
-            };
-        }
+            DeclaringType = typeId,
+            Parameters = tupleModel.Elements.Select((p, i) => MapTupleConstructorParameter(typeId, p, i)).ToImmutableEquatableArray(),
+            RequiredMembers = [],
+            OptionalMembers = [],
+            OptionalMemberFlagsType = OptionalMemberFlagsType.None,
+            StaticFactoryName = null,
+            StaticFactoryIsProperty = false,
+            ResultRequiresCast = false,
+            IsAccessible = true,
+            CanUseUnsafeAccessors = false,
+            IsPublic = true,
+        };
 
         static ParameterShapeModel MapTupleConstructorParameter(TypeId typeId, PropertyDataModel tupleElement, int position)
         {

--- a/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
@@ -132,16 +132,8 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
 
         if (IsTupleType)
         {
-            if (typeof(T).IsValueType)
-            {
-                IConstructorShapeInfo ctorInfo = CreateDefaultConstructor(memberInitializers: null);
-                return Provider.CreateConstructor(this, ctorInfo);
-            }
-            else
-            {
-                IConstructorShapeInfo ctorInfo = ReflectionTypeShapeProvider.CreateTupleConstructorShapeInfo(typeof(T));
-                return Provider.CreateConstructor(this, ctorInfo);
-            }
+            IConstructorShapeInfo ctorInfo = ReflectionTypeShapeProvider.CreateTupleConstructorShapeInfo(typeof(T));
+            return Provider.CreateConstructor(this, ctorInfo);
         }
 
         PropertyShapeInfo[] allMembers;

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -488,7 +488,12 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
 
     internal static IConstructorShapeInfo CreateTupleConstructorShapeInfo(Type tupleType)
     {
-        Debug.Assert(tupleType.IsTupleType() && tupleType != typeof(ValueTuple));
+        Debug.Assert(tupleType.IsTupleType());
+
+        if (tupleType == typeof(ValueTuple))
+        {
+            return new MethodConstructorShapeInfo(tupleType, constructorMethod: null, parameters: []);
+        }
 
         if (!tupleType.IsNestedTupleRepresentation())
         {

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -141,6 +141,13 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
             return;
         }
 
+        if (testCase.IsTuple)
+        {
+            Assert.NotNull(objectShape.Constructor);
+            Assert.Equal(typeof(T).IsGenericType, objectShape.Constructor.Parameters.Count > 0);
+            Assert.All(objectShape.Constructor.Parameters, param => Assert.True(param.IsRequired));
+        }
+
         var visitor = new ConstructorTestVisitor();
         if (objectShape.Constructor is { } ctor)
         {


### PR DESCRIPTION
Fix #162.