### PR TITLE
Use precise assembly versioning for roslyn analyzer assembly

### DIFF
--- a/src/PolyType.SourceGenerator/version.json
+++ b/src/PolyType.SourceGenerator/version.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "inherit": true,
+  "assemblyVersion": {
+    "precision": "revision"
+  }
+}


### PR DESCRIPTION
Using a precise assembly version is important so that .NET Framework processes running the C# compiler won't malfunction when building multiple projects that use a variety of PolyType versions.

This version.json was already present in the PolyType.Roslyn project directory. But since the source generator that ships with PolyType builds from another project, we needed it there too.