### PR TITLE
Allow duplicate element tracking for mutable collections.

### DIFF
--- a/docs/core-abstractions.md
+++ b/docs/core-abstractions.md
@@ -581,7 +581,7 @@ public partial interface IEnumerableTypeShape<TEnumerable, TElement>
 
     // Implemented by CollectionConstructionStrategy.Mutable types
     MutableCollectionConstructor<TKey, TEnumerable> GetDefaultConstructor();
-    Setter<TEnumerable, TElement> GetAddElement();
+    EnumerableAppender<TEnumerable, TElement> GetAppender();
 
     // Implemented by CollectionConstructionStrategy.Parameterized types
     ParameterizedCollectionConstructor<TKey, TElement, TEnumerable> GetParameterizedConstructor();
@@ -604,11 +604,11 @@ class EmptyConstructorVisitor : TypeShapeVisitor
         {
             case CollectionConstructionStrategy.Mutable:
                 var defaultCtor = typeShape.GetDefaultConstructor();
-                var addElement = typeShape.GetAddElement();
+                var appender = typeShape.GetAppender();
                 return new Func<TEnumerable>(() =>
                 {
                     TEnumerable value = defaultCtor();
-                    for (int i = 0; i < size; i++) addElement(ref value, elementFactory());
+                    for (int i = 0; i < size; i++) appender(ref value, elementFactory());
                     return value;
                 });
 

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -12,3 +12,4 @@ netstandard
 numerics
 polyfilled
 unloadability
+Appender

--- a/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
@@ -119,7 +119,7 @@ public static partial class CborSerializer
                         valueConverter,
                         getDictionary,
                         dictionaryShape.GetMutableConstructor(),
-                        dictionaryShape.GetInserter()),
+                        dictionaryShape.GetInserter(DictionaryInsertionMode.Discard)),
 
                 CollectionConstructionStrategy.Parameterized =>
                     new CborParameterizedDictionaryConverter<TDictionary, TKey, TValue>(

--- a/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
@@ -93,7 +93,7 @@ public static partial class CborSerializer
                         elementConverter,
                         getEnumerable,
                         enumerableShape.GetMutableConstructor(),
-                        enumerableShape.GetAddElement()),
+                        enumerableShape.GetAppender()),
 
                 CollectionConstructionStrategy.Parameterized =>
                     new CborParameterizedEnumerableConverter<TEnumerable, TElement>(
@@ -119,7 +119,7 @@ public static partial class CborSerializer
                         valueConverter,
                         getDictionary,
                         dictionaryShape.GetMutableConstructor(),
-                        dictionaryShape.GetAddKeyValuePair()),
+                        dictionaryShape.GetInserter()),
 
                 CollectionConstructionStrategy.Parameterized =>
                     new CborParameterizedDictionaryConverter<TDictionary, TKey, TValue>(

--- a/src/PolyType.Examples/CborSerializer/Converters/CborDictionaryConverter.cs
+++ b/src/PolyType.Examples/CborSerializer/Converters/CborDictionaryConverter.cs
@@ -51,9 +51,9 @@ internal sealed class CborMutableDictionaryConverter<TDictionary, TKey, TValue>(
     CborConverter<TValue> valueConverter,
     Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> getDictionary,
     MutableCollectionConstructor<TKey, TDictionary> createObject,
-    Setter<TDictionary, KeyValuePair<TKey, TValue>> addDelegate) : CborDictionaryConverter<TDictionary, TKey, TValue>(keyConverter, valueConverter, getDictionary)
+    DictionaryInserter<TDictionary, TKey, TValue> inserter) : CborDictionaryConverter<TDictionary, TKey, TValue>(keyConverter, valueConverter, getDictionary)
 {
-    private readonly Setter<TDictionary, KeyValuePair<TKey, TValue>> _addDelegate = addDelegate;
+    private readonly DictionaryInserter<TDictionary, TKey, TValue> _inserter = inserter;
 
     public override TDictionary? Read(CborReader reader)
     {
@@ -68,13 +68,13 @@ internal sealed class CborMutableDictionaryConverter<TDictionary, TKey, TValue>(
 
         CborConverter<TKey> keyConverter = _keyConverter;
         CborConverter<TValue> valueConverter = _valueConverter;
-        Setter<TDictionary, KeyValuePair<TKey, TValue>> addDelegate = _addDelegate;
+        DictionaryInserter<TDictionary, TKey, TValue> inserter = _inserter;
 
         while (reader.PeekState() != CborReaderState.EndMap)
         {
             TKey key = keyConverter.Read(reader)!;
             TValue value = valueConverter.Read(reader)!;
-            addDelegate(ref result, new(key, value));
+            inserter(ref result, key, value);
         }
 
         reader.ReadEndMap();

--- a/src/PolyType.Examples/CborSerializer/Converters/CborDictionaryConverter.cs
+++ b/src/PolyType.Examples/CborSerializer/Converters/CborDictionaryConverter.cs
@@ -74,7 +74,11 @@ internal sealed class CborMutableDictionaryConverter<TDictionary, TKey, TValue>(
         {
             TKey key = keyConverter.Read(reader)!;
             TValue value = valueConverter.Read(reader)!;
-            inserter(ref result, key, value);
+            if (!inserter(ref result, key, value))
+            {
+                Throw(key);
+                static void Throw(TKey key) => throw new ArgumentException($"Found duplicate key '{key}.'");
+            }
         }
 
         reader.ReadEndMap();

--- a/src/PolyType.Examples/CborSerializer/Converters/CborEnumerableConverter.cs
+++ b/src/PolyType.Examples/CborSerializer/Converters/CborEnumerableConverter.cs
@@ -46,9 +46,9 @@ internal sealed class CborMutableEnumerableConverter<TEnumerable, TElement>(
     CborConverter<TElement> elementConverter,
     Func<TEnumerable, IEnumerable<TElement>> getEnumerable,
     MutableCollectionConstructor<TElement, TEnumerable> createObject,
-    Setter<TEnumerable, TElement> addDelegate) : CborEnumerableConverter<TEnumerable, TElement>(elementConverter, getEnumerable)
+    EnumerableAppender<TEnumerable, TElement> appender) : CborEnumerableConverter<TEnumerable, TElement>(elementConverter, getEnumerable)
 {
-    private readonly Setter<TEnumerable, TElement> _addDelegate = addDelegate;
+    private readonly EnumerableAppender<TEnumerable, TElement> _appender = appender;
 
     public override TEnumerable? Read(CborReader reader)
     {
@@ -62,12 +62,12 @@ internal sealed class CborMutableEnumerableConverter<TEnumerable, TElement>(
         TEnumerable result = createObject(new() { Capacity = definiteLength });
 
         CborConverter<TElement> elementConverter = _elementConverter;
-        Setter<TEnumerable, TElement> addDelegate = _addDelegate;
+        EnumerableAppender<TEnumerable, TElement> appender = _appender;
 
         while (reader.PeekState() != CborReaderState.EndArray)
         {
             TElement? element = elementConverter.Read(reader);
-            addDelegate(ref result, element!);
+            appender(ref result, element!);
         }
 
         reader.ReadEndArray();

--- a/src/PolyType.Examples/Cloner/Cloner.Builder.cs
+++ b/src/PolyType.Examples/Cloner/Cloner.Builder.cs
@@ -144,7 +144,7 @@ public static partial class Cloner
             {
                 case CollectionConstructionStrategy.Mutable:
                     var defaultCtor = enumerableShape.GetMutableConstructor();
-                    var addMember = enumerableShape.GetAddElement();
+                    var appender = enumerableShape.GetAppender();
                     return new Func<TEnumerable?, TEnumerable?>(source =>
                     {
                         if (source is null)
@@ -155,7 +155,7 @@ public static partial class Cloner
                         var target = defaultCtor();
                         foreach (var element in getEnumerable(source))
                         {
-                            addMember(ref target, elementCloner(element)!);
+                            appender(ref target, elementCloner(element)!);
                         }
 
                         return target;
@@ -193,7 +193,7 @@ public static partial class Cloner
             {
                 case CollectionConstructionStrategy.Mutable:
                     var defaultCtor = dictionaryShape.GetMutableConstructor();
-                    var addEntry = dictionaryShape.GetAddKeyValuePair();
+                    var inserter = dictionaryShape.GetInserter();
                     return new Func<TDictionary?, TDictionary?>(source =>
                     {
                         if (source is null)
@@ -204,8 +204,7 @@ public static partial class Cloner
                         var target = defaultCtor();
                         foreach (var entry in getDictionary(source))
                         {
-                            KeyValuePair<TKey, TValue> targetEntry = new(keyCloner(entry.Key)!, valueCloner(entry.Value)!);
-                            addEntry(ref target, targetEntry);
+                            inserter(ref target, keyCloner(entry.Key)!, valueCloner(entry.Value)!);
                         }
 
                         return target;

--- a/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
+++ b/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
@@ -201,6 +201,7 @@ public static partial class ConfigurationBinderTS
                 
                 case CollectionConstructionStrategy.Parameterized:
                     ParameterizedCollectionConstructor<TKey, KeyValuePair<TKey, TValue>, TDictionary> spanCtor = dictionaryShape.GetParameterizedConstructor();
+                    var duplicateKeyValidator = dictionaryShape.CreateDuplicateKeyValidator();
                     return new Func<IConfiguration, TDictionary?>(configuration =>
                     {
                         if (IsNullConfiguration(configuration))
@@ -220,7 +221,10 @@ public static partial class ConfigurationBinderTS
                             buffer.Add(entry);
                         }
 
-                        return spanCtor(buffer.AsSpan());
+                        var span = buffer.AsSpan();
+                        var finalDict = spanCtor(span);
+                        duplicateKeyValidator.ValidatePotentialDuplicates(finalDict, span);
+                        return finalDict;
                     });
                 
                 default:

--- a/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
+++ b/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
@@ -121,7 +121,7 @@ public static partial class ConfigurationBinderTS
             {
                 case CollectionConstructionStrategy.Mutable:
                     MutableCollectionConstructor<TElement, TEnumerable> defaultCtor = enumerableShape.GetMutableConstructor();
-                    Setter<TEnumerable, TElement> addElement = enumerableShape.GetAddElement();
+                    EnumerableAppender<TEnumerable, TElement> appender = enumerableShape.GetAppender();
                     return new Func<IConfiguration, TEnumerable?>(configuration =>
                     {
                         if (IsNullConfiguration(configuration))
@@ -133,7 +133,7 @@ public static partial class ConfigurationBinderTS
                         foreach (IConfigurationSection child in configuration.GetChildren())
                         {
                             TElement element = elementBinder(child);
-                            addElement(ref enumerable, element);
+                            appender(ref enumerable, element);
                         }
 
                         return enumerable;
@@ -177,7 +177,7 @@ public static partial class ConfigurationBinderTS
             {
                 case CollectionConstructionStrategy.Mutable:
                     MutableCollectionConstructor<TKey, TDictionary> defaultCtor = dictionaryShape.GetMutableConstructor();
-                    Setter<TDictionary, KeyValuePair<TKey, TValue>> addEntry = dictionaryShape.GetAddKeyValuePair();
+                    var inserter = dictionaryShape.GetInserter();
                     return new Func<IConfiguration, TDictionary?>(configuration =>
                     {
                         if (IsNullConfiguration(configuration))
@@ -193,8 +193,7 @@ public static partial class ConfigurationBinderTS
                                 continue;
                             }
 
-                            KeyValuePair<TKey, TValue> entry = new(keyBinder(section), valueBinder(section));
-                            addEntry(ref dict, entry);
+                            inserter(ref dict, keyBinder(section), valueBinder(section));
                         }
 
                         return dict;

--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonDictionaryConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonDictionaryConverter.cs
@@ -86,10 +86,10 @@ internal sealed class JsonMutableDictionaryConverter<TDictionary, TKey, TValue>(
     JsonConverter<TValue> valueConverter,
     IDictionaryTypeShape<TDictionary, TKey, TValue> shape,
     MutableCollectionConstructor<TKey, TDictionary> createObject,
-    Setter<TDictionary, KeyValuePair<TKey, TValue>> addDelegate) : JsonDictionaryConverter<TDictionary, TKey, TValue>(keyConverter, valueConverter, shape)
+    DictionaryInserter<TDictionary, TKey, TValue> inserter) : JsonDictionaryConverter<TDictionary, TKey, TValue>(keyConverter, valueConverter, shape)
     where TKey : notnull
 {
-    private readonly Setter<TDictionary, KeyValuePair<TKey, TValue>> _addDelegate = addDelegate;
+    private readonly DictionaryInserter<TDictionary, TKey, TValue> _inserter = inserter;
 
     public override TDictionary? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -105,7 +105,7 @@ internal sealed class JsonMutableDictionaryConverter<TDictionary, TKey, TValue>(
 
         JsonConverter<TKey> keyConverter = _keyConverter;
         JsonConverter<TValue> valueConverter = _valueConverter;
-        Setter<TDictionary, KeyValuePair<TKey, TValue>> addDelegate = _addDelegate;
+        DictionaryInserter<TDictionary, TKey, TValue> inserter = _inserter;
 
         while (reader.TokenType != JsonTokenType.EndObject)
         {
@@ -124,7 +124,7 @@ internal sealed class JsonMutableDictionaryConverter<TDictionary, TKey, TValue>(
             TValue value = valueConverter.Read(ref reader, typeof(TValue), options)!;
             reader.EnsureRead();
 
-            addDelegate(ref result, new(key, value));
+            inserter(ref result, key, value);
         }
 
         return result;

--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonEnumerableConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonEnumerableConverter.cs
@@ -73,9 +73,9 @@ internal sealed class JsonMutableEnumerableConverter<TEnumerable, TElement>(
     JsonConverter<TElement> elementConverter,
     IEnumerableTypeShape<TEnumerable, TElement> typeShape,
     MutableCollectionConstructor<TElement, TEnumerable> createObject,
-    Setter<TEnumerable, TElement> addDelegate) : JsonEnumerableConverter<TEnumerable, TElement>(elementConverter, typeShape)
+    EnumerableAppender<TEnumerable, TElement> appender) : JsonEnumerableConverter<TEnumerable, TElement>(elementConverter, typeShape)
 {
-    private readonly Setter<TEnumerable, TElement> _addDelegate = addDelegate;
+    private readonly EnumerableAppender<TEnumerable, TElement> _appender = appender;
 
     public override TEnumerable? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -90,12 +90,12 @@ internal sealed class JsonMutableEnumerableConverter<TEnumerable, TElement>(
         reader.EnsureRead();
 
         JsonConverter<TElement> elementConverter = _elementConverter;
-        Setter<TEnumerable, TElement> addDelegate = _addDelegate;
+        EnumerableAppender<TEnumerable, TElement> appender = _appender;
 
         while (reader.TokenType != JsonTokenType.EndArray)
         {
             TElement? element = elementConverter.Read(ref reader, typeof(TElement), options);
-            addDelegate(ref result, element!);
+            appender(ref result, element!);
             reader.EnsureRead();
         }
 

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
@@ -91,7 +91,7 @@ public static partial class JsonSerializerTS
                         elementConverter,
                         enumerableShape,
                         enumerableShape.GetMutableConstructor(),
-                        enumerableShape.GetAddElement()),
+                        enumerableShape.GetAppender()),
 
                 CollectionConstructionStrategy.Parameterized => 
                     new JsonParameterizedEnumerableConverter<TEnumerable, TElement>(
@@ -115,7 +115,7 @@ public static partial class JsonSerializerTS
                         valueConverter,
                         dictionaryShape,
                         dictionaryShape.GetMutableConstructor(),
-                        dictionaryShape.GetAddKeyValuePair()),
+                        dictionaryShape.GetInserter()),
 
                 CollectionConstructionStrategy.Parameterized => 
                     new JsonParameterizedDictionaryConverter<TDictionary, TKey, TValue>(

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
@@ -115,7 +115,7 @@ public static partial class JsonSerializerTS
                         valueConverter,
                         dictionaryShape,
                         dictionaryShape.GetMutableConstructor(),
-                        dictionaryShape.GetInserter()),
+                        dictionaryShape.GetInserter(DictionaryInsertionMode.Overwrite)),
 
                 CollectionConstructionStrategy.Parameterized => 
                     new JsonParameterizedDictionaryConverter<TDictionary, TKey, TValue>(

--- a/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
+++ b/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
@@ -250,7 +250,7 @@ public static partial class Mapper
                 {
                     case CollectionConstructionStrategy.Mutable:
                         var defaultCtor = enumerableShape.GetMutableConstructor();
-                        var addElement = enumerableShape.GetAddElement();
+                        var appender = enumerableShape.GetAppender();
                         return new Mapper<TSourceEnumerable, TTargetEnumerable>(source =>
                         {
                             if (source is null)
@@ -261,7 +261,7 @@ public static partial class Mapper
                             var target = defaultCtor();
                             foreach (TSourceElement sourceElement in sourceGetEnumerable(source))
                             {
-                                addElement(ref target, elementMapper(sourceElement)!);
+                                appender(ref target, elementMapper(sourceElement)!);
                             }
 
                             return target;
@@ -300,7 +300,7 @@ public static partial class Mapper
                 {
                     case CollectionConstructionStrategy.Mutable:
                         var defaultCtor = targetDictionary.GetMutableConstructor();
-                        var addEntry = targetDictionary.GetAddKeyValuePair();
+                        var inserter = targetDictionary.GetInserter();
                         return new Mapper<TSourceDictionary, TTargetDictionary>(source =>
                         {
                             if (source is null)
@@ -311,8 +311,7 @@ public static partial class Mapper
                             var target = defaultCtor();
                             foreach (var sourceEntry in sourceGetDictionary(source))
                             {
-                                KeyValuePair<TTargetKey, TTargetValue> entry = new(keyMapper(sourceEntry.Key), valueMapper(sourceEntry.Value)!);
-                                addEntry(ref target, entry);
+                                inserter(ref target, keyMapper(sourceEntry.Key), valueMapper(sourceEntry.Value)!);
                             }
 
                             return target;

--- a/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
+++ b/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
@@ -165,7 +165,7 @@ public partial class RandomGenerator
             {
                 case CollectionConstructionStrategy.Mutable:
                     MutableCollectionConstructor<TElement, TEnumerable> defaultCtor = enumerableShape.GetMutableConstructor();
-                    Setter<TEnumerable, TElement> addElementFunc = enumerableShape.GetAddElement();
+                    EnumerableAppender<TEnumerable, TElement> addElementFunc = enumerableShape.GetAppender();
                     return new RandomGenerator<TEnumerable>((Random random, int size) =>
                     {
                         if (size == 0)
@@ -220,7 +220,7 @@ public partial class RandomGenerator
             {
                 case CollectionConstructionStrategy.Mutable:
                     MutableCollectionConstructor<TKey, TDictionary> defaultCtorFunc = dictionaryShape.GetMutableConstructor();
-                    Setter<TDictionary, KeyValuePair<TKey, TValue>> addKeyValuePairFunc = dictionaryShape.GetAddKeyValuePair();
+                    DictionaryInserter<TDictionary, TKey, TValue> inserter = dictionaryShape.GetInserter();
                     return new RandomGenerator<TDictionary>((Random random, int size) =>
                     {
                         if (size == 0)
@@ -234,9 +234,9 @@ public partial class RandomGenerator
 
                         for (int i = 0; i < count; i++)
                         {
-                            addKeyValuePairFunc(ref obj,
-                                new(keyGenerator(random, entrySize),
-                                    valueGenerator(random, entrySize)));
+                            inserter(ref obj,
+                                keyGenerator(random, entrySize),
+                                valueGenerator(random, entrySize));
                         }
 
                         return obj;

--- a/src/PolyType.Examples/Utilities/DuplicateDictionaryKeyValidator.cs
+++ b/src/PolyType.Examples/Utilities/DuplicateDictionaryKeyValidator.cs
@@ -1,0 +1,84 @@
+﻿using PolyType.Abstractions;
+
+namespace PolyType.Utilities;
+
+/// <summary>
+/// Performs post-hoc duplicate key detection for parameterized dictionary constructors.
+/// </summary>
+public static class DuplicateDictionaryKeyValidator
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="DuplicateDictionaryKeyValidator{TDictionary, TKey, TValue}"/>.
+    /// </summary>
+    /// <typeparam name="TDictionary">The type of the dictionary.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="dictionaryTypeShape">The dictionary type shape.</param>
+    /// <param name="throwOnDuplicateKey">Function to throw an exception on duplicate key.</param>
+    public static DuplicateDictionaryKeyValidator<TDictionary, TKey, TValue> CreateDuplicateKeyValidator<TDictionary, TKey, TValue>(
+        this IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryTypeShape,
+        Func<TKey?, Exception>? throwOnDuplicateKey = null)
+        where TKey : notnull
+    {
+        throwOnDuplicateKey ??= key => new ArgumentException($"The key '{key}' already exists in the dictionary.", nameof(key));
+        return new DuplicateDictionaryKeyValidator<TDictionary, TKey, TValue>(dictionaryTypeShape, throwOnDuplicateKey);
+    }
+}
+
+/// <summary>
+/// Performs post-hoc duplicate key detection for parameterized dictionary constructors.
+/// </summary>
+public sealed class DuplicateDictionaryKeyValidator<TDictionary, TKey, TValue>
+    where TKey : notnull
+{
+    private readonly Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> _getDictionary;
+    private readonly Func<TKey, Exception> _throwOnDuplicateKey;
+
+    internal DuplicateDictionaryKeyValidator(
+        IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryTypeShape,
+        Func<TKey, Exception> throwOnDuplicateKey)
+    {
+        _getDictionary = dictionaryTypeShape.GetGetDictionary();
+        _throwOnDuplicateKey = throwOnDuplicateKey;
+    }
+
+    /// <summary>
+    /// Checks if the final dictionary was constructed with potential duplicate key from the source buffer.
+    /// </summary>
+    /// <param name="finalDictionary">The constructed final dictionary.</param>
+    /// <param name="sourceBuffer">The source buffer used to construct the dictionary.</param>
+    /// <param name="options">The construction options used to build the dictionary.</param>
+    public void ValidatePotentialDuplicates(
+        in TDictionary finalDictionary,
+        ReadOnlySpan<KeyValuePair<TKey, TValue>> sourceBuffer,
+        CollectionConstructionOptions<TKey> options = default)
+    {
+        var idictionary = _getDictionary(finalDictionary);
+        if (idictionary.Count < sourceBuffer.Length)
+        {
+            SlowIdentifyDuplicateKeyAndThrow(sourceBuffer, options);
+        }
+    }
+
+    private void SlowIdentifyDuplicateKeyAndThrow(
+        ReadOnlySpan<KeyValuePair<TKey, TValue>> sourceBuffer,
+        CollectionConstructionOptions<TKey> options)
+    {
+        ISet<TKey> keys = options switch
+        {
+            { EqualityComparer: { } cmp } => new HashSet<TKey>(cmp),
+            { Comparer: { } cmp } => new SortedSet<TKey>(cmp),
+            _ => new HashSet<TKey>()
+        };
+
+        foreach (var kvp in sourceBuffer)
+        {
+            if (!keys.Add(kvp.Key))
+            {
+                throw _throwOnDuplicateKey(kvp.Key);
+            }
+        }
+
+        throw new ArgumentException("The payload was found to contain duplicate keys");
+    }
+}

--- a/src/PolyType.Examples/XmlSerializer/Converters/XmlDictionaryConverter.cs
+++ b/src/PolyType.Examples/XmlSerializer/Converters/XmlDictionaryConverter.cs
@@ -45,11 +45,11 @@ internal sealed class XmlMutableDictionaryConverter<TDictionary, TKey, TValue>(
     XmlConverter<TValue> valueConverter,
     Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> getEnumerable,
     MutableCollectionConstructor<TKey, TDictionary> createObject,
-    Setter<TDictionary, KeyValuePair<TKey, TValue>> addDelegate)
+    DictionaryInserter<TDictionary, TKey, TValue> inserter)
     : XmlDictionaryConverter<TDictionary, TKey, TValue>(keyConverter, valueConverter, getEnumerable)
     where TKey : notnull
 {
-    private readonly Setter<TDictionary, KeyValuePair<TKey, TValue>> _addDelegate = addDelegate;
+    private readonly DictionaryInserter<TDictionary, TKey, TValue> _inserter = inserter;
 
     public override TDictionary? Read(XmlReader reader)
     {
@@ -68,7 +68,7 @@ internal sealed class XmlMutableDictionaryConverter<TDictionary, TKey, TValue>(
 
         XmlConverter<TKey> keyConverter = _keyConverter;
         XmlConverter<TValue> valueConverter = _valueConverter;
-        Setter<TDictionary, KeyValuePair<TKey, TValue>> addDelegate = _addDelegate;
+        DictionaryInserter<TDictionary, TKey, TValue> inserter = _inserter;
         
         reader.ReadStartElement();
         while (reader.NodeType != XmlNodeType.EndElement)
@@ -81,7 +81,7 @@ internal sealed class XmlMutableDictionaryConverter<TDictionary, TKey, TValue>(
             reader.ReadStartElement();
             TKey key = keyConverter.Read(reader)!;
             TValue value = valueConverter.Read(reader)!;
-            addDelegate(ref result, new(key, value));
+            inserter(ref result, key, value);
             reader.ReadEndElement();
         }
 

--- a/src/PolyType.Examples/XmlSerializer/Converters/XmlEnumerableConverter.cs
+++ b/src/PolyType.Examples/XmlSerializer/Converters/XmlEnumerableConverter.cs
@@ -36,10 +36,10 @@ internal sealed class XmlMutableEnumerableConverter<TEnumerable, TElement>(
     XmlConverter<TElement> elementConverter,
     Func<TEnumerable, IEnumerable<TElement>> getEnumerable,
     MutableCollectionConstructor<TElement, TEnumerable> createObject,
-    Setter<TEnumerable, TElement> addDelegate)
+    EnumerableAppender<TEnumerable, TElement> appender)
     : XmlEnumerableConverter<TEnumerable, TElement>(elementConverter, getEnumerable)
 {
-    private readonly Setter<TEnumerable, TElement> _addDelegate = addDelegate;
+    private readonly EnumerableAppender<TEnumerable, TElement> _appender = appender;
 
     public override TEnumerable? Read(XmlReader reader)
     {
@@ -58,7 +58,7 @@ internal sealed class XmlMutableEnumerableConverter<TEnumerable, TElement>(
 
         reader.ReadStartElement();
         XmlConverter<TElement> elementConverter = _elementConverter;
-        Setter<TEnumerable, TElement> addDelegate = _addDelegate;
+        EnumerableAppender<TEnumerable, TElement> appender = _appender;
 
         while (reader.NodeType != XmlNodeType.EndElement)
         {
@@ -68,7 +68,7 @@ internal sealed class XmlMutableEnumerableConverter<TEnumerable, TElement>(
             }
 
             TElement? element = elementConverter.Read(reader);
-            addDelegate(ref result, element!);
+            appender(ref result, element!);
         }
 
         reader.ReadEndElement();

--- a/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
+++ b/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
@@ -108,7 +108,7 @@ public static partial class XmlSerializer
                         valueConverter,
                         getEnumerable,
                         dictionaryShape.GetMutableConstructor(),
-                        dictionaryShape.GetInserter()),
+                        dictionaryShape.GetInserter(DictionaryInsertionMode.Throw)),
 
                 CollectionConstructionStrategy.Parameterized => 
                     new XmlParameterizedDictionaryConverter<TDictionary, TKey, TValue>(

--- a/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
+++ b/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
@@ -84,7 +84,7 @@ public static partial class XmlSerializer
                         elementConverter,
                         getEnumerable,
                         enumerableShape.GetMutableConstructor(),
-                        enumerableShape.GetAddElement()),
+                        enumerableShape.GetAppender()),
                 CollectionConstructionStrategy.Parameterized => 
                     new XmlParameterizedEnumerableConverter<TEnumerable, TElement>(
                         elementConverter,
@@ -108,7 +108,7 @@ public static partial class XmlSerializer
                         valueConverter,
                         getEnumerable,
                         dictionaryShape.GetMutableConstructor(),
-                        dictionaryShape.GetAddKeyValuePair()),
+                        dictionaryShape.GetInserter()),
 
                 CollectionConstructionStrategy.Parameterized => 
                     new XmlParameterizedDictionaryConverter<TDictionary, TKey, TValue>(

--- a/src/PolyType.Roslyn/KnownSymbols.cs
+++ b/src/PolyType.Roslyn/KnownSymbols.cs
@@ -51,6 +51,12 @@ public class KnownSymbols(Compilation compilation)
     private Option<INamedTypeSymbol?> _IReadOnlySetOfT;
 
     /// <summary>
+    /// The type symbol for IImmutableSet{T}.
+    /// </summary>
+    public INamedTypeSymbol? IImmutableSetOfT => GetOrResolveType("System.Collections.Immutable.IImmutableSet`1", ref _IImmutableSetOfT);
+    private Option<INamedTypeSymbol?> _IImmutableSetOfT;
+
+    /// <summary>
     /// The type symbol for <see cref="IDictionary{TKey, TValue}"/>.
     /// </summary>
     public INamedTypeSymbol? IDictionaryOfTKeyTValue => GetOrResolveType("System.Collections.Generic.IDictionary`2", ref _IDictionaryOfTKeyTValue);

--- a/src/PolyType.Roslyn/KnownSymbols.cs
+++ b/src/PolyType.Roslyn/KnownSymbols.cs
@@ -45,6 +45,12 @@ public class KnownSymbols(Compilation compilation)
     private Option<INamedTypeSymbol?> _IReadOnlyDictionaryOfTKeyTValue;
 
     /// <summary>
+    /// The type symbol for IReadOnlySet{T}.
+    /// </summary>
+    public INamedTypeSymbol? IReadOnlySetOfT => GetOrResolveType("System.Collections.Generic.IReadOnlySet`1", ref _IReadOnlySetOfT);
+    private Option<INamedTypeSymbol?> _IReadOnlySetOfT;
+
+    /// <summary>
     /// The type symbol for <see cref="IDictionary{TKey, TValue}"/>.
     /// </summary>
     public INamedTypeSymbol? IDictionaryOfTKeyTValue => GetOrResolveType("System.Collections.Generic.IDictionary`2", ref _IDictionaryOfTKeyTValue);
@@ -147,6 +153,18 @@ public class KnownSymbols(Compilation compilation)
     private Option<INamedTypeSymbol?> _ICollectionOfT;
 
     /// <summary>
+    /// The type symbol for <see cref="ISet{T}"/>.
+    /// </summary>
+    public INamedTypeSymbol? ISetOfT => GetOrResolveType("System.Collections.Generic.ISet`1", ref _ISetOfT);
+    private Option<INamedTypeSymbol?> _ISetOfT;
+
+    /// <summary>
+    /// The type symbol for <see cref="System.Collections.ICollection"/>.
+    /// </summary>
+    public INamedTypeSymbol? ICollection => GetOrResolveType("System.Collections.ICollection", ref _ICollection);
+    private Option<INamedTypeSymbol?> _ICollection;
+
+    /// <summary>
     /// The type symbol for <see cref="System.Collections.IList"/>.
     /// </summary>
     public INamedTypeSymbol? IList => GetOrResolveType("System.Collections.IList", ref _IList);
@@ -205,7 +223,13 @@ public class KnownSymbols(Compilation compilation)
     /// </summary>
     public INamedTypeSymbol? ImmutableSortedDictionary => GetOrResolveType("System.Collections.Immutable.ImmutableSortedDictionary`2", ref _ImmutableSortedDictionary);
     private Option<INamedTypeSymbol?> _ImmutableSortedDictionary;
-    
+
+    /// <summary>
+    /// The type symbol for <see cref="System.Collections.Immutable.IImmutableDictionary{TKey, TValue}"/>.
+    /// </summary>
+    public INamedTypeSymbol? IImmutableDictionary => GetOrResolveType("System.Collections.Immutable.IImmutableDictionary`2", ref _IImmutableDictionary);
+    private Option<INamedTypeSymbol?> _IImmutableDictionary;
+
     /// <summary>
     /// The type symbol for FrozenDictionary.
     /// </summary>

--- a/src/PolyType.Roslyn/Model/DictionaryDataModel.cs
+++ b/src/PolyType.Roslyn/Model/DictionaryDataModel.cs
@@ -41,9 +41,9 @@ public sealed class DictionaryDataModel : TypeDataModel
     public required ImmutableArray<CollectionConstructorParameter> FactorySignature { get; init; }
 
     /// <summary>
-    /// <see langword="true"/> if the dictionary type only exposes an indexer via an explicit interface implementation of either <see cref="IDictionary{TKey, TValue}"/> or <see cref="IDictionary"/>.
+    /// Gets the available insertion modes supported by the dictionary type if mutable.
     /// </summary>
-    public required bool IndexerIsExplicitInterfaceImplementation { get; init; }
+    public required DictionaryInsertionMode AvailableInsertionModes { get; init; }
 }
 
 /// <summary>
@@ -65,4 +65,46 @@ public enum DictionaryKind
     /// The type implements <see cref="System.Collections.IDictionary"/>.
     /// </summary>
     IDictionary,
+}
+
+/// <summary>
+/// Identifies the insertion models available to the dictionary.
+/// </summary>
+[Flags]
+public enum DictionaryInsertionMode
+{
+    /// <summary>
+    /// No available insertion mode.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Dictionary exposes a settable indexer.
+    /// </summary>
+    SetItem = 1,
+
+    /// <summary>
+    /// Dictionary exposes a "TryAdd" method,
+    /// </summary>
+    TryAdd = 2,
+
+    /// <summary>
+    /// Dictionary exposes an "Add" method.
+    /// </summary>
+    Add = 4,
+
+    /// <summary>
+    /// Dictionary supports emulating "TryAdd" using a combination of "ContainsKey" and "Add".
+    /// </summary>
+    ContainsKeyAdd = 8,
+
+    /// <summary>
+    /// Dictionary explicitly implements <see cref="IDictionary{TKey, TValue}"/>.
+    /// </summary>
+    ExplicitIDictionaryOfT = 16,
+
+    /// <summary>
+    /// Dictionary explicitly implements <see cref="IDictionary"/>.
+    /// </summary>
+    ExplicitIDictionary = 32,
 }

--- a/src/PolyType.Roslyn/Model/EnumerableDataModel.cs
+++ b/src/PolyType.Roslyn/Model/EnumerableDataModel.cs
@@ -48,6 +48,11 @@ public sealed class EnumerableDataModel : TypeDataModel
     public required int Rank { get; init; }
 
     /// <summary>
+    /// Indicates whether the enumerable is a known set type.
+    /// </summary>
+    public required bool IsSetType { get; init; }
+
+    /// <summary>
     ///  Gets the insertion mode supported by the enumerable type if mutable.
     /// </summary>
     public required EnumerableInsertionMode InsertionMode { get; init; }

--- a/src/PolyType.Roslyn/Model/EnumerableDataModel.cs
+++ b/src/PolyType.Roslyn/Model/EnumerableDataModel.cs
@@ -30,7 +30,7 @@ public sealed class EnumerableDataModel : TypeDataModel
     /// Instance method used for appending an element to the collection.
     /// Implies that the collection also has an accessible default constructor.
     /// </summary>
-    public required IMethodSymbol? AddElementMethod { get; init; }
+    public required IMethodSymbol? AppendMethod { get; init; }
 
     /// <summary>
     /// Constructor or static factory method for the collection.
@@ -48,9 +48,9 @@ public sealed class EnumerableDataModel : TypeDataModel
     public required int Rank { get; init; }
 
     /// <summary>
-    /// <see langword="true"/> if the enumerable type only exposes an add method via an explicit interface implementation of either <see cref="ICollection{T}"/> or <see cref="ICollection"/>.
+    ///  Gets the insertion mode supported by the enumerable type if mutable.
     /// </summary>
-    public required bool AddMethodIsExplicitInterfaceImplementation { get; init; }
+    public required EnumerableInsertionMode InsertionMode { get; init; }
 }
 
 /// <summary>
@@ -99,4 +99,30 @@ public enum EnumerableKind
     /// An IAsyncEnumerable{T} type.
     /// </summary>
     IAsyncEnumerableOfT,
+}
+
+/// <summary>
+/// Identifies the insertion models available to the dictionary.
+/// </summary>
+public enum EnumerableInsertionMode
+{
+    /// <summary>
+    /// No insertion model available.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Insertion possible by an Add-like method defined on the type.
+    /// </summary>
+    AddMethod,
+
+    /// <summary>
+    /// Enumerable explicitly implements <see cref="ICollection{T}"/>.
+    /// </summary>
+    ExplicitICollectionOfT,
+
+    /// <summary>
+    /// Enumerable explicitly implements <see cref="ICollection"/>.
+    /// </summary>
+    ExplicitIList,
 }

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Dictionary.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Dictionary.cs
@@ -23,7 +23,7 @@ public partial class TypeDataModelGenerator
         CollectionConstructorParameter[]? factorySignature = null;
         ITypeSymbol? keyType = null;
         ITypeSymbol? valueType = null;
-        bool indexerIsExplicitImplementation = false;
+        DictionaryInsertionMode availableInsertionModes = DictionaryInsertionMode.None;
 
         if (namedType.GetCompatibleGenericBaseType(KnownSymbols.IReadOnlyDictionaryOfTKeyTValue) is { } genericReadOnlyIDictInstance)
         {
@@ -48,43 +48,20 @@ public partial class TypeDataModelGenerator
             return false; // Not a dictionary type
         }
 
-        if (namedType.TypeKind is TypeKind.Interface)
-        {
-            if (namedType.TypeParameters.Length == 2)
-            {
-                if (KnownSymbols.DictionaryOfTKeyTValue?.GetCompatibleGenericBaseType(namedType.ConstructedFrom) is not null)
-                {
-                    // Handle IDictionary<TKey, TValue> and IReadOnlyDictionary<TKey, TValue> using Dictionary<TKey, TValue>
-                    namedType = KnownSymbols.DictionaryOfTKeyTValue!.Construct(keyType, valueType);
-                }
-                else if (KnownSymbols.ImmutableDictionary?.GetCompatibleGenericBaseType(namedType.ConstructedFrom) is not null)
-                {
-                    // Handle IImmutableDictionary<TKey, TValue> using ImmutableDictionary<TKey, TValue>
-                    namedType = KnownSymbols.ImmutableDictionary!.Construct(keyType, valueType);
-                }
-            }
-            else if (SymbolEqualityComparer.Default.Equals(namedType, KnownSymbols.IDictionary))
-            {
-                // Handle IDictionary using Dictionary<object, object>
-                namedType = KnownSymbols.DictionaryOfTKeyTValue!.Construct(keyType, valueType);
-            }
-        }
-
         var elementType = KnownSymbols.KeyValuePairOfKV!.Construct(keyType, valueType);
-
-        if (ResolveBestCollectionCtor(
+        if (GetImmutableDictionaryFactory(namedType) is { } bestImmutableDictionaryCtor)
+        {
+            (factoryMethod, factorySignature, isParameterizedFactory) = bestImmutableDictionaryCtor;
+        }
+        else if (ResolveBestCollectionCtor(
             namedType,
-            namedType.GetConstructors(),
-            hasAddMethod: ContainsSettableIndexer(namedType, keyType, valueType, out indexerIsExplicitImplementation),
+            DetermineImplementationType(namedType).GetConstructors(),
+            hasInserter: ContainsInserter(type, keyType, valueType, out availableInsertionModes),
             elementType,
             keyType,
             valueType) is { } bestCtor)
         {
             (factoryMethod, factorySignature, isParameterizedFactory) = bestCtor;
-        }
-        else if (GetImmutableDictionaryFactory(namedType) is { } bestImmutableDictionaryCtor)
-        {
-            (factoryMethod, factorySignature, isParameterizedFactory) = bestImmutableDictionaryCtor;
         }
 
         if ((status = IncludeNestedType(keyType, ref ctx)) != TypeDataModelGenerationStatus.Success ||
@@ -104,40 +81,79 @@ public partial class TypeDataModelGenerator
             DerivedTypes = IncludeDerivedTypes(type, ref ctx, TypeShapeRequirements.Full),
             FactoryMethod = factoryMethod,
             FactorySignature = factorySignature?.ToImmutableArray() ?? ImmutableArray<CollectionConstructorParameter>.Empty,
-            IndexerIsExplicitInterfaceImplementation = indexerIsExplicitImplementation,
+            AvailableInsertionModes = availableInsertionModes,
         };
 
         return true;
 
-        bool ContainsSettableIndexer(ITypeSymbol type, ITypeSymbol keyType, ITypeSymbol valueType, out bool isExplicitInterfaceImplementation)
+        bool ContainsInserter(ITypeSymbol type, ITypeSymbol keyType, ITypeSymbol valueType, out DictionaryInsertionMode availableInsertionModes)
         {
-            bool hasSettableIndexer = type.GetAllMembers()
-                .OfType<IPropertySymbol>()
-                .Any(prop =>
-                    prop is { IsStatic: false, IsIndexer: true, Parameters.Length: 1, SetMethod: not null } &&
-                    SymbolEqualityComparer.Default.Equals(prop.Parameters[0].Type, keyType) &&
-                    SymbolEqualityComparer.Default.Equals(prop.Type, valueType) &&
-                    IsAccessibleSymbol(prop));
+            availableInsertionModes = DictionaryInsertionMode.None;
+            bool foundContainsKey = false;
+            var instanceMethods = type.GetAllMembers()
+                .OfType<IMethodSymbol>()
+                .Where(method => method.IsStatic is false && IsAccessibleSymbol(method));
 
-            if (!hasSettableIndexer && !type.IsValueType && kind is DictionaryKind.IDictionaryOfKV or DictionaryKind.IDictionary)
+            foreach (var method in instanceMethods)
             {
-                // For reference types, allow using explicit interface implementations of the indexer.
-                isExplicitInterfaceImplementation = true;
-                return true;
+                if (method.Parameters is [var p1, var p2] &&
+                    SymbolEqualityComparer.Default.Equals(p1.Type, keyType) &&
+                    SymbolEqualityComparer.Default.Equals(p2.Type, valueType))
+                {
+                    if (method.Name is "Add")
+                    {
+                        availableInsertionModes |= DictionaryInsertionMode.Add;
+                    }
+                    else if (method is { Name: "TryAdd", ReturnType.SpecialType: SpecialType.System_Boolean })
+                    {
+                        availableInsertionModes |= DictionaryInsertionMode.TryAdd;
+                    }
+                    else if (method is { Name: "set_Item", MethodKind: MethodKind.PropertySet })
+                    {
+                        availableInsertionModes |= DictionaryInsertionMode.SetItem;
+                    }
+
+                    continue;
+                }
+
+                if (method is { Name: "ContainsKey", Parameters: [var param], ReturnType.SpecialType: SpecialType.System_Boolean } &&
+                    SymbolEqualityComparer.Default.Equals(param.Type, keyType))
+                {
+                    foundContainsKey = true;
+                }
             }
 
-            isExplicitInterfaceImplementation = false;
-            return hasSettableIndexer;
+            if (foundContainsKey && (availableInsertionModes & DictionaryInsertionMode.Add) != 0)
+            {
+                availableInsertionModes |= DictionaryInsertionMode.ContainsKeyAdd;
+            }
+
+            if (kind is DictionaryKind.IDictionaryOfKV)
+            {
+                availableInsertionModes |= DictionaryInsertionMode.ExplicitIDictionaryOfT;
+            }
+            else if (kind is DictionaryKind.IDictionary)
+            {
+                availableInsertionModes |= DictionaryInsertionMode.ExplicitIDictionary;
+            }
+
+            return availableInsertionModes is not DictionaryInsertionMode.None;
         }
 
         (IMethodSymbol Factory, CollectionConstructorParameter[] Signature, bool IsParameterized)? GetImmutableDictionaryFactory(INamedTypeSymbol namedType)
         {
+            if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.IReadOnlyDictionaryOfTKeyTValue))
+            {
+                return ResolveFactoryMethod("PolyType.SourceGenModel.CollectionHelpers", "CreateDictionary");
+            }
+
             if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.ImmutableDictionary))
             {
                 return ResolveFactoryMethod("System.Collections.Immutable.ImmutableDictionary");
             }
 
-            if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.ImmutableSortedDictionary))
+            if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.ImmutableSortedDictionary) ||
+                SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.IImmutableDictionary))
             {
                 return ResolveFactoryMethod("System.Collections.Immutable.ImmutableSortedDictionary");
             }
@@ -169,8 +185,23 @@ public partial class TypeDataModelGenerator
                         (factoryName is null ? method.Name is "Create" or "CreateRange" : method.Name == factoryName))
                     .Select(method => method.MakeGenericMethod(keyType, valueType)!);
 
-                return ResolveBestCollectionCtor(type, candidates, hasAddMethod: false, elementType, keyType, valueType: null);
+                return ResolveBestCollectionCtor(type, candidates, hasInserter: false, elementType, keyType, valueType: null);
             }
+        }
+
+        INamedTypeSymbol DetermineImplementationType(INamedTypeSymbol namedType)
+        {
+            if (namedType.TypeKind is TypeKind.Interface)
+            {
+                if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.IDictionaryOfTKeyTValue) ||
+                    SymbolEqualityComparer.Default.Equals(namedType, KnownSymbols.IDictionary))
+                {
+                    // Handle IDictionary<TKey, TValue> and IDictionary using Dictionary<TKey, TValue>
+                    return KnownSymbols.DictionaryOfTKeyTValue!.Construct(keyType, valueType);
+                }
+            }
+
+            return namedType;
         }
     }
 }

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Dictionary.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Dictionary.cs
@@ -128,11 +128,11 @@ public partial class TypeDataModelGenerator
                 availableInsertionModes |= DictionaryInsertionMode.ContainsKeyAdd;
             }
 
-            if (kind is DictionaryKind.IDictionaryOfKV)
+            if (type.GetCompatibleGenericBaseType(KnownSymbols.IDictionaryOfTKeyTValue) is not null)
             {
                 availableInsertionModes |= DictionaryInsertionMode.ExplicitIDictionaryOfT;
             }
-            else if (kind is DictionaryKind.IDictionary)
+            else if (KnownSymbols.IDictionary.IsAssignableFrom(type))
             {
                 availableInsertionModes |= DictionaryInsertionMode.ExplicitIDictionary;
             }

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enumerable.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enumerable.cs
@@ -21,6 +21,7 @@ public partial class TypeDataModelGenerator
         int rank = 1;
         EnumerableKind kind;
         ITypeSymbol? elementType;
+        bool isSetType = false;
         IMethodSymbol? appendMethod = null;
         bool isParameterizedFactory = false;
         IMethodSymbol? factoryMethod = null;
@@ -114,6 +115,13 @@ public partial class TypeDataModelGenerator
             {
                 (factoryMethod, factorySignature, isParameterizedFactory) = classifiedBuilderMethod;
             }
+
+            if (type.GetCompatibleGenericBaseType(KnownSymbols.ISetOfT) is not null ||
+                type.GetCompatibleGenericBaseType(KnownSymbols.IReadOnlySetOfT) is not null ||
+                type.GetCompatibleGenericBaseType(KnownSymbols.IImmutableSetOfT) is not null)
+            {
+                isSetType = true;
+            }
         }
 
         if ((status = IncludeNestedType(elementType, ref ctx)) != TypeDataModelGenerationStatus.Success)
@@ -133,6 +141,7 @@ public partial class TypeDataModelGenerator
             InsertionMode = isParameterizedFactory ? EnumerableInsertionMode.None : insertionMode,
             FactoryMethod = factoryMethod,
             FactorySignature = factorySignature?.ToImmutableArray() ?? ImmutableArray<CollectionConstructorParameter>.Empty,
+            IsSetType = isSetType,
             Rank = rank,
         };
 

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enumerable.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enumerable.cs
@@ -2,7 +2,6 @@
 using PolyType.Roslyn.Helpers;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 
 namespace PolyType.Roslyn;
 
@@ -22,11 +21,11 @@ public partial class TypeDataModelGenerator
         int rank = 1;
         EnumerableKind kind;
         ITypeSymbol? elementType;
-        IMethodSymbol? addMethod = null;
+        IMethodSymbol? appendMethod = null;
         bool isParameterizedFactory = false;
         IMethodSymbol? factoryMethod = null;
         CollectionConstructorParameter[]? factorySignature = null;
-        bool addMethodIsExplicitInterfaceImplementation = false;
+        EnumerableInsertionMode insertionMode = EnumerableInsertionMode.None;
 
         if (type is IArrayTypeSymbol array)
         {
@@ -89,38 +88,14 @@ public partial class TypeDataModelGenerator
                 return false; // Type is not IEnumerable
             }
 
-            if (namedType.TypeKind is TypeKind.Interface)
-            {
-                INamedTypeSymbol listOfT = KnownSymbols.ListOfT!.Construct(elementType);
-                if (namedType.IsAssignableFrom(listOfT))
-                {
-                    // Handle IEnumerable<T>, ICollection<T>, IList<T>, IReadOnlyCollection<T> and IReadOnlyList<T> types using List<T>
-                    namedType = listOfT;
-                }
-                else if (namedType.IsAssignableFrom(KnownSymbols.IList))
-                {
-                    // Handle construction of IList, ICollection and IEnumerable interfaces using List<object?>
-                    namedType = KnownSymbols.ListOfT!.Construct(KnownSymbols.Compilation.ObjectType);
-                }
-                else
-                {
-                    INamedTypeSymbol hashSetOfT = KnownSymbols.HashSetOfT!.Construct(elementType);
-                    if (namedType.IsAssignableFrom(hashSetOfT))
-                    {
-                        // Handle ISet<T> and IReadOnlySet<T> types using HashSet<T>
-                        namedType = hashSetOfT;
-                    }
-                }
-            }
-
             if (GetImmutableCollectionFactory(namedType) is { } result)
             {
                 (factoryMethod, factorySignature, isParameterizedFactory) = result;
             }
             else if (ResolveBestCollectionCtor(
                 namedType,
-                namedType.GetConstructors(),
-                hasAddMethod: (addMethod = ResolveAddMethod(namedType, elementType, out addMethodIsExplicitInterfaceImplementation)) is not null,
+                DetermineImplementationType(namedType).GetConstructors(),
+                hasInserter: (appendMethod = ResolveAddMethod(type, elementType, out insertionMode)) is not null,
                 elementType,
                 keyType: elementType,
                 valueType: null) is { } bestCtor)
@@ -132,7 +107,7 @@ public partial class TypeDataModelGenerator
                 ResolveBestCollectionCtor(
                     namedType,
                     candidates: KnownSymbols.Compilation.GetCollectionBuilderAttributeMethods(namedType, elementType, CancellationToken),
-                    hasAddMethod: false,
+                    hasInserter: false,
                     elementType,
                     keyType: elementType,
                     valueType: null) is { } classifiedBuilderMethod)
@@ -154,103 +129,128 @@ public partial class TypeDataModelGenerator
             ElementType = elementType,
             EnumerableKind = kind,
             DerivedTypes = IncludeDerivedTypes(type, ref ctx, TypeShapeRequirements.Full),
-            AddElementMethod = isParameterizedFactory ? null : addMethod,
+            AppendMethod = isParameterizedFactory ? null : appendMethod,
+            InsertionMode = isParameterizedFactory ? EnumerableInsertionMode.None : insertionMode,
             FactoryMethod = factoryMethod,
             FactorySignature = factorySignature?.ToImmutableArray() ?? ImmutableArray<CollectionConstructorParameter>.Empty,
             Rank = rank,
-            AddMethodIsExplicitInterfaceImplementation = addMethodIsExplicitInterfaceImplementation,
         };
 
         return true;
 
-        IMethodSymbol? ResolveAddMethod(ITypeSymbol type, ITypeSymbol elementType, out bool isExplicitImplementation)
+        IMethodSymbol? ResolveAddMethod(ITypeSymbol type, ITypeSymbol elementType, out EnumerableInsertionMode insertionMode)
         {
-            isExplicitImplementation = false;
+            insertionMode = EnumerableInsertionMode.None;
             IMethodSymbol? result = type.GetAllMembers()
                 .OfType<IMethodSymbol>()
                 .FirstOrDefault(method =>
                     method is { DeclaredAccessibility: Accessibility.Public, IsStatic: false, Name: "Add" or "Enqueue" or "Push", Parameters: [{ Type: ITypeSymbol parameterType }] } &&
                     SymbolEqualityComparer.Default.Equals(method.Parameters[0].Type, elementType));
 
-            if (!type.IsValueType)
+            if (result is not null)
             {
-                // For reference types, allow using explicit interface implementations of known Add methods.
-                if (result is null && type.GetCompatibleGenericBaseType(KnownSymbols.ICollectionOfT) is { } iCollectionOfT)
+                insertionMode = EnumerableInsertionMode.AddMethod;
+                return result;
+            }
+
+            // Allow using explicit interface implementations of known Add methods.
+            if (type.GetCompatibleGenericBaseType(KnownSymbols.ICollectionOfT) is { } iCollectionOfT)
+            {
+                result = iCollectionOfT.GetMethods("Add", isStatic: false)
+                    .FirstOrDefault(m =>
+                        m is { DeclaredAccessibility: Accessibility.Public, Parameters: [{ Type: ITypeSymbol paramType }] } &&
+                        SymbolEqualityComparer.Default.Equals(paramType, elementType));
+
+                if (result is not null)
                 {
-
-                    result = iCollectionOfT.GetMethods("Add", isStatic: false)
-                        .FirstOrDefault(m =>
-                            m is { DeclaredAccessibility: Accessibility.Public, Parameters: [{ Type: ITypeSymbol paramType }] } &&
-                            SymbolEqualityComparer.Default.Equals(paramType, elementType));
-
-                    isExplicitImplementation = result is not null;
-                }
-
-                if (result is null && KnownSymbols.IList.IsAssignableFrom(type))
-                {
-                    result = KnownSymbols.IList.GetMethods("Add", isStatic: false)
-                        .OfType<IMethodSymbol>()
-                        .FirstOrDefault(m =>
-                            m is { DeclaredAccessibility: Accessibility.Public, Parameters: [{ Type: ITypeSymbol paramType }] } &&
-                            SymbolEqualityComparer.Default.Equals(paramType, elementType));
-
-                    isExplicitImplementation = result is not null;
+                    insertionMode = EnumerableInsertionMode.ExplicitICollectionOfT;
+                    return result;
                 }
             }
 
-            return result;
+            if (KnownSymbols.IList.IsAssignableFrom(type))
+            {
+                result = KnownSymbols.IList.GetMethods("Add", isStatic: false)
+                    .OfType<IMethodSymbol>()
+                    .FirstOrDefault(m =>
+                        m is { DeclaredAccessibility: Accessibility.Public, Parameters: [{ Type: ITypeSymbol paramType }] } &&
+                        SymbolEqualityComparer.Default.Equals(paramType, elementType));
+
+                if (result is not null)
+                {
+                    insertionMode = EnumerableInsertionMode.ExplicitIList;
+                    return result;
+                }
+            }
+
+            return appendMethod;
         }
 
         (IMethodSymbol Factory, CollectionConstructorParameter[] Signature, bool IsParameterized)? GetImmutableCollectionFactory(INamedTypeSymbol namedType)
         {
+            if (namedType.OriginalDefinition.SpecialType 
+                    is SpecialType.System_Collections_IEnumerable or SpecialType.System_Collections_Generic_IEnumerable_T
+                    or SpecialType.System_Collections_Generic_IReadOnlyCollection_T or SpecialType.System_Collections_Generic_IReadOnlyList_T ||
+                SymbolEqualityComparer.Default.Equals(namedType, KnownSymbols.ICollection))
+            {
+                // Handle readonly list-like collection interfaces using a static factory method.
+                return ResolveFactoryMethod("PolyType.SourceGenModel.CollectionHelpers", "CreateList");
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.IReadOnlySetOfT))
+            {
+                // Handle readonly set-like collection interfaces using a static factory method.
+                return ResolveFactoryMethod("PolyType.SourceGenModel.CollectionHelpers", "CreateHashSet");
+            }
+
             if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.ImmutableArray))
             {
-                return FindCreateRangeMethods("System.Collections.Immutable.ImmutableArray");
+                return ResolveFactoryMethod("System.Collections.Immutable.ImmutableArray");
             }
 
             if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.ImmutableList))
             {
-                return FindCreateRangeMethods("System.Collections.Immutable.ImmutableList");
+                return ResolveFactoryMethod("System.Collections.Immutable.ImmutableList");
             }
 
             if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.ImmutableQueue))
             {
-                return FindCreateRangeMethods("System.Collections.Immutable.ImmutableQueue");
+                return ResolveFactoryMethod("System.Collections.Immutable.ImmutableQueue");
             }
 
             if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.ImmutableStack))
             {
-                return FindCreateRangeMethods("System.Collections.Immutable.ImmutableStack");
+                return ResolveFactoryMethod("System.Collections.Immutable.ImmutableStack");
             }
 
             if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.ImmutableHashSet))
             {
-                return FindCreateRangeMethods("System.Collections.Immutable.ImmutableHashSet");
+                return ResolveFactoryMethod("System.Collections.Immutable.ImmutableHashSet");
             }
 
             if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.IImmutableSet))
             {
-                return FindCreateRangeMethods("System.Collections.Immutable.ImmutableHashSet");
+                return ResolveFactoryMethod("System.Collections.Immutable.ImmutableHashSet");
             }
 
             if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.ImmutableSortedSet))
             {
-                return FindCreateRangeMethods("System.Collections.Immutable.ImmutableSortedSet");
+                return ResolveFactoryMethod("System.Collections.Immutable.ImmutableSortedSet");
             }
 
             if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.FrozenSet))
             {
-                return FindCreateRangeMethods("System.Collections.Frozen.FrozenSet", "ToFrozenSet");
+                return ResolveFactoryMethod("System.Collections.Frozen.FrozenSet", "ToFrozenSet");
             }
 
             if (SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, KnownSymbols.FSharpList))
             {
-                return FindCreateRangeMethods("Microsoft.FSharp.Collections.ListModule", factoryName: "OfSeq");
+                return ResolveFactoryMethod("Microsoft.FSharp.Collections.ListModule", factoryName: "OfSeq");
             }
 
             return default;
 
