### PR TITLE
Fix concurrency bug in lazy init of object constructor shapes

### DIFF
--- a/src/PolyType/SourceGenModel/SourceGenConstructorShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenConstructorShape.cs
@@ -1,4 +1,5 @@
 ﻿using PolyType.Abstractions;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace PolyType.SourceGenModel;
@@ -50,7 +51,10 @@ public sealed class SourceGenConstructorShape<TDeclaringType, TArgumentState> : 
     /// </summary>
     public Constructor<TArgumentState, TDeclaringType>? ParameterizedConstructorFunc { get; init; }
 
-    IReadOnlyList<IParameterShape> IConstructorShape.Parameters => _parameters ?? CommonHelpers.ExchangeIfNull(ref _parameters, (GetParametersFunc?.Invoke()).AsReadOnlyList());
+    /// <inheritdoc/>
+    public IReadOnlyList<IParameterShape> Parameters => _parameters ?? CommonHelpers.ExchangeIfNull(ref _parameters, (GetParametersFunc?.Invoke()).AsReadOnlyList());
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private IReadOnlyList<IParameterShape>? _parameters;
 
     Func<TDeclaringType> IConstructorShape<TDeclaringType, TArgumentState>.GetDefaultConstructor()

--- a/src/PolyType/SourceGenModel/SourceGenObjectTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenObjectTypeShape.cs
@@ -49,9 +49,9 @@ public sealed class SourceGenObjectTypeShape<TObject> : SourceGenTypeShape<TObje
         {
             if (!_isConstructorResolved)
             {
-                if (CreateConstructorFunc is not null)
+                if (CreateConstructorFunc?.Invoke() is { } constructor)
                 {
-                    CommonHelpers.ExchangeIfNull(ref _constructor, CreateConstructorFunc());
+                    CommonHelpers.ExchangeIfNull(ref _constructor, constructor);
                 }
 
                 Volatile.Write(ref _isConstructorResolved, true);

--- a/src/PolyType/SourceGenModel/SourceGenObjectTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenObjectTypeShape.cs
@@ -1,4 +1,6 @@
-﻿using PolyType.Abstractions;
+﻿using System.Data;
+using System.Diagnostics;
+using PolyType.Abstractions;
 
 namespace PolyType.SourceGenModel;
 
@@ -34,16 +36,24 @@ public sealed class SourceGenObjectTypeShape<TObject> : SourceGenTypeShape<TObje
     /// <inheritdoc/>
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitObject(this, state);
 
-    IReadOnlyList<IPropertyShape> IObjectTypeShape.Properties => _properties ?? CommonHelpers.ExchangeIfNull(ref _properties, (CreatePropertiesFunc?.Invoke()).AsReadOnlyList());
+    /// <inheritdoc/>
+    public IReadOnlyList<IPropertyShape> Properties => _properties ?? CommonHelpers.ExchangeIfNull(ref _properties, (CreatePropertiesFunc?.Invoke()).AsReadOnlyList());
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private IReadOnlyList<IPropertyShape>? _properties;
 
-    IConstructorShape? IObjectTypeShape.Constructor
+    /// <inheritdoc/>
+    public IConstructorShape? Constructor
     {
         get
         {
             if (!_isConstructorResolved)
             {
-                _constructor = CreateConstructorFunc?.Invoke();
+                if (CreateConstructorFunc is not null)
+                {
+                    CommonHelpers.ExchangeIfNull(ref _constructor, CreateConstructorFunc());
+                }
+
                 Volatile.Write(ref _isConstructorResolved, true);
             }
 
@@ -52,5 +62,7 @@ public sealed class SourceGenObjectTypeShape<TObject> : SourceGenTypeShape<TObje
     }
 
     private bool _isConstructorResolved;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private IConstructorShape? _constructor;
 }


### PR DESCRIPTION
Fixes https://github.com/AArnott/Nerdbank.MessagePack/issues/485

Another concurrency bug in lazy initialization was causing unstable tests in Nerdbank.MessagePack where the deserializer would incorrectly report that required properties were missing from the deserialized stream when in fact they were present.

Before the fix in addition to tests failing randomly in my CI/PR, I was able to get it to fail using Run Until Failure in VS. The first time it failed on iteration 20. The second time it failed on the first iteration. With the fix, I got through 200 iterations without any failures.

I also improve the debugger display of the properties on these shapes.