-            (IMethodSymbol Factory, CollectionConstructorParameter[] Signature, bool IsParameterized)? FindCreateRangeMethods(string typeName, string? factoryName = null)
+            (IMethodSymbol Factory, CollectionConstructorParameter[] Signature, bool IsParameterized)? ResolveFactoryMethod(string typeName, string? factoryName = null)
             {
                 INamedTypeSymbol? typeSymbol = KnownSymbols.Compilation.GetTypeByMetadataName(typeName);
                 if (typeSymbol is null)
@@ -265,15 +265,40 @@ public partial class TypeDataModelGenerator
                         factoryName is null ? method.Name is "Create" or "CreateRange" : method.Name == factoryName)
                     .Select(method => method.MakeGenericMethod(elementType)!);
 
-                return ResolveBestCollectionCtor(type, candidates, hasAddMethod: false, elementType, elementType, valueType: null);
+                return ResolveBestCollectionCtor(type, candidates, hasInserter: false, elementType, elementType, valueType: null);
             }
+        }
+
+        INamedTypeSymbol DetermineImplementationType(INamedTypeSymbol namedType)
+        {
+            if (namedType.TypeKind is TypeKind.Interface)
+            {
+                if (namedType.OriginalDefinition.SpecialType is SpecialType.System_Collections_Generic_ICollection_T 
+                                                             or SpecialType.System_Collections_Generic_IList_T ||
+                    SymbolEqualityComparer.Default.Equals(namedType, KnownSymbols.IList))
+                {
+                    // Handle IList, ICollection<T> and IList<T> types using List<T>
+                    return KnownSymbols.ListOfT!.Construct(elementType);
+                }
+                else
+                {
+                    INamedTypeSymbol hashSetOfT = KnownSymbols.HashSetOfT!.Construct(elementType);
+                    if (namedType.IsAssignableFrom(hashSetOfT))
+                    {
+                        // Handle ISet<T> types using HashSet<T>
+                        return hashSetOfT;
+                    }
+                }
+            }
+
+            return namedType;
         }
     }
 
     private (IMethodSymbol Factory, CollectionConstructorParameter[] Signature, bool IsParameterized)? ResolveBestCollectionCtor(
         ITypeSymbol collectionType,
         IEnumerable<IMethodSymbol> candidates,
-        bool hasAddMethod,
+        bool hasInserter,
         ITypeSymbol elementType,
         ITypeSymbol keyType,
         ITypeSymbol? valueType)
@@ -284,7 +309,7 @@ public partial class TypeDataModelGenerator
                 var signature = ClassifyCollectionConstructor(
                     collectionType,
                     method,
-                    hasAddMethod,
+                    hasInserter,
                     out CollectionConstructorParameter? valuesParam,
                     out CollectionConstructorParameter? comparerParam,
                     elementType, keyType, valueType);
@@ -326,7 +351,7 @@ public partial class TypeDataModelGenerator
 
         int RankStrategy(CollectionConstructorParameter? valueParam)
         {
-            return (hasAddMethod, valueParam) switch
+            return (hasInserter, valueParam) switch
             {
                 (true, null) => 0, // Mutable collections with add methods are ranked highest.
                 (false, not null) => 0, // Parameterized constructors are ranked highest if an add method is not available.

--- a/src/PolyType.SourceGenerator/Model/DictionaryShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/DictionaryShapeModel.cs
@@ -13,5 +13,5 @@ public sealed record DictionaryShapeModel : TypeShapeModel
     public required string? ImplementationTypeFQN { get; init; }
     public required string? StaticFactoryMethod { get; init; }
     public required bool KeyValueTypesContainNullableAnnotations { get; init; }
-    public required bool IndexerIsExplicitInterfaceImplementation { get; init; }
+    public required DictionaryInsertionMode AvailableInsertionModes { get; init; }
 }

--- a/src/PolyType.SourceGenerator/Model/EnumerableShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/EnumerableShapeModel.cs
@@ -10,9 +10,10 @@ public sealed record EnumerableShapeModel : TypeShapeModel
     public required int Rank { get; init; }
     public required CollectionConstructionStrategy ConstructionStrategy { get; init; }
     public required ImmutableEquatableArray<CollectionConstructorParameter> ConstructorParameters { get; init; }
-    public required string? AddElementMethod { get; init; }
+    public required string? AppendMethod { get; init; }
     public required string? ImplementationTypeFQN { get; init; }
     public required string? StaticFactoryMethod { get; init; }
     public required bool ElementTypeContainsNullableAnnotations { get; init; }
-    public required bool AddMethodIsExplicitInterfaceImplementation { get; init; }
+    public required bool AppendMethodReturnsBoolean { get; init; }
+    public required EnumerableInsertionMode InsertionMode { get; init; }
 }

--- a/src/PolyType.SourceGenerator/Model/EnumerableShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/EnumerableShapeModel.cs
@@ -8,6 +8,7 @@ public sealed record EnumerableShapeModel : TypeShapeModel
     public required TypeId ElementType { get; init; }
     public required EnumerableKind Kind { get; init; }
     public required int Rank { get; init; }
+    public required bool IsSetType { get; init; }
     public required CollectionConstructionStrategy ConstructionStrategy { get; init; }
     public required ImmutableEquatableArray<CollectionConstructorParameter> ConstructorParameters { get; init; }
     public required string? AppendMethod { get; init; }

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -85,6 +85,7 @@ public sealed partial class Parser
 
                 Kind = enumerableModel.EnumerableKind,
                 Rank = enumerableModel.Rank,
+                IsSetType = enumerableModel.IsSetType,
                 ElementTypeContainsNullableAnnotations = enumerableModel.ElementType.ContainsNullabilityAnnotations(),
                 InsertionMode = enumerableModel.InsertionMode,
                 AppendMethodReturnsBoolean = enumerableModel.AppendMethod?.ReturnType.SpecialType is SpecialType.System_Boolean,

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -65,8 +65,7 @@ public sealed partial class Parser
                 {
                     { EnumerableKind: EnumerableKind.ArrayOfT or EnumerableKind.MemoryOfT or EnumerableKind.ReadOnlyMemoryOfT } =>
                         CollectionConstructionStrategy.Parameterized, // use ReadOnlySpan.ToArray() to create the collection
-
-                    { FactoryMethod: not null } => 
+                    { FactoryMethod: not null } =>
                         IsParameterizedConstructor(enumerableModel.FactorySignature)
                         ? CollectionConstructionStrategy.Parameterized
                         : CollectionConstructionStrategy.Mutable,
@@ -74,12 +73,10 @@ public sealed partial class Parser
                     _ => CollectionConstructionStrategy.None,
                 },
 
-                AddElementMethod = enumerableModel.AddElementMethod?.Name,
+                AppendMethod = enumerableModel.AppendMethod?.Name,
                 ImplementationTypeFQN =
                     enumerableModel.FactoryMethod is { IsStatic: false, ContainingType: INamedTypeSymbol implType } &&
-                    !IsParameterizedConstructor(enumerableModel.FactorySignature) &&
                     !SymbolEqualityComparer.Default.Equals(implType, enumerableModel.Type)
-
                     ? implType.GetFullyQualifiedName()
                     : null,
 
@@ -89,7 +86,8 @@ public sealed partial class Parser
                 Kind = enumerableModel.EnumerableKind,
                 Rank = enumerableModel.Rank,
                 ElementTypeContainsNullableAnnotations = enumerableModel.ElementType.ContainsNullabilityAnnotations(),
-                AddMethodIsExplicitInterfaceImplementation = enumerableModel.AddMethodIsExplicitInterfaceImplementation,
+                InsertionMode = enumerableModel.InsertionMode,
+                AppendMethodReturnsBoolean = enumerableModel.AppendMethod?.ReturnType.SpecialType is SpecialType.System_Boolean,
                 AssociatedTypes = associatedTypes,
             },
 
@@ -111,7 +109,6 @@ public sealed partial class Parser
 
                 ImplementationTypeFQN =
                     dictionaryModel.FactoryMethod is { IsStatic: false, ContainingType: INamedTypeSymbol implType } &&
-                    !IsParameterizedConstructor(dictionaryModel.FactorySignature) &&
                     !SymbolEqualityComparer.Default.Equals(implType, dictionaryModel.Type)
 
                     ? implType.GetFullyQualifiedName()
@@ -123,7 +120,7 @@ public sealed partial class Parser
                 KeyValueTypesContainNullableAnnotations =
                     dictionaryModel.KeyType.ContainsNullabilityAnnotations() ||
                     dictionaryModel.ValueType.ContainsNullabilityAnnotations(),
-                IndexerIsExplicitInterfaceImplementation = dictionaryModel.IndexerIsExplicitInterfaceImplementation,
+                AvailableInsertionModes = dictionaryModel.AvailableInsertionModes,
                 AssociatedTypes = associatedTypes,
             },
 

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
@@ -21,6 +21,7 @@ internal sealed partial class SourceFormatter
                     GetEnumerableFunc = {{FormatGetEnumerableFunc(enumerableShapeModel)}},
                     AppenderFunc = {{FormatAppenderFunc(enumerableShapeModel)}},
                     IsAsyncEnumerable = {{FormatBool(enumerableShapeModel.Kind is EnumerableKind.IAsyncEnumerableOfT)}},
+                    IsSetType = {{FormatBool(enumerableShapeModel.IsSetType)}},
                     Rank = {{enumerableShapeModel.Rank}},
                     AssociatedTypeShapes = {{FormatAssociatedTypeShapes(enumerableShapeModel)}},
                     Provider = this,

--- a/src/PolyType.TestCases/TestCase.cs
+++ b/src/PolyType.TestCases/TestCase.cs
@@ -22,6 +22,7 @@ public static class TestCase
     /// <param name="hasRefConstructorParameters">Whether the shape constructor accepts any ref parameters.</param>
     /// <param name="hasOutConstructorParameters">Whether the shape constructor accepts any out parameters.</param>
     /// <param name="usesSpanConstructor">Whether the shape defines a collection constructor that takes a span of elements.</param>
+    /// <param name="isSet">Whether the type is a set.</param>
     /// <param name="isStack">Whether the type is a stack.</param>
     /// <param name="isUnion">Whether the type is a union.</param>
     /// <returns>A test case instance using the specified parameters.</returns>
@@ -31,6 +32,7 @@ public static class TestCase
         bool hasRefConstructorParameters = false,
         bool hasOutConstructorParameters = false,
         bool usesSpanConstructor = false,
+        bool isSet = false,
         bool isStack = false,
         bool isUnion = false)
         where T : IShapeable<T>
@@ -41,6 +43,7 @@ public static class TestCase
             HasRefConstructorParameters = hasRefConstructorParameters,
             HasOutConstructorParameters = hasOutConstructorParameters,
             UsesSpanConstructor = usesSpanConstructor,
+            IsSet = isSet,
             IsStack = isStack,
             IsUnion = isUnion,
         };
@@ -57,6 +60,7 @@ public static class TestCase
     /// <param name="hasRefConstructorParameters">Whether the shape constructor accepts any ref parameters.</param>
     /// <param name="hasOutConstructorParameters">Whether the shape constructor accepts any out parameters.</param>
     /// <param name="usesSpanConstructor">Whether the shape defines a collection constructor that takes a span of elements.</param>
+    /// <param name="isSet">Whether the type is a set.</param>
     /// <param name="isStack">Whether the type is a stack.</param>
     /// <param name="isUnion">Whether the type is a union.</param>
     /// <returns>A test case instance using the specified parameters.</returns>
@@ -67,6 +71,7 @@ public static class TestCase
         bool hasRefConstructorParameters = false,
         bool hasOutConstructorParameters = false,
         bool usesSpanConstructor = false,
+        bool isSet = false,
         bool isStack = false,
         bool isUnion = false)
         where TProvider : IShapeable<T>
@@ -77,6 +82,7 @@ public static class TestCase
             HasRefConstructorParameters = hasRefConstructorParameters,
             HasOutConstructorParameters = hasOutConstructorParameters,
             UsesSpanConstructor = usesSpanConstructor,
+            IsSet = isSet,
             IsStack = isStack,
             IsUnion = isUnion,
         };
@@ -94,6 +100,7 @@ public static class TestCase
     /// <param name="hasRefConstructorParameters">Whether the shape constructor accepts any ref parameters.</param>
     /// <param name="hasOutConstructorParameters">Whether the shape constructor accepts any out parameters.</param>
     /// <param name="usesSpanConstructor">Whether the shape defines a collection constructor that takes a span of elements.</param>
+    /// <param name="isSet">Whether the type is a set.</param>
     /// <param name="isStack">Whether the type is a stack.</param>
     /// <param name="isUnion">Whether the type is a union.</param>
     /// <returns>A test case instance using the specified parameters.</returns>
@@ -104,6 +111,7 @@ public static class TestCase
         bool hasRefConstructorParameters = false,
         bool hasOutConstructorParameters = false,
         bool usesSpanConstructor = false,
+        bool isSet = false,
         bool isStack = false,
         bool isUnion = false)
     {
@@ -113,6 +121,7 @@ public static class TestCase
             HasRefConstructorParameters = hasRefConstructorParameters,
             HasOutConstructorParameters = hasOutConstructorParameters,
             UsesSpanConstructor = usesSpanConstructor,
+            IsSet = isSet,
             IsStack = isStack,
             IsUnion = isUnion,
         };
@@ -127,6 +136,7 @@ public static class TestCase
         bool hasRefConstructorParameters = false,
         bool hasOutConstructorParameters = false,
         bool usesSpanConstructor = false,
+        bool isSet = false,
         bool isStack = false,
         bool isUnion = false)
     {
@@ -136,6 +146,7 @@ public static class TestCase
             HasRefConstructorParameters = hasRefConstructorParameters,
             HasOutConstructorParameters = hasOutConstructorParameters,
             UsesSpanConstructor = usesSpanConstructor,
+            IsSet = isSet,
             IsStack = isStack,
             IsUnion = isUnion,
         };

--- a/src/PolyType.TestCases/TestCaseOfT.cs
+++ b/src/PolyType.TestCases/TestCaseOfT.cs
@@ -60,6 +60,11 @@ public record TestCase<T> : ITestCase
     public T?[]? AdditionalValues { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether the type represents a set.
+    /// </summary>
+    public bool IsSet { get; init; }
+
+    /// <summary>
     /// Gets a value indicating whether the type is a LIFO collection that serializes elements in reverse order.
     /// </summary>
     public bool IsStack { get; init; }

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -135,8 +135,8 @@ public static class TestTypes
         yield return TestCase.Create(new Queue<int>([1, 2, 3]), p);
         yield return TestCase.Create(new Stack<int>([1, 2, 3]), isStack: true, provider: p);
         yield return TestCase.Create(new Dictionary<string, int> { ["key1"] = 42, ["key2"] = -1 }, provider: p);
-        yield return TestCase.Create((HashSet<string>)["apple", "orange", "banana"], p);
-        yield return TestCase.Create((SortedSet<string>)["apple", "orange", "banana"], p);
+        yield return TestCase.Create((HashSet<string>)["apple", "orange", "banana"], isSet: true, provider: p);
+        yield return TestCase.Create((SortedSet<string>)["apple", "orange", "banana"], isSet: true, provider: p);
         yield return TestCase.Create(new SortedDictionary<string, int> { ["key1"] = 42, ["key2"] = -1 }, provider: p);
         yield return TestCase.Create(new SortedList<int, string> { [42] = "forty-two", [32] = "thirty-two" }, provider: p);
 
@@ -159,9 +159,9 @@ public static class TestTypes
         yield return TestCase.Create((IList<int>)[1, 2, 1, 3], p);
         yield return TestCase.Create((IReadOnlyCollection<int>)[1, 2, 1, 3], p);
         yield return TestCase.Create((IReadOnlyList<int>)[1, 2, 1, 3], p);
-        yield return TestCase.Create((ISet<int>)new HashSet<int> { 1, 2, 3 }, p);
+        yield return TestCase.Create((ISet<int>)new HashSet<int> { 1, 2, 3 }, isSet: true, provider: p);
 #if NET
-        yield return TestCase.Create((IReadOnlySet<int>)new HashSet<int> { 1, 2, 3 }, p);
+        yield return TestCase.Create((IReadOnlySet<int>)new HashSet<int> { 1, 2, 3 }, isSet: true, provider: p);
 #endif
         yield return TestCase.Create((IDictionary<int, int>)new Dictionary<int, int> { [42] = 42 }, p);
         yield return TestCase.Create((IReadOnlyDictionary<int, int>)new Dictionary<int, int> { [42] = 42 }, p);
@@ -192,7 +192,7 @@ public static class TestTypes
         yield return TestCase.Create(new ReadOnlyCollection<int>([1, 2, 1, 3]), p);
         yield return TestCase.Create(new ReadOnlyDictionary<int, int>(new Dictionary<int, int> { [1] = 1, [2] = 2 }), p);
 #if NET9_0_OR_GREATER
-        yield return TestCase.Create(new ReadOnlySet<int>(new HashSet<int> { 1, 2, 3 }), p);
+        yield return TestCase.Create(new ReadOnlySet<int>(new HashSet<int> { 1, 2, 3 }), isSet: true, provider: p);
 #endif
 
         yield return TestCase.Create(new EnumerableAsObject { Value = 42 });
@@ -204,18 +204,18 @@ public static class TestTypes
         yield return TestCase.Create(ImmutableList.Create("1", "2", null), p);
         yield return TestCase.Create(ImmutableQueue.Create(1, 2, 1, 3), p);
         yield return TestCase.Create(ImmutableStack.Create(1, 2, 1, 3), isStack: true, provider: p);
-        yield return TestCase.Create(ImmutableHashSet.Create(1, 2, 1, 3), p);
-        yield return TestCase.Create(ImmutableSortedSet.Create(1, 2, 1, 3), p);
+        yield return TestCase.Create(ImmutableHashSet.Create(1, 2, 1, 3), isSet: true, provider: p);
+        yield return TestCase.Create(ImmutableSortedSet.Create(1, 2, 1, 3), isSet: true, provider: p);
         yield return TestCase.Create(ImmutableDictionary.CreateRange(new Dictionary<string, string> { ["key"] = "value" }), p);
         yield return TestCase.Create(ImmutableDictionary.CreateRange(new Dictionary<string, string?> { ["key"] = null }), p);
         yield return TestCase.Create(ImmutableSortedDictionary.CreateRange(new Dictionary<string, string> { ["key"] = "value" }), p);
         yield return TestCase.Create((IImmutableList<int>)[1, 2, 1, 3], p);
         yield return TestCase.Create((IImmutableQueue<int>)[1, 2, 1, 3], p);
-        yield return TestCase.Create((IImmutableSet<int>)[1, 2, 1, 3], p);
+        yield return TestCase.Create((IImmutableSet<int>)[1, 2, 1, 3], isSet: true, provider: p);
         yield return TestCase.Create((IImmutableStack<int>)[1, 2, 1, 3], isStack: true, provider: p);
         yield return TestCase.Create((IImmutableDictionary<string, string>)ImmutableSortedDictionary.CreateRange(new Dictionary<string, string> { ["key"] = "value" }), p);
         yield return TestCase.Create(Enumerable.Range(1, 5).Select(i => i.ToString(CultureInfo.InvariantCulture)).ToFrozenDictionary(i => i, i => i), p);
-        yield return TestCase.Create(Enumerable.Range(1, 5).ToFrozenSet(), p);
+        yield return TestCase.Create(Enumerable.Range(1, 5).ToFrozenSet(), isSet: true, provider: p);
 
         yield return TestCase.Create(new PocoWithListAndDictionaryProps(@string: "myString")
         {
@@ -798,13 +798,13 @@ public sealed partial class ExplicitlyImplementedIDictionary : IDictionary
     IDictionaryEnumerator IDictionary.GetEnumerator() => ((IDictionary)_dictionary).GetEnumerator();
     void IDictionary.Clear() => _dictionary.Clear();
     int ICollection.Count => _dictionary.Count;
+    bool IDictionary.Contains(object key) => _dictionary.ContainsKey(key);
     bool IDictionary.IsFixedSize => throw new NotImplementedException();
     bool IDictionary.IsReadOnly => throw new NotImplementedException();
     bool ICollection.IsSynchronized => throw new NotImplementedException();
     object ICollection.SyncRoot => throw new NotImplementedException();
     ICollection IDictionary.Keys => throw new NotImplementedException();
     ICollection IDictionary.Values => throw new NotImplementedException();
-    bool IDictionary.Contains(object? key) => throw new NotImplementedException();
     void ICollection.CopyTo(Array array, int index) => throw new NotImplementedException();
     void IDictionary.Remove(object? key) => throw new NotImplementedException();
 }

--- a/src/PolyType/Abstractions/Delegates.cs
+++ b/src/PolyType/Abstractions/Delegates.cs
@@ -50,6 +50,28 @@ public delegate TDeclaringType MutableCollectionConstructor<TKey, TDeclaringType
 public delegate TDeclaringType ParameterizedCollectionConstructor<TKey, TElement, TDeclaringType>(ReadOnlySpan<TElement> values, in CollectionConstructionOptions<TKey> options = default);
 
 /// <summary>
+/// Delegate that appends an element to a mutable enumerable collection.
+/// </summary>
+/// <typeparam name="TEnumerable">The type of the enumerable collection to append to.</typeparam>
+/// <typeparam name="TElement">The type of the element to append.</typeparam>
+/// <param name="enumerable">The enumerable collection instance to append the element to.</param>
+/// <param name="value">The element to append to the collection.</param>
+/// <returns><see langword="true"/> if the append operation was successful, <see langword="false"/> otherwise.</returns>
+public delegate bool EnumerableAppender<TEnumerable, TElement>(ref TEnumerable enumerable, TElement value);
+
+/// <summary>
+/// Delegate that inserts a key-value pair into a mutable dictionary.
+/// </summary>
+/// <typeparam name="TDictionary">The type of the dictionary to insert into.</typeparam>
+/// <typeparam name="TKey">The type of the key to insert.</typeparam>
+/// <typeparam name="TValue">The type of the value to insert.</typeparam>
+/// <param name="dictionary">The dictionary instance to insert the key-value pair into.</param>
+/// <param name="key">The key to insert.</param>
+/// <param name="value">The value to insert.</param>
+/// <returns><see langword="true"/> if the insertion was successful, <see langword="false"/> otherwise.</returns>
+public delegate bool DictionaryInserter<TDictionary, TKey, TValue>(ref TDictionary dictionary, TKey key, TValue value);
+
+/// <summary>
 /// Delegate deconstructing an optional type.
 /// </summary>
 /// <typeparam name="TOptional">The optional type to deconstruct.</typeparam>

--- a/src/PolyType/Abstractions/DictionaryInsertionMode.cs
+++ b/src/PolyType/Abstractions/DictionaryInsertionMode.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PolyType.Abstractions;
+
+/// <summary>
+/// Specifies insertion behavior for a mutable dictionary type.
+/// </summary>
+[Flags]
+public enum DictionaryInsertionMode
+{
+    /// <summary>
+    /// No specific insertion behavior is specified.
+    /// </summary>
+    /// <remarks>
+    /// When passed to <see cref="IDictionaryTypeShape{TDictionary, TKey, TValue}.GetInserter(DictionaryInsertionMode)"/>,
+    /// picks any available insertion method offered by the dictionary.
+    /// </remarks>
+    None = 0,
+
+    /// <summary>
+    /// Overwrites the existing value with the new value when the key already exists.
+    /// </summary>
+    /// <remarks>
+    /// Canonically maps to the indexer of the dictionary.
+    /// </remarks>
+    Overwrite = 1,
+
+    /// <summary>
+    /// Discards the new value when the key already exists.
+    /// </summary>
+    /// <remarks>
+    /// Canonically maps to the "TryAdd" method of the dictionary,
+    /// falling back to a combination of "ContainsKey"/"Add" calls if the former is not available.
+    /// </remarks>
+    Discard = 2,
+
+    /// <summary>
+    /// Throws an exception when the key already exists.
+    /// </summary>
+    /// <remarks>
+    /// Canonically maps to the "Add" method of the dictionary.
+    /// </remarks>
+    Throw = 4,
+}

--- a/src/PolyType/Abstractions/IDictionaryTypeShape.cs
+++ b/src/PolyType/Abstractions/IDictionaryTypeShape.cs
@@ -37,6 +37,11 @@ public interface IDictionaryTypeShape : ITypeShape
     /// Gets the kind of custom comparer (if any) that this collection may be initialized with.
     /// </summary>
     CollectionComparerOptions SupportedComparer { get; }
+
+    /// <summary>
+    /// Gets the available insertion modes supported by the dictionary type.
+    /// </summary>
+    DictionaryInsertionMode AvailableInsertionModes { get; }
 }
 
 /// <summary>
@@ -86,11 +91,12 @@ public interface IDictionaryTypeShape<TDictionary, TKey, TValue> : ITypeShape<TD
     MutableCollectionConstructor<TKey, TDictionary> GetMutableConstructor();
 
     /// <summary>
-    /// Creates a setter delegate used for appending a <see cref="KeyValuePair{TKey, TValue}"/> to a mutable dictionary.
+    /// Creates a delegate used for inserting a new key/value pair to a mutable dictionary.
     /// </summary>
+    /// <param name="insertionMode">Specifies the duplicate key handling strategy used by the delegate.</param>
     /// <exception cref="InvalidOperationException">The collection is not <see cref="CollectionConstructionStrategy.Mutable"/>.</exception>
-    /// <returns>A setter delegate used for appending entries to a mutable dictionary.</returns>
-    Setter<TDictionary, KeyValuePair<TKey, TValue>> GetAddKeyValuePair();
+    /// <returns>A delegate used for inserting entries into a mutable dictionary.</returns>
+    DictionaryInserter<TDictionary, TKey, TValue> GetInserter(DictionaryInsertionMode insertionMode = DictionaryInsertionMode.None);
 
     /// <summary>
     /// Creates a delegate for creating a collection from a span.

--- a/src/PolyType/Abstractions/IEnumerableTypeShape.cs
+++ b/src/PolyType/Abstractions/IEnumerableTypeShape.cs
@@ -90,11 +90,11 @@ public interface IEnumerableTypeShape<TEnumerable, TElement> : ITypeShape<TEnume
     MutableCollectionConstructor<TElement, TEnumerable> GetMutableConstructor();
 
     /// <summary>
-    /// Creates a setter delegate used for appending a <typeparamref name="TElement"/> to a mutable collection.
+    /// Creates a delegate used for appending a <typeparamref name="TElement"/> to a mutable collection.
     /// </summary>
     /// <exception cref="InvalidOperationException">The collection is not <see cref="CollectionConstructionStrategy.Mutable"/>.</exception>
     /// <returns>A setter delegate used for appending elements to a mutable collection.</returns>
-    Setter<TEnumerable, TElement> GetAddElement();
+    EnumerableAppender<TEnumerable, TElement> GetAppender();
 
     /// <summary>
     /// Creates a delegate for creating a collection from a span.

--- a/src/PolyType/Abstractions/IEnumerableTypeShape.cs
+++ b/src/PolyType/Abstractions/IEnumerableTypeShape.cs
@@ -49,6 +49,11 @@ public interface IEnumerableTypeShape : ITypeShape
     /// instances to IAsyncEnumerable and enumerate elements asynchronously.
     /// </remarks>
     bool IsAsyncEnumerable { get; }
+
+    /// <summary>
+    /// Indicates whether the enumerable is one of the recognized set collection types.
+    /// </summary>
+    bool IsSetType { get; }
 }
 
 /// <summary>

--- a/src/PolyType/ReflectionProvider/CollectionConstructionInfo.cs
+++ b/src/PolyType/ReflectionProvider/CollectionConstructionInfo.cs
@@ -15,14 +15,37 @@ internal sealed class NoCollectionConstructorInfo() : CollectionConstructorInfo(
     public static NoCollectionConstructorInfo Instance { get; } = new();
 }
 
-internal sealed class MethodCollectionConstructorInfo(
+internal abstract class MethodCollectionConstructorInfo(
     MethodBase factory,
     CollectionConstructorParameter[] signature,
-    CollectionComparerOptions comparerOptions,
-    MethodInfo? addMethod)
-    : CollectionConstructorInfo(addMethod is null ? CollectionConstructionStrategy.Parameterized : CollectionConstructionStrategy.Mutable, comparerOptions)
+    CollectionConstructionStrategy strategy,
+    CollectionComparerOptions comparerOptions)
+    : CollectionConstructorInfo(strategy, comparerOptions)
 {
     public MethodBase Factory { get; } = factory;
     public CollectionConstructorParameter[] Signature { get; } = signature;
-    public MethodInfo? AddMethod { get; } = addMethod;
 }
+
+internal sealed class MutableCollectionConstructorInfo(
+    MethodBase factory,
+    CollectionConstructorParameter[] signature,
+    MethodInfo? addMethod,
+    MethodInfo? setMethod,
+    MethodInfo? tryAddMethod,
+    MethodInfo? containsKeyMethod,
+    DictionaryInsertionMode insertionModes,
+    CollectionComparerOptions comparerOptions)
+    : MethodCollectionConstructorInfo(factory, signature, CollectionConstructionStrategy.Mutable, comparerOptions)
+{
+    public MethodInfo? AddMethod { get; } = addMethod;
+    public MethodInfo? TryAddMethod { get; } = tryAddMethod;
+    public MethodInfo? SetMethod { get; } = setMethod;
+    public MethodInfo? ContainsKeyMethod { get; } = containsKeyMethod;
+    public DictionaryInsertionMode AvailableInsertionModes { get; } = insertionModes;
+}
+
+internal sealed class ParameterizedCollectionConstructorInfo(
+    MethodBase factory,
+    CollectionConstructorParameter[] signature,
+    CollectionComparerOptions comparerOptions)
+    : MethodCollectionConstructorInfo(factory, signature, CollectionConstructionStrategy.Parameterized, comparerOptions);

--- a/src/PolyType/ReflectionProvider/MemberAccessors/IReflectionMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/IReflectionMemberAccessor.cs
@@ -8,8 +8,8 @@ internal interface IReflectionMemberAccessor
     Getter<TDeclaringType, TPropertyType> CreateGetter<TDeclaringType, TPropertyType>(MemberInfo memberInfo, MemberInfo[]? parentMembers);
     Setter<TDeclaringType, TPropertyType> CreateSetter<TDeclaringType, TPropertyType>(MemberInfo memberInfo, MemberInfo[]? parentMembers);
 
-    Setter<TEnumerable, TElement> CreateEnumerableAddDelegate<TEnumerable, TElement>(MethodInfo methodInfo);
-    Setter<TDictionary, KeyValuePair<TKey, TValue>> CreateDictionaryAddDelegate<TDictionary, TKey, TValue>(MethodInfo methodInfo);
+    EnumerableAppender<TEnumerable, TElement> CreateEnumerableAppender<TEnumerable, TElement>(MethodInfo methodInfo);
+    DictionaryInserter<TDictionary, TKey, TValue> CreateDictionaryInserter<TDictionary, TKey, TValue>(MutableCollectionConstructorInfo ctorInfo, DictionaryInsertionMode insertionMode);
 
     Func<TDeclaringType> CreateDefaultConstructor<TDeclaringType>(IConstructorShapeInfo ctorInfo);
 
@@ -23,8 +23,8 @@ internal interface IReflectionMemberAccessor
     Func<T1, T2, TResult> CreateFuncDelegate<T1, T2, TResult>(ConstructorInfo ctorInfo);
 
     bool IsCollectionConstructorSupported(MethodBase method, CollectionConstructorParameter[] signature);
-    MutableCollectionConstructor<TKey, TCollection> CreateMutableCollectionConstructor<TKey, TElement, TCollection>(MethodCollectionConstructorInfo constructorInfo);
-    ParameterizedCollectionConstructor<TKey, TElement, TCollection> CreateParameterizedCollectionConstructor<TKey, TElement, TCollection>(MethodCollectionConstructorInfo constructorInfo);
+    MutableCollectionConstructor<TKey, TCollection> CreateMutableCollectionConstructor<TKey, TElement, TCollection>(MutableCollectionConstructorInfo constructorInfo);
+    ParameterizedCollectionConstructor<TKey, TElement, TCollection> CreateParameterizedCollectionConstructor<TKey, TElement, TCollection>(ParameterizedCollectionConstructorInfo constructorInfo);
 
     Getter<TUnion, int> CreateGetUnionCaseIndex<TUnion>(DerivedTypeInfo[] derivedTypeInfos);
 }

--- a/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
@@ -260,7 +260,7 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
                 // If TryAdd is not available, check if a ContainsKey/Add combination is available.
                 containsKeyMethod = instanceMethods
                     .Where(m =>
-                        m.Name is "ContainsKey" &&
+                        m.Name is "ContainsKey" or "Contains" &&
                         m.GetParameters() is [ParameterInfo key] &&
                         m.ReturnType == typeof(bool) &&
                         key.ParameterType == typeof(TKey))

--- a/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
@@ -13,8 +13,10 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
     where TKey : notnull
 {
     private CollectionConstructorInfo? _constructorInfo;
-    private Setter<TDictionary, KeyValuePair<TKey, TValue>>? _addDelegate;
     private MutableCollectionConstructor<TKey, TDictionary>? _mutableCtorDelegate;
+    private DictionaryInserter<TDictionary, TKey, TValue>? _addInserter;
+    private DictionaryInserter<TDictionary, TKey, TValue>? _setInserter;
+    private DictionaryInserter<TDictionary, TKey, TValue>? _tryAddInserter;
     private ParameterizedCollectionConstructor<TKey, KeyValuePair<TKey, TValue>, TDictionary>? _spanCtorDelegate;
 
     private CollectionConstructorInfo ConstructorInfo
@@ -27,6 +29,10 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
 
     public CollectionComparerOptions SupportedComparer => ConstructorInfo.ComparerOptions;
     public CollectionConstructionStrategy ConstructionStrategy => ConstructorInfo.Strategy;
+    public DictionaryInsertionMode AvailableInsertionModes =>
+        ConstructorInfo is MutableCollectionConstructorInfo mutableCtor
+        ? mutableCtor.AvailableInsertionModes
+        : DictionaryInsertionMode.None;
 
     public ITypeShape<TKey> KeyType => Provider.GetShape<TKey>();
     public ITypeShape<TValue> ValueType => Provider.GetShape<TValue>();
@@ -35,7 +41,7 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
 
     public abstract Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> GetGetDictionary();
 
-    public Setter<TDictionary, KeyValuePair<TKey, TValue>> GetAddKeyValuePair()
+    public DictionaryInserter<TDictionary, TKey, TValue> GetInserter(DictionaryInsertionMode insertionMode)
     {
         if (ConstructionStrategy is not CollectionConstructionStrategy.Mutable)
         {
@@ -43,12 +49,22 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
             static void Throw() => throw new InvalidOperationException("The current dictionary shape does not support mutation.");
         }
 
-        return _addDelegate ?? CommonHelpers.ExchangeIfNull(ref _addDelegate, CreateAddKeyValuePair());
-
-        Setter<TDictionary, KeyValuePair<TKey, TValue>> CreateAddKeyValuePair()
+        switch (DetermineInsertionMode(AvailableInsertionModes, insertionMode))
         {
-            DebugExt.Assert(_constructorInfo is MethodCollectionConstructorInfo { AddMethod: not null });
-            return Provider.MemberAccessor.CreateDictionaryAddDelegate<TDictionary, TKey, TValue>(((MethodCollectionConstructorInfo)_constructorInfo).AddMethod!);
+            case DictionaryInsertionMode.Overwrite: return _setInserter ?? CreateInserter(ref _setInserter, DictionaryInsertionMode.Overwrite);
+            case DictionaryInsertionMode.Discard: return _tryAddInserter ?? CreateInserter(ref _tryAddInserter, DictionaryInsertionMode.Discard);
+            case DictionaryInsertionMode.Throw: return _addInserter ?? CreateInserter(ref _addInserter, DictionaryInsertionMode.Throw);
+            default:
+                Throw();
+                return null!;
+                static void Throw() => throw new ArgumentOutOfRangeException(nameof(insertionMode), "The requested insertion mode is not supported by the current dictionary shape.");
+        }
+
+        DictionaryInserter<TDictionary, TKey, TValue> CreateInserter(ref DictionaryInserter<TDictionary, TKey, TValue>? field, DictionaryInsertionMode insertionMode)
+        {
+            DebugExt.Assert(_constructorInfo is MutableCollectionConstructorInfo);
+            var inserter = Provider.MemberAccessor.CreateDictionaryInserter<TDictionary, TKey, TValue>((MutableCollectionConstructorInfo)_constructorInfo, insertionMode);
+            return CommonHelpers.ExchangeIfNull(ref field, inserter);
         }
     }
 
@@ -64,8 +80,8 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
 
         MutableCollectionConstructor<TKey, TDictionary> CreateMutableCtor()
         {
-            DebugExt.Assert(_constructorInfo is MethodCollectionConstructorInfo);
-            return Provider.MemberAccessor.CreateMutableCollectionConstructor<TKey, TValue, TDictionary>((MethodCollectionConstructorInfo)_constructorInfo);
+            DebugExt.Assert(_constructorInfo is MutableCollectionConstructorInfo);
+            return Provider.MemberAccessor.CreateMutableCollectionConstructor<TKey, TValue, TDictionary>((MutableCollectionConstructorInfo)_constructorInfo);
         }
     }
 
@@ -80,8 +96,8 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
         return _spanCtorDelegate ?? CommonHelpers.ExchangeIfNull(ref _spanCtorDelegate, CreateParameterizedCtor());
         ParameterizedCollectionConstructor<TKey, KeyValuePair<TKey, TValue>, TDictionary> CreateParameterizedCtor()
         {
-            DebugExt.Assert(_constructorInfo is MethodCollectionConstructorInfo);
-            return Provider.MemberAccessor.CreateParameterizedCollectionConstructor<TKey, KeyValuePair<TKey, TValue>, TDictionary>((MethodCollectionConstructorInfo)_constructorInfo);
+            DebugExt.Assert(_constructorInfo is ParameterizedCollectionConstructorInfo);
+            return Provider.MemberAccessor.CreateParameterizedCollectionConstructor<TKey, KeyValuePair<TKey, TValue>, TDictionary>((ParameterizedCollectionConstructorInfo)_constructorInfo);
         }
     }
 
@@ -96,107 +112,219 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
         // Used by the F# map factory method.
         Type correspondingTupleEnumerableType = typeof(IEnumerable<Tuple<TKey, TValue>>);
 
-        if (dictionaryType.IsInterface)
+        if (GetImmutableDictionaryFactory() is { } factoryCtorInfo)
         {
-            if (dictionaryType.IsAssignableFrom(typeof(Dictionary<TKey, TValue>)))
-            {
-                // Handle IDictionary, IDictionary<TKey, TValue> and IReadOnlyDictionary<TKey, TValue> using Dictionary<TKey, TValue>
-                dictionaryType = typeof(Dictionary<TKey, TValue>);
-            }
-            else if (dictionaryType == typeof(IDictionary))
-            {
-                // Handle IDictionary using Dictionary<object, object>
-                Debug.Assert(typeof(TKey) == typeof(object) && typeof(TValue) == typeof(object));
-                dictionaryType = typeof(Dictionary<object, object>);
-            }
+            return factoryCtorInfo;
         }
 
-        ConstructorInfo[] allCtors = dictionaryType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
-        MethodInfo? addMethod = ResolveAddMethod(dictionaryType);
+        ConstructorInfo[] allCtors = DetermineImplementationType(dictionaryType).GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        DictionaryInsertionMode availableInsertionModes = ResolveInsertionMethods(
+            typeof(TDictionary),
+            out MethodInfo? addMethod,
+            out MethodInfo? setMethod,
+            out MethodInfo? tryAddMethod,
+            out MethodInfo? containsKeyMethod);
+
         if (Provider.ResolveBestCollectionCtor<KeyValuePair<TKey, TValue>, TKey>(
                 dictionaryType,
                 allCtors,
                 addMethod,
+                setMethod,
+                tryAddMethod,
+                containsKeyMethod,
+                availableInsertionModes,
                 correspondingGenericDictionaryType,
                 correspondingTupleEnumerableType) is { } collectionCtorInfo)
         {
             return collectionCtorInfo;
         }
 
-        if (dictionaryType is { Name: "ImmutableDictionary`2", Namespace: "System.Collections.Immutable" }
-                           or { Name: "IImmutableDictionary`2", Namespace: "System.Collections.Immutable" })
-        {
-            return ResolveFactoryMethod("System.Collections.Immutable.ImmutableDictionary");
-        }
-
-        if (dictionaryType is { Name: "ImmutableSortedDictionary`2", Namespace: "System.Collections.Immutable" })
-        {
-            return ResolveFactoryMethod("System.Collections.Immutable.ImmutableSortedDictionary");
-        }
-
-        if (dictionaryType is { Name: "FrozenDictionary`2", Namespace: "System.Collections.Frozen" })
-        {
-            return ResolveFactoryMethod("System.Collections.Frozen.FrozenDictionary", "ToFrozenDictionary");
-        }
-
-        if (dictionaryType is { Name: "FSharpMap`2", Namespace: "Microsoft.FSharp.Collections" })
-        {
-            return ResolveFactoryMethod("Microsoft.FSharp.Collections.MapModule", "OfSeq");
-        }
-
         return NoCollectionConstructorInfo.Instance;
 
-        CollectionConstructorInfo ResolveFactoryMethod(string typeName, string? factoryName = null)
+        CollectionConstructorInfo? GetImmutableDictionaryFactory()
         {
-            Type? factoryType = dictionaryType.Assembly.GetType(typeName);
-            if (factoryType is not null)
+            if (dictionaryType == typeof(IReadOnlyDictionary<TKey, TValue>))
             {
-                var candidates = factoryType.GetMethods(BindingFlags.Public | BindingFlags.Static)
-                    .Where(m => factoryName is null ? m.Name is "Create" or "CreateRange" : m.Name == factoryName)
-                    .Where(m => m.GetGenericArguments().Length == 2)
-                    .Select(m => m.MakeGenericMethod(typeof(TKey), typeof(TValue)));
+                return ResolveFactoryMethod("PolyType.SourceGenModel.CollectionHelpers", "CreateDictionary");
+            }
 
-                if (Provider.ResolveBestCollectionCtor<KeyValuePair<TKey, TValue>, TKey>(
-                        dictionaryType,
-                        candidates,
-                        addMethod: null,
-                        correspondingGenericDictionaryType,
-                        correspondingTupleEnumerableType) is { } factoryCtorInfo)
+            if (dictionaryType is { Name: "ImmutableDictionary`2", Namespace: "System.Collections.Immutable" }
+                   or { Name: "IImmutableDictionary`2", Namespace: "System.Collections.Immutable" })
+            {
+                return ResolveFactoryMethod("System.Collections.Immutable.ImmutableDictionary");
+            }
+
+            if (dictionaryType is { Name: "ImmutableSortedDictionary`2", Namespace: "System.Collections.Immutable" })
+            {
+                return ResolveFactoryMethod("System.Collections.Immutable.ImmutableSortedDictionary");
+            }
+
+            if (dictionaryType is { Name: "FrozenDictionary`2", Namespace: "System.Collections.Frozen" })
+            {
+                return ResolveFactoryMethod("System.Collections.Frozen.FrozenDictionary", "ToFrozenDictionary");
+            }
+
+            if (dictionaryType is { Name: "FSharpMap`2", Namespace: "Microsoft.FSharp.Collections" })
+            {
+                return ResolveFactoryMethod("Microsoft.FSharp.Collections.MapModule", "OfSeq");
+            }
+
+            return null;
+
+            CollectionConstructorInfo ResolveFactoryMethod(string typeName, string? factoryName = null)
+            {
+                Type? factoryType = dictionaryType.Assembly.GetType(typeName) ?? Assembly.GetExecutingAssembly().GetType(typeName);
+                if (factoryType is not null)
                 {
-                    return factoryCtorInfo;
+                    var candidates = factoryType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                        .Where(m => factoryName is null ? m.Name is "Create" or "CreateRange" : m.Name == factoryName)
+                        .Where(m => m.GetGenericArguments().Length == 2)
+                        .Select(m => m.MakeGenericMethod(typeof(TKey), typeof(TValue)));
+
+                    if (Provider.ResolveBestCollectionCtor<KeyValuePair<TKey, TValue>, TKey>(
+                            dictionaryType,
+                            candidates,
+                            addMethod: null,
+                            correspondingDictionaryType: correspondingGenericDictionaryType,
+                            correspondingTupleEnumerableType: correspondingTupleEnumerableType) is { } factoryCtorInfo)
+                    {
+                        return factoryCtorInfo;
+                    }
+                }
+
+                return NoCollectionConstructorInfo.Instance;
+            }
+        }
+
+        static DictionaryInsertionMode ResolveInsertionMethods(
+            Type dictionaryType,
+            out MethodInfo? addMethod,
+            out MethodInfo? setMethod,
+            out MethodInfo? tryAddMethod,
+            out MethodInfo? containsKeyMethod)
+        {
+            IEnumerable<MethodInfo> instanceMethods = dictionaryType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+            if (!dictionaryType.IsInterface)
+            {
+                if (typeof(IDictionary<TKey, TValue>).IsAssignableFrom(dictionaryType))
+                {
+                    instanceMethods = instanceMethods.Concat(typeof(IDictionary<TKey, TValue>).GetMethods());
+                }
+                else if (typeof(IDictionary).IsAssignableFrom(dictionaryType))
+                {
+                    instanceMethods = instanceMethods.Concat(typeof(IDictionary).GetMethods());
                 }
             }
 
-            return NoCollectionConstructorInfo.Instance;
-        }
+            DictionaryInsertionMode availableModes = DictionaryInsertionMode.None;
 
-        static MethodInfo? ResolveAddMethod(Type dictionaryType)
-        {
-            MethodInfo? addMethod = dictionaryType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            addMethod = instanceMethods
                 .Where(m =>
-                    m.Name is "set_Item" or "Add" &&
+                    m.Name is "Add" &&
                     m.GetParameters() is [ParameterInfo key, ParameterInfo value] &&
                     key.ParameterType == typeof(TKey) && value.ParameterType == typeof(TValue))
-                .OrderByDescending(m => m.Name) // Prefer set_Item over Add
                 .FirstOrDefault();
 
-            if (!dictionaryType.IsValueType)
+            if (addMethod is not null)
             {
-                // If no indexer was found, check for potential explicit interface implementations.
-                // Only do so if the type is not a value type, since this would force boxing otherwise.
-                if (addMethod is null && typeof(IDictionary<TKey, TValue>).IsAssignableFrom(dictionaryType))
-                {
-                    addMethod = typeof(IDictionary<TKey, TValue>).GetMethod("set_Item", BindingFlags.Public | BindingFlags.Instance);
-                }
-
-                if (addMethod is null && typeof(IDictionary).IsAssignableFrom(dictionaryType) && typeof(TKey) == typeof(object))
-                {
-                    addMethod = typeof(IDictionary).GetMethod("set_Item", BindingFlags.Public | BindingFlags.Instance);
-                }
+                availableModes |= DictionaryInsertionMode.Throw;
             }
 
-            return addMethod;
+            setMethod = instanceMethods
+                .Where(m =>
+                    m.Name is "set_Item" &&
+                    m.GetParameters() is [ParameterInfo key, ParameterInfo value] &&
+                    key.ParameterType == typeof(TKey) && value.ParameterType == typeof(TValue))
+                .FirstOrDefault();
+
+            if (setMethod is not null)
+            {
+                availableModes |= DictionaryInsertionMode.Overwrite;
+            }
+
+            tryAddMethod = instanceMethods
+                .Where(m =>
+                    m.Name is "TryAdd" &&
+                    m.GetParameters() is [ParameterInfo key, ParameterInfo value] &&
+                    m.ReturnType == typeof(bool) &&
+                    key.ParameterType == typeof(TKey) && value.ParameterType == typeof(TValue))
+                .FirstOrDefault();
+
+            if (tryAddMethod is not null)
+            {
+                availableModes |= DictionaryInsertionMode.Discard;
+                containsKeyMethod = null;
+            }
+            else if (addMethod is not null || setMethod is not null)
+            {
+                // If TryAdd is not available, check if a ContainsKey/Add combination is available.
+                containsKeyMethod = instanceMethods
+                    .Where(m =>
+                        m.Name is "ContainsKey" &&
+                        m.GetParameters() is [ParameterInfo key] &&
+                        m.ReturnType == typeof(bool) &&
+                        key.ParameterType == typeof(TKey))
+                    .FirstOrDefault();
+
+                if (containsKeyMethod is not null)
+                {
+                    availableModes |= DictionaryInsertionMode.Discard;
+                }
+            }
+            else
+            {
+                containsKeyMethod = null;
+            }
+
+            return availableModes;
         }
+    }
+
+    private static Type DetermineImplementationType(Type dictionaryType)
+    {
+        if (dictionaryType.IsInterface)
+        {
+            if (dictionaryType == typeof(IDictionary<TKey, TValue>) ||
+                dictionaryType == typeof(IDictionary))
+            {
+                // Handle IDictionary<TKey, TValue> and IDictionary using Dictionary<TKey, TValue>
+                return typeof(Dictionary<TKey, TValue>);
+            }
+        }
+
+        return dictionaryType;
+    }
+
+    private static DictionaryInsertionMode DetermineInsertionMode(DictionaryInsertionMode supportedModes, DictionaryInsertionMode requestedMode)
+    {
+        Debug.Assert(supportedModes is not DictionaryInsertionMode.None);
+        switch (requestedMode)
+        {
+            case DictionaryInsertionMode.None:
+                // If no specific mode is requested, return the first supported mode.
+                ReadOnlySpan<DictionaryInsertionMode> allModes = [
+                    DictionaryInsertionMode.Overwrite,
+                    DictionaryInsertionMode.Discard,
+                    DictionaryInsertionMode.Throw
+                ];
+
+                foreach (var mode in allModes)
+                {
+                    if ((supportedModes & mode) != 0)
+                    {
+                        return mode;
+                    }
+                }
+
+                break;
+
+            case DictionaryInsertionMode.Overwrite when (supportedModes & DictionaryInsertionMode.Overwrite) != 0:
+            case DictionaryInsertionMode.Discard when (supportedModes & DictionaryInsertionMode.Discard) != 0:
+            case DictionaryInsertionMode.Throw when (supportedModes & DictionaryInsertionMode.Throw) != 0:
+                return requestedMode;
+        }
+
+        return DictionaryInsertionMode.None;
     }
 }
 

--- a/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
@@ -12,7 +12,7 @@ namespace PolyType.ReflectionProvider;
 internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(ReflectionTypeShapeProvider provider) : ReflectionTypeShape<TEnumerable>(provider), IEnumerableTypeShape<TEnumerable, TElement>
 {
     private CollectionConstructorInfo? _constructorInfo;
-    private Setter<TEnumerable, TElement>? _addDelegate;
+    private EnumerableAppender<TEnumerable, TElement>? _addDelegate;
     private MutableCollectionConstructor<TElement, TEnumerable>? _mutableCtorDelegate;
     private ParameterizedCollectionConstructor<TElement, TElement, TEnumerable>? _spanCtorDelegate;
 
@@ -33,7 +33,7 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
     public ITypeShape<TElement> ElementType => Provider.GetShape<TElement>();
     ITypeShape IEnumerableTypeShape.ElementType => ElementType;
 
-    public virtual Setter<TEnumerable, TElement> GetAddElement()
+    public virtual EnumerableAppender<TEnumerable, TElement> GetAppender()
     {
         if (ConstructionStrategy is not CollectionConstructionStrategy.Mutable)
         {
@@ -43,10 +43,10 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
         return _addDelegate ?? CommonHelpers.ExchangeIfNull(ref _addDelegate, CreateAddDelegate());
 
-        Setter<TEnumerable, TElement> CreateAddDelegate()
+        EnumerableAppender<TEnumerable, TElement> CreateAddDelegate()
         {
-            DebugExt.Assert(ConstructorInfo is MethodCollectionConstructorInfo { AddMethod: not null });
-            return Provider.MemberAccessor.CreateEnumerableAddDelegate<TEnumerable, TElement>(((MethodCollectionConstructorInfo)ConstructorInfo).AddMethod!);
+            DebugExt.Assert(ConstructorInfo is MutableCollectionConstructorInfo { AddMethod: not null });
+            return Provider.MemberAccessor.CreateEnumerableAppender<TEnumerable, TElement>(((MutableCollectionConstructorInfo)ConstructorInfo).AddMethod!);
         }
     }
 
@@ -62,8 +62,8 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
         MutableCollectionConstructor<TElement, TEnumerable> CreateDefaultConstructor()
         {
-            DebugExt.Assert(ConstructorInfo is MethodCollectionConstructorInfo);
-            return Provider.MemberAccessor.CreateMutableCollectionConstructor<TElement, TElement, TEnumerable>((MethodCollectionConstructorInfo)ConstructorInfo);
+            DebugExt.Assert(ConstructorInfo is MutableCollectionConstructorInfo);
+            return Provider.MemberAccessor.CreateMutableCollectionConstructor<TElement, TElement, TEnumerable>((MutableCollectionConstructorInfo)ConstructorInfo);
         }
     }
 
@@ -79,8 +79,8 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
         ParameterizedCollectionConstructor<TElement, TElement, TEnumerable> CreateParameterizedConstructor()
         {
-            DebugExt.Assert(ConstructorInfo is MethodCollectionConstructorInfo);
-            return Provider.MemberAccessor.CreateParameterizedCollectionConstructor<TElement, TElement, TEnumerable>((MethodCollectionConstructorInfo)ConstructorInfo);
+            DebugExt.Assert(ConstructorInfo is ParameterizedCollectionConstructorInfo);
+            return Provider.MemberAccessor.CreateParameterizedCollectionConstructor<TElement, TElement, TEnumerable>((ParameterizedCollectionConstructorInfo)ConstructorInfo);
         }
     }
 
@@ -92,22 +92,8 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
         }
 
         Type enumerableType = typeof(TEnumerable);
-        if (enumerableType.IsInterface)
-        {
-            if (enumerableType.IsAssignableFrom(typeof(List<TElement>)))
-            {
-                // Handle IEnumerable<T>, ICollection<T>, IList<T>, IReadOnlyCollection<T> and IReadOnlyList<T> types using List<T>
-                enumerableType = typeof(List<TElement>);
-            }
-            else if (enumerableType.IsAssignableFrom(typeof(HashSet<TElement>)))
-            {
-                // Handle ISet<T> and IReadOnlySet<T> types using HashSet<T>
-                enumerableType = typeof(HashSet<TElement>);
-            }
-        }
-
-        ConstructorInfo[] allCtors = enumerableType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
-        MethodInfo? addMethod = ResolveAddMethod(enumerableType);
+        ConstructorInfo[] allCtors = DetermineImplementationType(enumerableType).GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        MethodInfo? addMethod = ResolveAddMethod(typeof(TEnumerable));
         if (Provider.ResolveBestCollectionCtor<TElement, TElement>(enumerableType, allCtors, addMethod) is { } collectionCtorInfo)
         {
             return collectionCtorInfo;
@@ -124,6 +110,24 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
         CollectionConstructorInfo? TryGetImmutableCollectionFactory()
         {
+            if (typeof(TEnumerable) == typeof(IEnumerable) ||
+                typeof(TEnumerable) == typeof(ICollection) ||
+                typeof(TEnumerable) == typeof(IEnumerable<TElement>) ||
+                typeof(TEnumerable) == typeof(IReadOnlyCollection<TElement>) ||
+                typeof(TEnumerable) == typeof(IReadOnlyList<TElement>))
+            {
+                // Handle readonly list-like collection interfaces using a static factory method.
+                return ResolveFactoryMethod("PolyType.SourceGenModel.CollectionHelpers", "CreateList");
+            }
+
+#if NET
+            if (typeof(TEnumerable) == typeof(IReadOnlySet<TElement>))
+            {
+                // Handle readonly set-like collection interfaces using a static factory method.
+                return ResolveFactoryMethod("PolyType.SourceGenModel.CollectionHelpers", "CreateHashSet");
+            }
+#endif
+
             if (typeof(TEnumerable) is { Name: "ImmutableArray`1", Namespace: "System.Collections.Immutable" })
             {
                 return ResolveFactoryMethod("System.Collections.Immutable.ImmutableArray");
@@ -169,7 +173,7 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
             CollectionConstructorInfo ResolveFactoryMethod(string typeName, string? factoryName = null)
             {
-                Type? factoryType = typeof(TEnumerable).Assembly.GetType(typeName);
+                Type? factoryType = typeof(TEnumerable).Assembly.GetType(typeName) ?? Assembly.GetExecutingAssembly().GetType(typeName);
                 if (factoryType is not null)
                 {
                     var candidates = factoryType.GetMethods(BindingFlags.Public | BindingFlags.Static)
@@ -187,6 +191,27 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
             }
         }
 
+        static Type DetermineImplementationType(Type enumerableType)
+        {
+            if (enumerableType.IsInterface)
+            {
+                if (enumerableType == typeof(ICollection<TElement>) ||
+                    enumerableType == typeof(IList<TElement>) ||
+                    enumerableType == typeof(IList))
+                {
+                    // Handle IList, ICollection<T> and IList<T> types using List<T>
+                    return typeof(List<TElement>);
+                }
+                else if (enumerableType == typeof(ISet<TElement>))
+                {
+                    // Handle ISet<T> types using HashSet<T>
+                    return typeof(HashSet<TElement>);
+                }
+            }
+
+            return enumerableType;
+        }
+
         static MethodInfo? ResolveAddMethod(Type enumerableType)
         {
             MethodInfo? addMethod = null;
@@ -201,10 +226,9 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
                 }
             }
 
-            if (!enumerableType.IsValueType)
+            if (!enumerableType.IsInterface)
             {
                 // If no Add method was found, check for potential explicit interface implementations.
-                // Only do so if the type is not a value type, since this would force boxing otherwise.
                 if (addMethod is null && typeof(ICollection<TElement>).IsAssignableFrom(enumerableType))
                 {
                     addMethod = typeof(ICollection<TElement>).GetMethod(nameof(ICollection<TElement>.Add));

--- a/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
@@ -26,6 +26,9 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
     public virtual int Rank => 1;
     public virtual bool IsAsyncEnumerable => false;
+    public bool IsSetType => _isSetType ??= DetermineIsSetType();
+    private bool? _isSetType;
+
     public abstract Func<TEnumerable, IEnumerable<TElement>> GetGetEnumerable();
 
     public sealed override TypeShapeKind Kind => TypeShapeKind.Enumerable;
@@ -242,6 +245,16 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
             return addMethod;
         }
+    }
+
+    private static bool DetermineIsSetType()
+    {
+        return
+            typeof(ISet<TElement>).IsAssignableFrom(typeof(TEnumerable)) ||
+#if NET
+            typeof(IReadOnlySet<TElement>).IsAssignableFrom(typeof(TEnumerable)) ||
+#endif
+            typeof(TEnumerable) is { Name: "IImmutableSet`1", Namespace: "System.Collections.Immutable" };
     }
 }
 

--- a/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
@@ -25,6 +25,11 @@ public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : Source
     public required bool IsAsyncEnumerable { get; init; }
 
     /// <summary>
+    /// Indicates whether the enumerable is one of the recognized set collection types.
+    /// </summary>
+    public required bool IsSetType { get; init; }
+
+    /// <summary>
     /// Gets the function that retrieves an enumerable from an instance of the collection.
     /// </summary>
     public required Func<TEnumerable, IEnumerable<TElement>> GetEnumerableFunc { get; init; }

--- a/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
@@ -43,9 +43,9 @@ public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : Source
     public MutableCollectionConstructor<TElement, TEnumerable>? MutableConstructorFunc { get; init; }
 
     /// <summary>
-    /// Gets the function that adds an element to the collection.
+    /// Gets the function that appends an element to the collection.
     /// </summary>
-    public Setter<TEnumerable, TElement>? AddElementFunc { get; init; }
+    public EnumerableAppender<TEnumerable, TElement>? AppenderFunc { get; init; }
 
     /// <summary>
     /// Gets the function that constructs a collection from a span.
@@ -66,8 +66,8 @@ public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : Source
     MutableCollectionConstructor<TElement, TEnumerable> IEnumerableTypeShape<TEnumerable, TElement>.GetMutableConstructor()
         => MutableConstructorFunc ?? throw new InvalidOperationException("Enumerable shape does not specify a default constructor.");
 
-    Setter<TEnumerable, TElement> IEnumerableTypeShape<TEnumerable, TElement>.GetAddElement()
-        => AddElementFunc ?? throw new InvalidOperationException("Enumerable shape does not specify an append delegate.");
+    EnumerableAppender<TEnumerable, TElement> IEnumerableTypeShape<TEnumerable, TElement>.GetAppender()
+        => AppenderFunc ?? throw new InvalidOperationException("Enumerable shape does not specify an append delegate.");
 
     ParameterizedCollectionConstructor<TElement, TElement, TEnumerable> IEnumerableTypeShape<TEnumerable, TElement>.GetParameterizedConstructor()
         => SpanConstructorFunc ?? throw new InvalidOperationException("Enumerable shape does not specify a span constructor.");

--- a/src/Shared/Helpers/ReflectionHelpers.cs
+++ b/src/Shared/Helpers/ReflectionHelpers.cs
@@ -414,24 +414,6 @@ internal static class ReflectionHelpers
         }
     }
 
-    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
-    public static bool ImplementsInterface(this Type type, Type interfaceType)
-    {
-        Debug.Assert(interfaceType is { IsInterface: true, IsConstructedGenericType: false });
-
-        foreach (Type otherInterface in type.GetAllInterfaces())
-        {
-            if (otherInterface.IsGenericType
-                ? otherInterface.GetGenericTypeDefinition() == interfaceType
-                : otherInterface == interfaceType)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     public static bool IsExplicitInterfaceImplementation(this MethodInfo methodInfo)
     {
         DebugExt.Assert(!methodInfo.IsStatic);

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -481,6 +481,7 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
         {
             IEnumerableTypeShape enumerableTypeType = Assert.IsAssignableFrom<IEnumerableTypeShape>(shape);
             Assert.Equal(typeof(T), enumerableTypeType.Type);
+            Assert.Equal(testCase.IsSet, enumerableTypeType.IsSetType);
 
             if (typeof(T).GetCompatibleGenericInterface(typeof(IEnumerable<>)) is { } enumerableImplementation)
             {


### PR DESCRIPTION
This PR enables optional duplicate element/key tracking for mutable collection types. It does so by replacing the `Setter<,>` delegate used to represent the "Add" functions with bespoke delegate types that return `bool` indicating the success of the operation. The `GetAddMethod()` name has been replaced with `GetAppender()` and `GetInserter()` for enumerable and dictionary types respectively. Dictionary types additionally accept a `DictionaryInsertionMode` enum that controls how duplicate will be handled.

cc @AArnott 

Fix #205.