### PR TITLE
Introduce an `IArgumentState` interface for constructor shapes.

### DIFF
--- a/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
@@ -61,7 +61,7 @@ public static partial class CborSerializer
 
             if (constructor.Parameters is [])
             {
-                return new CborObjectConverterWithDefaultCtor<TDeclaringType>(constructor.GetDefaultConstructor(), properties);
+                return new CborObjectConverterWithDefaultCtor<TDeclaringType>(constructor.GetDefaultConstructor(), properties, constructor.DeclaringType.Properties);
             }
 
             CborPropertyConverter<TArgumentState>[] constructorParams = constructor.Parameters
@@ -72,7 +72,8 @@ public static partial class CborSerializer
                 constructor.GetArgumentStateConstructor(),
                 constructor.GetParameterizedConstructor(),
                 constructorParams,
-                properties);
+                properties,
+                constructor.Parameters);
         }
 
         public override object? VisitParameter<TArgumentState, TParameterType>(IParameterShape<TArgumentState, TParameterType> parameter, object? state)

--- a/src/PolyType.Examples/CborSerializer/Converters/CborPropertyConverter.cs
+++ b/src/PolyType.Examples/CborSerializer/Converters/CborPropertyConverter.cs
@@ -9,7 +9,7 @@ internal abstract class CborPropertyConverter<TDeclaringType>(string name)
     public string Name { get; } = name;
     public abstract bool HasGetter { get; }
     public abstract bool HasSetter { get; }
-    public bool IsParameter { get; private protected init; }
+    public int Position { get; private protected init; }
 
     public abstract void Write(CborWriter writer, ref TDeclaringType value);
     public abstract void Read(CborReader reader, ref TDeclaringType value);
@@ -24,6 +24,7 @@ internal sealed class CborPropertyConverter<TDeclaringType, TPropertyType> : Cbo
     public CborPropertyConverter(IPropertyShape<TDeclaringType, TPropertyType> property, CborConverter<TPropertyType> propertyConverter)
         : base(property.Name)
     {
+        Position = property.Position;
         _propertyConverter = propertyConverter;
 
         if (property.HasGetter)
@@ -38,11 +39,11 @@ internal sealed class CborPropertyConverter<TDeclaringType, TPropertyType> : Cbo
     }
 
     public CborPropertyConverter(IParameterShape<TDeclaringType, TPropertyType> parameter, CborConverter<TPropertyType> propertyConverter)
-    : base(parameter.Name)
+        : base(parameter.Name)
     {
         _propertyConverter = propertyConverter;
         _setter = parameter.GetSetter();
-        IsParameter = parameter.Kind is ParameterKind.MethodParameter;
+        Position = parameter.Position;
     }
 
     public override bool HasGetter => _getter != null;

--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonPropertyConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonPropertyConverter.cs
@@ -11,7 +11,6 @@ internal abstract class JsonPropertyConverter<TDeclaringType>(string name)
     public JsonEncodedText EncodedName { get; } = JsonEncodedText.Encode(name);
     public abstract bool HasGetter { get; }
     public abstract bool HasSetter { get; }
-    public bool IsParameter { get; private protected init; }
 
     public abstract void Read(ref Utf8JsonReader reader, ref TDeclaringType declaringType, JsonSerializerOptions options);
     public abstract void Write(Utf8JsonWriter writer, ref TDeclaringType declaringType, JsonSerializerOptions options);
@@ -49,7 +48,6 @@ internal sealed class JsonPropertyConverter<TDeclaringType, TPropertyType> : Jso
         _propertyTypeConverter = propertyConverter;
         _setterDisallowsNull = parameter.IsNonNullable;
         _setter = parameter.GetSetter();
-        IsParameter = parameter.Kind is ParameterKind.MethodParameter;
     }
 
     public override bool HasGetter => _getter != null;

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
@@ -65,7 +65,8 @@ public static partial class JsonSerializerTS
                 constructor.GetArgumentStateConstructor(), 
                 constructor.GetParameterizedConstructor(), 
                 constructorParams,
-                properties);
+                properties,
+                constructor.Parameters);
         }
 
         public override object? VisitParameter<TArgumentState, TParameter>(IParameterShape<TArgumentState, TParameter> parameter, object? state)

--- a/src/PolyType.Examples/Utilities/DuplicateDictionaryKeyValidator.cs
+++ b/src/PolyType.Examples/Utilities/DuplicateDictionaryKeyValidator.cs
@@ -28,7 +28,7 @@ public static class DuplicateDictionaryKeyValidator
 /// <summary>
 /// Performs post-hoc duplicate key detection for parameterized dictionary constructors.
 /// </summary>
-public sealed class DuplicateDictionaryKeyValidator<TDictionary, TKey, TValue>
+public readonly struct DuplicateDictionaryKeyValidator<TDictionary, TKey, TValue>
     where TKey : notnull
 {
     private readonly Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> _getDictionary;

--- a/src/PolyType.Examples/Utilities/DuplicatePropertyValidator.cs
+++ b/src/PolyType.Examples/Utilities/DuplicatePropertyValidator.cs
@@ -1,0 +1,80 @@
+﻿using PolyType.Abstractions;
+using System.Collections;
+
+namespace PolyType.Examples.Utilities;
+
+/// <summary>
+/// A helper type for tracking duplicate properties assigned to a mutable object.
+/// </summary>
+public struct DuplicatePropertyValidator
+{
+    private readonly IReadOnlyList<IPropertyShape> _properties;
+    private readonly Func<IPropertyShape, Exception> _throwOnDuplicateProperty;
+    private readonly uint _length;
+    private ulong _smallSet;
+    private readonly BitArray? _largeSet;
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="DuplicatePropertyValidator"/> struct.
+    /// </summary>
+    /// <param name="properties">The list of properties to track.</param>
+    /// <param name="throwOnDuplicateProperty">A function to call when a duplicate property is detected.</param>
+    public DuplicatePropertyValidator(
+        IReadOnlyList<IPropertyShape> properties,
+        Func<IPropertyShape, Exception>? throwOnDuplicateProperty = null)
+    {
+        _properties = properties ?? throw new ArgumentNullException(nameof(properties));
+        _throwOnDuplicateProperty = throwOnDuplicateProperty ?? (static prop => new ArgumentException($"Duplicate property: {prop.Name}"));
+        _length = (uint)properties.Count;
+        if (_length > 64)
+        {
+            _largeSet = new BitArray((int)_length);
+        }
+    }
+
+    /// <summary>
+    /// Marks the property as read or throws an exception if the property has already been added.
+    /// </summary>
+    /// <param name="propertyIndex">The index of the property we're marking as read.</param>
+    public void MarkAsRead(int propertyIndex)
+    {
+        if (!TryMarkAsRead(propertyIndex))
+        {
+            ThrowDuplicateProperty(propertyIndex);
+        }
+    }
+
+    /// <summary>
+    /// Attempts to mark the property as read without throwing an exception.
+    /// </summary>
+    /// <param name="propertyIndex">The index of the property to mark as read.</param>
+    public bool TryMarkAsRead(int propertyIndex)
+    {
+        if ((uint)propertyIndex >= _length)
+        {
+            Throw();
+            static void Throw() => throw new ArgumentOutOfRangeException(nameof(propertyIndex), "Index is out of range.");
+        }
+
+        bool isUnset;
+        if (_largeSet is BitArray bitArray)
+        {
+            isUnset = !bitArray[propertyIndex];
+            bitArray[propertyIndex] = true;
+        }
+        else
+        {
+            ulong flag = 1UL << propertyIndex;
+            isUnset = (_smallSet & flag) == 0;
+            _smallSet |= flag;
+        }
+
+        return isUnset;
+    }
+
+    private void ThrowDuplicateProperty(int propertyIndex)
+    {
+        IPropertyShape property = _properties[propertyIndex];
+        throw _throwOnDuplicateProperty(property);
+    }
+}

--- a/src/PolyType.Examples/Utilities/Helpers.cs
+++ b/src/PolyType.Examples/Utilities/Helpers.cs
@@ -10,6 +10,22 @@ namespace PolyType.Examples.Utilities;
 
 internal static class Helpers
 {
+    public static void ThrowMissingRequiredArguments<TArgumentState>(ref TArgumentState argumentState, IReadOnlyList<IParameterShape> parameters)
+        where TArgumentState : IArgumentState
+    {
+        Debug.Assert(!argumentState.AreRequiredArgumentsSet);
+        List<string> missingRequiredParams = new();
+        foreach (IParameterShape parameter in parameters)
+        {
+            if (parameter.IsRequired && !argumentState.IsArgumentSet(parameter.Position))
+            {
+                missingRequiredParams.Add($"'{parameter.Name}'");
+            }
+        }
+
+        throw new KeyNotFoundException($"Missing required parameters: {string.Join(", ", missingRequiredParams)}");
+    }
+
     public static string ConvertBytesToHexString(byte[] bytes)
     {
 #if NET

--- a/src/PolyType.Examples/XmlSerializer/Converters/XmlObjectConverter.cs
+++ b/src/PolyType.Examples/XmlSerializer/Converters/XmlObjectConverter.cs
@@ -1,4 +1,5 @@
 ﻿using PolyType.Abstractions;
+using PolyType.Examples.Utilities;
 using System.Xml;
 
 namespace PolyType.Examples.XmlSerializer.Converters;
@@ -75,7 +76,9 @@ internal sealed class XmlObjectConverterWithParameterizedCtor<TDeclaringType, TA
     Func<TArgumentState> createArgumentState,
     Constructor<TArgumentState, TDeclaringType> createObject,
     XmlPropertyConverter<TArgumentState>[] constructorParameters,
-    XmlPropertyConverter<TDeclaringType>[] properties) : XmlObjectConverter<TDeclaringType>(properties)
+    XmlPropertyConverter<TDeclaringType>[] properties,
+    IReadOnlyList<IParameterShape> parameters) : XmlObjectConverter<TDeclaringType>(properties)
+    where TArgumentState : IArgumentState
 {
     private readonly Dictionary<string, XmlPropertyConverter<TArgumentState>> _constructorParameters = constructorParameters
         .ToDictionary(param => param.Name, StringComparer.Ordinal);
@@ -114,6 +117,12 @@ internal sealed class XmlObjectConverterWithParameterizedCtor<TDeclaringType, TA
         }
 
         reader.ReadEndElement();
+
+        if (!argumentState.AreRequiredArgumentsSet)
+        {
+            Helpers.ThrowMissingRequiredArguments(ref argumentState, parameters);
+        }
+
         return createObject(ref argumentState);
     }
 }

--- a/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
+++ b/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
@@ -63,7 +63,8 @@ public static partial class XmlSerializer
                 constructor.GetArgumentStateConstructor(),
                 constructor.GetParameterizedConstructor(),
                 constructorParams,
-                properties);
+                properties,
+                constructor.Parameters);
         }
 
         public override object? VisitParameter<TArgumentState, TParameterType>(IParameterShape<TArgumentState, TParameterType> parameter, object? state)

--- a/src/PolyType.SourceGenerator/Helpers/RoslynHelpers.cs
+++ b/src/PolyType.SourceGenerator/Helpers/RoslynHelpers.cs
@@ -23,6 +23,9 @@ internal static partial class RoslynHelpers
         };
     }
 
+    public static ITypeSymbol GetReturnType(this IMethodSymbol method) =>
+        method is { MethodKind: MethodKind.Constructor, IsStatic: false } ? method.ContainingType : method.ReturnType;
+
     /// <summary>
     /// Removes erased compiler metadata such as tuple names and nullable annotations.
     /// </summary>

--- a/src/PolyType.SourceGenerator/Model/ConstructorShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/ConstructorShapeModel.cs
@@ -11,24 +11,35 @@ public sealed record ConstructorShapeModel
     public required ImmutableEquatableArray<ParameterShapeModel> Parameters { get; init; }
     public required ImmutableEquatableArray<ParameterShapeModel> RequiredMembers { get; init; }
     public required ImmutableEquatableArray<ParameterShapeModel> OptionalMembers { get; init; }
-    public required OptionalMemberFlagsType OptionalMemberFlagsType { get; init; }
+    public required ArgumentStateType ArgumentStateType { get; init; }
     public required string? StaticFactoryName { get; init; }
     public required bool StaticFactoryIsProperty { get; init; }
     public required bool ResultRequiresCast { get; init; }
 
     public int TotalArity => Parameters.Length + RequiredMembers.Length + OptionalMembers.Length;
     public bool IsStaticFactory => StaticFactoryName != null;
+    public IEnumerable<ParameterShapeModel> GetAllParameters()
+    {
+        foreach (var param in Parameters)
+        {
+            yield return param;
+        }
+        foreach (var member in RequiredMembers)
+        {
+            yield return member;
+        }
+        foreach (var member in OptionalMembers)
+        {
+            yield return member;
+        }
+    }
 }
 
 /// <summary>
-/// Type used to store flags for whether optional members are set.
+/// Type used to store the state of arguments for a constructor.
 /// </summary>
-public enum OptionalMemberFlagsType
+public enum ArgumentStateType
 {
-    None,
-    Byte,
-    UShort,
-    UInt32,
-    ULong,
-    BitArray,
+    SmallArgumentState,
+    LargeArgumentState,
 }

--- a/src/PolyType.SourceGenerator/PolyType.SourceGenerator.csproj
+++ b/src/PolyType.SourceGenerator/PolyType.SourceGenerator.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="..\PolyType\TypeShapeKind.cs" Link="Shared\PolyType\%(Filename).cs" />
+    <Compile Include="..\PolyType\SourceGenModel\Helpers\ValueBitArray.cs" Link="Shared\PolyType\SourceGenModel\Helpers\%(Filename).cs" />
     <Compile Include="..\Shared\Helpers\CommonHelpers.cs" Link="PolyType.Roslyn\Shared\Helpers\%(Filename).cs" />
     <Compile Include="..\Shared\Helpers\DebugExt.cs" Link="Shared\Helpers\%(Filename).cs" />
     <Compile Include="..\Shared\Polyfills\FSharpSourceConstructFlags.cs" Link="Shared\Polyfills\%(Filename).cs" />

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Properties.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Properties.cs
@@ -17,7 +17,7 @@ internal sealed partial class SourceFormatter
         int i = 0;
         foreach (PropertyShapeModel property in type.Properties)
         {
-            if (i++ > 0)
+            if (i > 0)
             {
                 writer.WriteLine();
             }
@@ -39,6 +39,7 @@ internal sealed partial class SourceFormatter
             writer.WriteLine($$"""
                 new global::PolyType.SourceGenModel.SourceGenPropertyShape<{{type.Type.FullyQualifiedName}}, {{property.PropertyType.FullyQualifiedName}}>
                 {
+                    Position = {{i}},
                     Name = {{FormatStringLiteral(property.Name)}},
                     DeclaringType = (global::PolyType.Abstractions.IObjectTypeShape<{{type.Type.FullyQualifiedName}}>){{type.SourceIdentifier}},
                     PropertyType = {{GetShapeModel(property.PropertyType).SourceIdentifier}},
@@ -52,6 +53,8 @@ internal sealed partial class SourceFormatter
                     IsSetterNonNullable = {{FormatBool(property.IsSetterNonNullable)}},
                 },
                 """, trimNullAssignmentLines: true);
+
+            i++;
 
             static string FormatAttributeProviderFunc(ObjectShapeModel type, PropertyShapeModel property)
             {

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -223,6 +223,7 @@ public static class TestTypes
             Dict = new() { ["key1"] = 42, ["key2"] = -1 },
         });
 
+        yield return TestCase.Create(new SimplePoco { Value = 42 });
         yield return TestCase.Create(new BaseClass { X = 1 });
         yield return TestCase.Create(new DerivedClass { X = 1, Y = 2 });
         yield return TestCase.Create(new DerivedClassWithVirtualProperties());
@@ -370,7 +371,7 @@ public static class TestTypes
         yield return TestCase.Create(new ClassWithDefaultConstructorAndSingleRequiredProperty { Value = 42 });
         yield return TestCase.Create(new ClassWithParameterizedConstructorAnd2OptionalSetters(42));
         yield return TestCase.Create(new ClassWithParameterizedConstructorAnd10OptionalSetters(42));
-        yield return TestCase.Create(new ClassWithParameterizedConstructorAnd70OptionalSetters(42));
+        yield return TestCase.Create(new ClassWithParameterizedConstructorAnd70Setters(42) { X03 = 3, X10 = 10, X47 = 47 });
 
         yield return TestCase.Create(new ClassRecord(0, 1, 2, 3));
         yield return TestCase.Create(new StructRecord(0, 1, 2, 3));
@@ -810,6 +811,12 @@ public sealed partial class ExplicitlyImplementedIDictionary : IDictionary
 }
 
 [GenerateShape]
+public partial class SimplePoco
+{
+    public int Value { get; set; }
+}
+
+[GenerateShape]
 public partial class PocoWithListAndDictionaryProps
 {
     public PocoWithListAndDictionaryProps(bool @bool = true, string @string = "str")
@@ -1190,18 +1197,18 @@ public partial class ClassWithParameterizedConstructorAnd10OptionalSetters(int x
 }
 
 [GenerateShape]
-public partial class ClassWithParameterizedConstructorAnd70OptionalSetters(int x01)
+public partial class ClassWithParameterizedConstructorAnd70Setters(int x01)
 {
     public int X01 { get; set; } = x01;
     public int X02 { get; set; } = x01;
-    public int X03 { get; set; } = x01;
+    public required int X03 { get; set; } = x01;
     public int X04 { get; set; } = x01;
     public int X05 { get; set; } = x01;
     public int X06 { get; set; } = x01;
     public int X07 { get; set; } = x01;
     public int X08 { get; set; } = x01;
     public int X09 { get; set; } = x01;
-    public int X10 { get; set; } = x01;
+    public required int X10 { get; set; } = x01;
     public int X11 { get; set; } = x01;
     public int X12 { get; set; } = x01;
     public int X13 { get; set; } = x01;
@@ -1238,7 +1245,7 @@ public partial class ClassWithParameterizedConstructorAnd70OptionalSetters(int x
     public int X44 { get; set; } = x01;
     public int X45 { get; set; } = x01;
     public int X46 { get; set; } = x01;
-    public int X47 { get; set; } = x01;
+    public required int X47 { get; set; } = x01;
     public int X48 { get; set; } = x01;
     public int X49 { get; set; } = x01;
     public int X50 { get; set; } = x01;

--- a/src/PolyType/Abstractions/IArgumentState.cs
+++ b/src/PolyType/Abstractions/IArgumentState.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace PolyType.Abstractions;
+﻿namespace PolyType.Abstractions;
 
 /// <summary>
 /// Declares list of arguments to be passed to a parameterized constructor or method.

--- a/src/PolyType/Abstractions/IArgumentState.cs
+++ b/src/PolyType/Abstractions/IArgumentState.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PolyType.Abstractions;
+
+/// <summary>
+/// Declares list of arguments to be passed to a parameterized constructor or method.
+/// </summary>
+[InternalImplementationsOnly]
+public interface IArgumentState
+{
+    /// <summary>
+    /// Gets the total number of arguments expected by the constructor.
+    /// </summary>
+    int Count { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether all required arguments have been set.
+    /// </summary>
+    bool AreRequiredArgumentsSet { get; }
+
+    /// <summary>
+    /// Checks if the argument at the specified index is set.
+    /// </summary>
+    /// <param name="index">The index of the argument to check.</param>
+    /// <returns>True if the argument is set; otherwise, false.</returns>
+    bool IsArgumentSet(int index);
+}

--- a/src/PolyType/Abstractions/IPropertyShape.cs
+++ b/src/PolyType/Abstractions/IPropertyShape.cs
@@ -10,6 +10,11 @@ namespace PolyType.Abstractions;
 public interface IPropertyShape
 {
     /// <summary>
+    /// Gets the 0-indexed position of the current property.
+    /// </summary>
+    int Position { get; }
+
+    /// <summary>
     /// Gets the name of the property.
     /// </summary>
     string Name { get; }

--- a/src/PolyType/Abstractions/TypeShapeVisitor.cs
+++ b/src/PolyType/Abstractions/TypeShapeVisitor.cs
@@ -40,6 +40,7 @@ public abstract class TypeShapeVisitor
     /// <param name="state">Defines user-provided state.</param>
     /// <returns>The result produced by the visitor.</returns>
     public virtual object? VisitConstructor<TDeclaringType, TArgumentState>(IConstructorShape<TDeclaringType, TArgumentState> constructorShape, object? state = null)
+        where TArgumentState : IArgumentState
         => ThrowNotImplementedException();
 
     /// <summary>
@@ -51,6 +52,7 @@ public abstract class TypeShapeVisitor
     /// <param name="state">Defines user-provided state.</param>
     /// <returns>The result produced by the visitor.</returns>
     public virtual object? VisitParameter<TArgumentState, TParameterType>(IParameterShape<TArgumentState, TParameterType> parameterShape, object? state = null)
+        where TArgumentState : IArgumentState
         => ThrowNotImplementedException();
 
     /// <summary>

--- a/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
@@ -92,12 +92,13 @@ internal sealed class FSharpUnionCaseTypeShape<TUnionCase>(FSharpUnionCaseInfo? 
             yield break;
         }
 
+        int i = 0;
         NullabilityInfoContext? nullabilityCtx = ReflectionTypeShapeProvider.CreateNullabilityInfoContext();
         foreach (PropertyInfo property in unionCaseInfo.Properties)
         {
             property.ResolveNullableAnnotation(nullabilityCtx, out bool isGetterNonNullable, out _);
             PropertyShapeInfo propertyShapeInfo = new(typeof(TUnionCase), property, AttributeProvider: property, IsGetterNonNullable: isGetterNonNullable);
-            yield return Provider.CreateProperty(this, propertyShapeInfo);
+            yield return Provider.CreateProperty(this, propertyShapeInfo, position: i++);
         }
     }
 }

--- a/src/PolyType/ReflectionProvider/MemberAccessors/IReflectionMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/IReflectionMemberAccessor.cs
@@ -14,13 +14,14 @@ internal interface IReflectionMemberAccessor
     Func<TDeclaringType> CreateDefaultConstructor<TDeclaringType>(IConstructorShapeInfo ctorInfo);
 
     Type CreateConstructorArgumentStateType(IConstructorShapeInfo ctorInfo);
-    Func<TArgumentState> CreateConstructorArgumentStateCtor<TArgumentState>(IConstructorShapeInfo ctorInfo);
-    Setter<TArgumentState, TParameter> CreateConstructorArgumentStateSetter<TArgumentState, TParameter>(IConstructorShapeInfo ctorInfo, int parameterIndex);
-    Constructor<TArgumentState, TDeclaringType> CreateParameterizedConstructor<TArgumentState, TDeclaringType>(IConstructorShapeInfo ctorInfo);
+    Func<TArgumentState> CreateConstructorArgumentStateCtor<TArgumentState>(IConstructorShapeInfo ctorInfo)
+        where TArgumentState : IArgumentState;
 
-    TDelegate CreateFuncDelegate<TDelegate>(ConstructorInfo ctorInfo) where TDelegate : Delegate;
-    Func<T, TResult> CreateFuncDelegate<T, TResult>(ConstructorInfo ctorInfo);
-    Func<T1, T2, TResult> CreateFuncDelegate<T1, T2, TResult>(ConstructorInfo ctorInfo);
+    Setter<TArgumentState, TParameter> CreateConstructorArgumentStateSetter<TArgumentState, TParameter>(IConstructorShapeInfo ctorInfo, int parameterIndex)
+        where TArgumentState : IArgumentState;
+
+    Constructor<TArgumentState, TDeclaringType> CreateParameterizedConstructor<TArgumentState, TDeclaringType>(IConstructorShapeInfo ctorInfo)
+        where TArgumentState : IArgumentState;
 
     bool IsCollectionConstructorSupported(MethodBase method, CollectionConstructorParameter[] signature);
     MutableCollectionConstructor<TKey, TCollection> CreateMutableCollectionConstructor<TKey, TElement, TCollection>(MutableCollectionConstructorInfo constructorInfo);

--- a/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionMemberAccessor.cs
@@ -241,118 +241,139 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
     {
         return ctorInfo switch
         {
-            { Parameters: [] } => typeof(object),
-            { Parameters: [MethodParameterShapeInfo param] } => param.Type,
-            MethodConstructorShapeInfo { MemberInitializers.Length: > 0 } => typeof((object?[] ctorArgs, object[]? memberInitializerArgs, BitArray memberInitializerFlags)),
-            _ => typeof(object?[]),
+            MethodConstructorShapeInfo { MemberInitializers.Length: > 0 } => typeof(LargeArgumentState<(object?[], object?[])>),
+            _ => typeof(LargeArgumentState<object?[]>),
         };
     }
 
     public Func<TArgumentState> CreateConstructorArgumentStateCtor<TArgumentState>(IConstructorShapeInfo ctorInfo)
+        where TArgumentState : IArgumentState
     {
         Debug.Assert(ctorInfo.Parameters.Length > 0);
-
-        if (ctorInfo.Parameters is [MethodParameterShapeInfo parameter])
-        {
-            Debug.Assert(typeof(TArgumentState) == parameter.Type);
-            TArgumentState? defaultValue = parameter.HasDefaultValue
-                ? (TArgumentState?)parameter.DefaultValue
-                : default;
-
-            return () => defaultValue!;
-        }
-
         if (ctorInfo is MethodConstructorShapeInfo { MemberInitializers.Length: > 0 } ctor)
         {
-            Debug.Assert(typeof(TArgumentState) == typeof((object?[], object?[], BitArray)));
-            return (Func<TArgumentState>)(object)CreateConstructorAndMemberInitializerArgumentArrayFunc(ctor);
+            Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<(object?[], object?[])>));
+            Func<object?[]> createCtorParameterArray = CreateConstructorArgumentArrayFunc(ctor.ConstructorParameters);
+            int memberInitializerLength = ctor.MemberInitializers.Length;
+            ValueBitArray requiredPropertiesMask = CreateRequiredParametersMask(ctorInfo);
+            return (Func<TArgumentState>)(object)new Func<LargeArgumentState<(object?[], object?[])>>(
+                () => new((createCtorParameterArray(), new object?[memberInitializerLength]), ctor.Parameters.Length, requiredPropertiesMask));
+        }
+        else
+        {
+            Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<object?[]>));
+            Func<object?[]> createCtorParameterArray = CreateConstructorArgumentArrayFunc(ctorInfo.Parameters);
+            ValueBitArray requiredPropertiesMask = CreateRequiredParametersMask(ctorInfo);
+            return (Func<TArgumentState>)(object)new Func<LargeArgumentState<object?[]>>(
+                () => new(createCtorParameterArray(), ctorInfo.Parameters.Length, requiredPropertiesMask));
         }
 
-        Debug.Assert(typeof(TArgumentState) == typeof(object?[]));
-        return (Func<TArgumentState>)(object)CreateConstructorArgumentArrayFunc(ctorInfo);
-    }
-
-    public Setter<TArgumentState, TParameter> CreateConstructorArgumentStateSetter<TArgumentState, TParameter>(IConstructorShapeInfo ctorInfo, int parameterIndex)
-    {
-        Debug.Assert(ctorInfo.Parameters.Length > 0);
-
-        if (ctorInfo.Parameters is [MethodParameterShapeInfo])
+        static ValueBitArray CreateRequiredParametersMask(IConstructorShapeInfo ctorInfo)
         {
-            Debug.Assert(parameterIndex == 0);
-            Debug.Assert(typeof(TArgumentState) == typeof(TParameter));
-            return (Setter<TArgumentState, TParameter>)(object)new Setter<TParameter, TParameter>(
-                static (ref TParameter state, TParameter param) => state = param);
-        }
-
-        if (ctorInfo is MethodConstructorShapeInfo { MemberInitializers.Length: > 0 } ctor)
-        {
-            Debug.Assert(typeof(TArgumentState) == typeof((object?[], object?[], BitArray)));
-            if (parameterIndex < ctor.ConstructorParameters.Length)
+            ValueBitArray mask = new(ctorInfo.Parameters.Length);
+            for (int i = 0; i < ctorInfo.Parameters.Length; i++)
             {
-                return (Setter<TArgumentState, TParameter>)(object)new Setter<(object?[], object?[], BitArray), TParameter>(
-                    (ref (object?[] ctorArgs, object?[], BitArray) state, TParameter value) => state.ctorArgs[parameterIndex] = value);
+                if (ctorInfo.Parameters[i].IsRequired)
+                {
+                    mask[i] = true;
+                }
+            }
+
+            return mask;
+        }
+
+        static Func<object?[]> CreateConstructorArgumentArrayFunc(IParameterShapeInfo[] parameters)
+        {
+            int arity = parameters.Length;
+            if (arity == 0)
+            {
+                return static () => [];
+            }
+            else if (parameters.Any(param => param.HasDefaultValue))
+            {
+                object?[] sourceParamArray = parameters.Select(p => p.DefaultValue).ToArray();
+                return () => (object?[])sourceParamArray.Clone();
             }
             else
             {
-                int initializerIndex = parameterIndex - ctor.ConstructorParameters.Length;
-                return (Setter<TArgumentState, TParameter>)(object)new Setter<(object?[], object?[], BitArray), TParameter>(
-                    (ref (object?[], object?[] memberArgs, BitArray flags) state, TParameter value) =>
-                    {
-                        state.memberArgs[initializerIndex] = value;
-                        state.flags[initializerIndex] = true;
-                    });
+                return () => new object?[arity];
             }
         }
+    }
 
-        Debug.Assert(typeof(TArgumentState) == typeof(object?[]));
-        return (Setter<TArgumentState, TParameter>)(object)new Setter<object?[], TParameter>(
-            (ref object?[] state, TParameter value) => state[parameterIndex] = value);
+    public Setter<TArgumentState, TParameter> CreateConstructorArgumentStateSetter<TArgumentState, TParameter>(IConstructorShapeInfo ctorInfo, int parameterIndex)
+        where TArgumentState : IArgumentState
+    {
+        Debug.Assert(ctorInfo.Parameters.Length > 0);
+        if (ctorInfo is MethodConstructorShapeInfo { MemberInitializers.Length: > 0 } ctor)
+        {
+            Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<(object?[], object?[])>));
+            int initializerIndex = parameterIndex - ctor.ConstructorParameters.Length;
+            return (Setter<TArgumentState, TParameter>)(object)new Setter<LargeArgumentState<(object?[], object?[])>, TParameter>(
+                (ref LargeArgumentState<(object?[] ctorArgs, object?[] memberArgs)> state, TParameter value) =>
+                {
+                    if (initializerIndex < 0)
+                    {
+                        state.Arguments.ctorArgs[parameterIndex] = value;
+                    }
+                    else
+                    {
+                        state.Arguments.memberArgs[initializerIndex] = value;
+                    }
+
+                    state.MarkArgumentSet(parameterIndex);
+                });
+        }
+        else
+        {
+            Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<object?[]>));
+            return (Setter<TArgumentState, TParameter>)(object)new Setter<LargeArgumentState<object?[]>, TParameter>(
+                (ref LargeArgumentState<object?[]> state, TParameter value) =>
+                {
+                    state.Arguments[parameterIndex] = value;
+                    state.MarkArgumentSet(parameterIndex);
+                });
+        }
     }
 
     public Constructor<TArgumentState, TDeclaringType> CreateParameterizedConstructor<TArgumentState, TDeclaringType>(IConstructorShapeInfo ctorInfo)
+        where TArgumentState : IArgumentState
     {
         Debug.Assert(ctorInfo.Parameters.Length > 0);
-
         if (ctorInfo is TupleConstructorShapeInfo tupleCtor)
         {
-            if (ctorInfo.Parameters is [IParameterShapeInfo param])
-            {
-                Debug.Assert(typeof(TArgumentState) == param.Type);
-                Debug.Assert(tupleCtor.NestedTupleConstructor is null);
-                ConstructorInfo ctor = tupleCtor.ConstructorInfo;
-                return (ref TArgumentState state) => (TDeclaringType)ctor.Invoke([state]);
-            }
-
-            Debug.Assert(typeof(TArgumentState) == typeof(object?[]));
-
-            Stack<(ConstructorInfo, int)> ctorStack = new();
+            Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<object?[]>));
+            List<(ConstructorInfo, int)> ctorStack = new();
             for (TupleConstructorShapeInfo? current = tupleCtor; current != null; current = current.NestedTupleConstructor)
             {
-                ctorStack.Push((current.ConstructorInfo, current.ConstructorParameters.Length));
+                ctorStack.Add((current.ConstructorInfo, current.ConstructorParameters.Length));
             }
 
-            return (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<object?[], TDeclaringType>(
-                (ref object?[] state) =>
+            ctorStack.Reverse();
+
+            return (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<LargeArgumentState<object?[]>, TDeclaringType>(
+                (ref LargeArgumentState<object?[]> state) =>
             {
+                object?[] arguments = state.Arguments;
                 object? result = null;
-                int i = state.Length;
+                int i = arguments.Length;
                 foreach ((ConstructorInfo ctorInfo, int arity) in ctorStack)
                 {
                     object?[] localParams;
-                    if (i == state.Length)
+                    if (i == arguments.Length)
                     {
 #if NET
-                        localParams = state[^arity..];
+                        localParams = arguments[^arity..];
 #else
                         // https://github.com/Sergio0694/PolySharp/issues/104
                         localParams = new object?[arity];
-                        state.AsSpan(state.Length - arity).CopyTo(localParams);
+                        arguments.AsSpan(arguments.Length - arity).CopyTo(localParams);
 #endif
                     }
                     else
                     {
                         localParams = new object?[arity + 1];
-                        state.AsSpan(i - arity, arity).CopyTo(localParams);
+                        arguments.AsSpan(i - arity, arity).CopyTo(localParams);
                         localParams[arity] = result;
                     }
 
@@ -364,94 +385,60 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
             });
         }
 
-        if (ctorInfo is MethodConstructorShapeInfo methodCtor)
+        if (ctorInfo is MethodConstructorShapeInfo { MemberInitializers.Length: > 0 } methodCtor)
         {
+            Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<(object?[], object?[])>));
             MemberInitializerShapeInfo[] memberInitializers = methodCtor.MemberInitializers;
-            if (memberInitializers.Length > 0)
+            if (methodCtor.ConstructorMethod is { } ctor)
             {
-                Debug.Assert(typeof(TArgumentState) == typeof((object?[], object?[], BitArray)));
-
-                if (methodCtor.ConstructorMethod is { } cI)
-                {
-                    return (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<(object?[], object?[], BitArray), TDeclaringType>(
-                        (ref (object?[] ctorArgs, object?[] memberArgs, BitArray memberFlags) state) =>
-                        {
-                            object obj = cI.Invoke(state.ctorArgs)!;
-                            PopulateMemberInitializers(obj, memberInitializers, state.memberArgs, state.memberFlags);
-                            return (TDeclaringType)obj!;
-                        });
-                }
-                else
-                {
-                    return (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<(object?[], object?[], BitArray), TDeclaringType>(
-                        (ref (object?[] ctorArgs, object?[] memberArgs, BitArray memberFlags) state) =>
-                        {
-                            object obj = default(TDeclaringType)!;
-                            PopulateMemberInitializers(obj, memberInitializers, state.memberArgs, state.memberFlags);
-                            return (TDeclaringType)obj!;
-                        });
-                }
-
-                static void PopulateMemberInitializers(object obj, MemberInitializerShapeInfo[] memberInitializers, object?[] memberArgs, BitArray memberFlags)
-                {
-                    for (int i = 0; i < memberInitializers.Length; i++)
+                return (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<LargeArgumentState<(object?[], object?[])>, TDeclaringType>(
+                    (ref LargeArgumentState<(object?[] ctorArgs, object?[] memberArgs)> state) =>
                     {
-                        if (!memberFlags[i])
-                        {
-                            continue;
-                        }
-
-                        MemberInfo member = memberInitializers[i].MemberInfo;
-
-                        if (member is PropertyInfo prop)
-                        {
-                            prop.SetValue(obj, memberArgs[i]);
-                        }
-                        else
-                        {
-                            ((FieldInfo)member).SetValue(obj, memberArgs[i]);
-                        }
-                    }
-                }
+                        object obj = ctor.Invoke(state.Arguments.ctorArgs)!;
+                        PopulateMemberInitializers(ref state, obj, memberInitializers, state.Arguments.memberArgs);
+                        return (TDeclaringType)obj!;
+                    });
             }
             else
             {
-                if (methodCtor.Parameters is [MethodParameterShapeInfo pI])
-                {
-                    DebugExt.Assert(typeof(TArgumentState) == pI.Type);
-                    DebugExt.Assert(methodCtor.ConstructorMethod != null);
-                    MethodBase ctor = methodCtor.ConstructorMethod;
-                    return (ref TArgumentState state) => (TDeclaringType)ctor.Invoke([state])!;
-                }
+                return (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<LargeArgumentState<(object?[], object?[])>, TDeclaringType>(
+                    (ref LargeArgumentState<(object?[] ctorArgs, object?[] memberArgs)> state) =>
+                    {
+                        object obj = default(TDeclaringType)!;
+                        PopulateMemberInitializers(ref state, obj, memberInitializers, state.Arguments.memberArgs);
+                        return (TDeclaringType)obj!;
+                    });
+            }
 
-                Debug.Assert(typeof(TArgumentState) == typeof(object?[]));
-                return methodCtor.ConstructorMethod is { } cI
-                    ? (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<object?[], TDeclaringType>((ref object?[] state) => (TDeclaringType)cI.Invoke(state)!)
-                    : static (ref TArgumentState _) => default!;
+            static void PopulateMemberInitializers<TArgState>(ref TArgState state, object obj, MemberInitializerShapeInfo[] memberInitializers, object?[] memberArgs)
+                where TArgState : IArgumentState
+            {
+                for (int i = 0; i < memberInitializers.Length; i++)
+                {
+                    if (!state.IsArgumentSet(i))
+                    {
+                        continue; // Skip to avoid setting uninitialized members.
+                    }
+
+                    MemberInfo member = memberInitializers[i].MemberInfo;
+
+                    if (member is PropertyInfo prop)
+                    {
+                        prop.SetValue(obj, memberArgs[i]);
+                    }
+                    else
+                    {
+                        ((FieldInfo)member).SetValue(obj, memberArgs[i]);
+                    }
+                }
             }
         }
 
-        Debug.Fail($"Unrecognized constructor shape {ctorInfo}.");
-        return null!;
-    }
-
-    public TDelegate CreateFuncDelegate<TDelegate>(ConstructorInfo ctorInfo) where TDelegate : Delegate
-    {
-        Debug.Fail("Should not be called if not using Reflection.Emit");
-        throw new NotSupportedException();
-    }
-
-    public Func<T, TResult> CreateFuncDelegate<T, TResult>(ConstructorInfo ctorInfo)
-        => value => (TResult)ctorInfo.Invoke([value]);
-
-    public Func<T1, T2, TResult> CreateFuncDelegate<T1, T2, TResult>(ConstructorInfo ctorInfo)
-        => (arg1, arg2) => (TResult)ctorInfo.Invoke([arg1, arg2]);
-
-    [DoesNotReturn]
-    private static T NotReachable<T>()
-    {
-        Debug.Fail("This code should not be reachable.");
-        throw new InvalidOperationException("This code should not be reachable.");
+        Debug.Assert(ctorInfo is MethodConstructorShapeInfo { ConstructorMethod: not null });
+        Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<object?[]>));
+        var cI = ((MethodConstructorShapeInfo)ctorInfo).ConstructorMethod!;
+        return (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<LargeArgumentState<object?[]>, TDeclaringType>(
+            (ref LargeArgumentState<object?[]> state) => (TDeclaringType)cI.Invoke(state.Arguments)!);
     }
 
     public Getter<TUnion, int> CreateGetUnionCaseIndex<TUnion>(DerivedTypeInfo[] derivedTypeInfos)
@@ -637,49 +624,6 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
             return factory.CreateDelegate<SpanFunc<TElement, IEnumerable>>();
         }
     }
-
-    private static Func<object?[]> CreateConstructorArgumentArrayFunc(IConstructorShapeInfo ctorInfo)
-    {
-        int arity = ctorInfo.Parameters.Length;
-        if (arity == 0)
-        {
-            return static () => [];
-        }
-        else if (ctorInfo.Parameters.Any(param => param.HasDefaultValue))
-        {
-            object?[] sourceParamArray = GetDefaultParameterArray(ctorInfo.Parameters);
-            return () => (object?[])sourceParamArray.Clone();
-        }
-        else
-        {
-            return () => new object?[arity];
-        }
-    }
-
-    private static Func<(object?[], object?[], BitArray)> CreateConstructorAndMemberInitializerArgumentArrayFunc(MethodConstructorShapeInfo ctorInfo)
-    {
-        Debug.Assert(ctorInfo.MemberInitializers.Length > 0);
-        int constructorParameterLength = ctorInfo.ConstructorParameters.Length;
-        int memberInitializerLength = ctorInfo.MemberInitializers.Length;
-
-        if (constructorParameterLength == 0)
-        {
-            return () => ([], new object?[memberInitializerLength], new BitArray(memberInitializerLength));
-        }
-
-        if (ctorInfo.ConstructorParameters.Any(param => param.HasDefaultValue))
-        {
-            object?[] sourceParamArray = GetDefaultParameterArray(ctorInfo.ConstructorParameters);
-            return () => ((object?[])sourceParamArray.Clone(), new object?[memberInitializerLength], new BitArray(memberInitializerLength));
-        }
-        else
-        {
-            return () => (new object?[constructorParameterLength], new object?[memberInitializerLength], new BitArray(memberInitializerLength));
-        }
-    }
-
-    private static object?[] GetDefaultParameterArray(IEnumerable<IParameterShapeInfo> parameters)
-        => parameters.Select(p => p.DefaultValue).ToArray();
 
     private delegate TResult SpanFunc<TElement, TResult>(ReadOnlySpan<TElement> span);
     private delegate TResult SpanFunc<TElement, TArg1, TResult>(ReadOnlySpan<TElement> span, TArg1 arg1);

--- a/src/PolyType/ReflectionProvider/ReflectionConstructorShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionConstructorShape.cs
@@ -10,6 +10,7 @@ internal sealed class ReflectionConstructorShape<TDeclaringType, TArgumentState>
     IObjectTypeShape<TDeclaringType> declaringType,
     IConstructorShapeInfo ctorInfo) :
     IConstructorShape<TDeclaringType, TArgumentState>
+    where TArgumentState : IArgumentState
 {
     private IReadOnlyList<IParameterShape>? _parameters;
     private Func<TArgumentState>? _argumentStateConstructor;

--- a/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
@@ -238,19 +238,21 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
 
         if (IsTupleType)
         {
+            int i = 0;
             foreach (var field in ReflectionHelpers.EnumerateTupleMemberPaths(typeof(T)))
             {
                 PropertyShapeInfo propertyShapeInfo = new(typeof(T), field.Member, field.Member, field.ParentMembers, field.LogicalName);
-                yield return Provider.CreateProperty(this, propertyShapeInfo);
+                yield return Provider.CreateProperty(this, propertyShapeInfo, position: i++);
             }
 
             yield break;
         }
 
+        int p = 0;
         NullabilityInfoContext? nullabilityCtx = ReflectionTypeShapeProvider.CreateNullabilityInfoContext();
         foreach (PropertyShapeInfo member in GetMembers(nullabilityCtx))
         {
-            yield return Provider.CreateProperty(this, member);
+            yield return Provider.CreateProperty(this, member, position: p++);
         }
     }
 

--- a/src/PolyType/ReflectionProvider/ReflectionParameterShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionParameterShape.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 namespace PolyType.ReflectionProvider;
 
 internal sealed class ReflectionParameterShape<TArgumentState, TParameter> : IParameterShape<TArgumentState, TParameter>
+    where TArgumentState : IArgumentState
 {
     private readonly ReflectionTypeShapeProvider _provider;
     private readonly IConstructorShapeInfo _ctorInfo;

--- a/src/PolyType/ReflectionProvider/ReflectionPropertyShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionPropertyShape.cs
@@ -13,7 +13,7 @@ internal sealed class ReflectionPropertyShape<TDeclaringType, TPropertyType> : I
     private Getter<TDeclaringType, TPropertyType>? _getter;
     private Setter<TDeclaringType, TPropertyType>? _setter;
 
-    public ReflectionPropertyShape(ReflectionTypeShapeProvider provider, IObjectTypeShape<TDeclaringType> declaringType, PropertyShapeInfo shapeInfo)
+    public ReflectionPropertyShape(ReflectionTypeShapeProvider provider, IObjectTypeShape<TDeclaringType> declaringType, PropertyShapeInfo shapeInfo, int position)
     {
         Debug.Assert(shapeInfo.MemberInfo.DeclaringType!.IsAssignableFrom(typeof(TDeclaringType)) || shapeInfo.ParentMembers is not null);
         Debug.Assert(shapeInfo.MemberInfo is PropertyInfo or FieldInfo);
@@ -25,6 +25,7 @@ internal sealed class ReflectionPropertyShape<TDeclaringType, TPropertyType> : I
         DeclaringType = declaringType;
         AttributeProvider = shapeInfo.AttributeProvider;
 
+        Position = position;
         Name = shapeInfo.LogicalName ?? shapeInfo.MemberInfo.Name;
 
         if (shapeInfo.MemberInfo is FieldInfo f)
@@ -48,6 +49,7 @@ internal sealed class ReflectionPropertyShape<TDeclaringType, TPropertyType> : I
         IsSetterNonNullable = HasSetter && shapeInfo.IsSetterNonNullable;
     }
 
+    public int Position { get; }
     public string Name { get; }
     public ICustomAttributeProvider AttributeProvider { get; }
     public IObjectTypeShape<TDeclaringType> DeclaringType { get; }

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShape.cs
@@ -25,7 +25,7 @@ internal abstract class ReflectionTypeShape<T>(ReflectionTypeShapeProvider provi
         }
 
         Type closedType = associatedType.IsGenericTypeDefinition
-            ? associatedType.MakeGenericType(this.Type.GenericTypeArguments)
+            ? associatedType.MakeGenericType(Type.GenericTypeArguments)
             : associatedType;
 
         return provider.GetShape(closedType);

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeExtensionModel.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeExtensionModel.cs
@@ -32,7 +32,7 @@ internal readonly record struct ReflectionTypeShapeExtensionModel
     {
         return this with
         {
-            Marshaller = this.Marshaller ?? other.Marshaller,
+            Marshaller = Marshaller ?? other.Marshaller,
         };
     }
 }

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -458,11 +458,11 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
         return TypeShapeKind.Object;
     }
 
-    internal IPropertyShape CreateProperty(IObjectTypeShape declaringType, PropertyShapeInfo propertyShapeInfo)
+    internal IPropertyShape CreateProperty(IObjectTypeShape declaringType, PropertyShapeInfo propertyShapeInfo, int position)
     {
         Type memberType = propertyShapeInfo.MemberInfo.GetMemberType();
         Type reflectionPropertyType = typeof(ReflectionPropertyShape<,>).MakeGenericType(propertyShapeInfo.DeclaringType, memberType);
-        return (IPropertyShape)Activator.CreateInstance(reflectionPropertyType, this, declaringType, propertyShapeInfo)!;
+        return (IPropertyShape)Activator.CreateInstance(reflectionPropertyType, this, declaringType, propertyShapeInfo, position)!;
     }
 
     internal IConstructorShape CreateConstructor(IObjectTypeShape declaringType, IConstructorShapeInfo ctorInfo)

--- a/src/PolyType/SourceGenModel/Helpers/CollectionHelpers.cs
+++ b/src/PolyType/SourceGenModel/Helpers/CollectionHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using PolyType.Abstractions;
 using System.Collections;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
@@ -8,6 +9,7 @@ namespace PolyType.SourceGenModel;
 /// <summary>
 /// Collection helper methods to be consumed by the source generator.
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class CollectionHelpers
 {
     /// <summary>

--- a/src/PolyType/SourceGenModel/Helpers/LargeArgumentState.cs
+++ b/src/PolyType/SourceGenModel/Helpers/LargeArgumentState.cs
@@ -1,0 +1,52 @@
+﻿using PolyType.Abstractions;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace PolyType.SourceGenModel;
+
+/// <summary>
+/// Defines an argument state for a constructor that can track a large (more than 64) number of arguments.
+/// </summary>
+/// <typeparam name="TArguments">The type storing the arguments.</typeparam>
+[EditorBrowsable(EditorBrowsableState.Never)]
+[StructLayout(LayoutKind.Auto)]
+public struct LargeArgumentState<TArguments> : IArgumentState
+{
+    private readonly ValueBitArray _requiredArgumentsMask;
+    private readonly ValueBitArray _setArguments;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LargeArgumentState{TArguments}"/> struct.
+    /// </summary>
+    /// <param name="arguments">The initial argument state object.</param>
+    /// <param name="count">The total number of arguments.</param>
+    /// <param name="requiredArgumentsMask">A bitmask indicating which arguments are required.</param>
+    public LargeArgumentState(TArguments arguments, int count, ValueBitArray requiredArgumentsMask)
+    {
+        Arguments = arguments;
+        _requiredArgumentsMask = requiredArgumentsMask;
+        _setArguments = new ValueBitArray(count);
+    }
+
+    /// <summary>
+    /// The actual arguments being tracked by this state.
+    /// </summary>
+#pragma warning disable CA1051 // Do not declare visible instance fields
+    public TArguments Arguments;
+#pragma warning restore CA1051 // Do not declare visible instance fields
+
+    /// <inheritdoc />
+    public readonly int Count => _setArguments.Length;
+
+    /// <inheritdoc />
+    public readonly bool AreRequiredArgumentsSet => _requiredArgumentsMask.IsSubsetOf(_setArguments);
+
+    /// <inheritdoc />
+    public readonly bool IsArgumentSet(int index) => _setArguments[index];
+
+    /// <summary>
+    /// Marks the argument at the specified index as set.
+    /// </summary>
+    /// <param name="index">The index of the argument to mark as set.</param>
+    public readonly void MarkArgumentSet(int index) => _setArguments[index] = true;
+}

--- a/src/PolyType/SourceGenModel/Helpers/LargeArgumentState.cs
+++ b/src/PolyType/SourceGenModel/Helpers/LargeArgumentState.cs
@@ -23,6 +23,12 @@ public struct LargeArgumentState<TArguments> : IArgumentState
     /// <param name="requiredArgumentsMask">A bitmask indicating which arguments are required.</param>
     public LargeArgumentState(TArguments arguments, int count, ValueBitArray requiredArgumentsMask)
     {
+        if (requiredArgumentsMask.Length != count)
+        {
+            Throw();
+            static void Throw() => throw new ArgumentOutOfRangeException(nameof(requiredArgumentsMask), "The length of the required arguments mask must match the count.");
+        }
+
         Arguments = arguments;
         _requiredArgumentsMask = requiredArgumentsMask;
         _setArguments = new ValueBitArray(count);

--- a/src/PolyType/SourceGenModel/Helpers/SmallArgumentState.cs
+++ b/src/PolyType/SourceGenModel/Helpers/SmallArgumentState.cs
@@ -12,6 +12,7 @@ namespace PolyType.SourceGenModel;
 [StructLayout(LayoutKind.Auto)]
 public struct SmallArgumentState<TArguments> : IArgumentState
 {
+    private readonly uint _count;
     private readonly ulong _requiredArgumentsMask;
     private ulong _setArguments;
 
@@ -25,11 +26,12 @@ public struct SmallArgumentState<TArguments> : IArgumentState
     {
         if ((uint)count > 64)
         {
-            ThrowArgumentOutOfRange();
+            Throw();
+            static void Throw() => throw new ArgumentOutOfRangeException(nameof(count), "Count must be 64 or fewer.");
         }
 
         Arguments = arguments;
-        Count = count;
+        _count = (uint)count;
         _requiredArgumentsMask = requiredArgumentsMask;
     }
 
@@ -41,7 +43,7 @@ public struct SmallArgumentState<TArguments> : IArgumentState
 #pragma warning restore CA1051 // Do not declare visible instance fields
 
     /// <inheritdoc />
-    public readonly int Count { get; }
+    public readonly int Count => (int)_count;
 
     /// <inheritdoc />
     public readonly bool AreRequiredArgumentsSet => (_setArguments & _requiredArgumentsMask) == _requiredArgumentsMask;
@@ -49,9 +51,9 @@ public struct SmallArgumentState<TArguments> : IArgumentState
     /// <inheritdoc />
     public readonly bool IsArgumentSet(int index)
     {
-        if ((uint)index >= Count)
+        if ((uint)index >= _count)
         {
-            ThrowArgumentOutOfRange();
+            return false;
         }
 
         // Check if the bit at the specified index is set in _setArguments.
@@ -64,11 +66,9 @@ public struct SmallArgumentState<TArguments> : IArgumentState
     /// <param name="index">The index of the argument to mark as set.</param>
     public void MarkArgumentSet(int index)
     {
-        if ((uint)index < Count)
+        if ((uint)index < _count)
         {
             _setArguments |= 1UL << index;
         }
     }
-
-    private static void ThrowArgumentOutOfRange() => throw new ArgumentOutOfRangeException("index");
 }

--- a/src/PolyType/SourceGenModel/Helpers/SmallArgumentState.cs
+++ b/src/PolyType/SourceGenModel/Helpers/SmallArgumentState.cs
@@ -1,0 +1,74 @@
+﻿using PolyType.Abstractions;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace PolyType.SourceGenModel;
+
+/// <summary>
+/// Defines an argument state for a constructor that can track a small (64 or fewer) number of arguments.
+/// </summary>
+/// <typeparam name="TArguments">The type storing the arguments.</typeparam>
+[EditorBrowsable(EditorBrowsableState.Never)]
+[StructLayout(LayoutKind.Auto)]
+public struct SmallArgumentState<TArguments> : IArgumentState
+{
+    private readonly ulong _requiredArgumentsMask;
+    private ulong _setArguments;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmallArgumentState{TArguments}"/> struct.
+    /// </summary>
+    /// <param name="arguments">The initial argument state object.</param>
+    /// <param name="count">The total number of arguments.</param>
+    /// <param name="requiredArgumentsMask">A bitmask indicating which arguments are required.</param>
+    public SmallArgumentState(TArguments arguments, int count, ulong requiredArgumentsMask)
+    {
+        if ((uint)count > 64)
+        {
+            ThrowArgumentOutOfRange();
+        }
+
+        Arguments = arguments;
+        Count = count;
+        _requiredArgumentsMask = requiredArgumentsMask;
+    }
+
+    /// <summary>
+    /// The actual arguments being tracked by this state.
+    /// </summary>
+#pragma warning disable CA1051 // Do not declare visible instance fields
+    public TArguments Arguments;
+#pragma warning restore CA1051 // Do not declare visible instance fields
+
+    /// <inheritdoc />
+    public readonly int Count { get; }
+
+    /// <inheritdoc />
+    public readonly bool AreRequiredArgumentsSet => (_setArguments & _requiredArgumentsMask) == _requiredArgumentsMask;
+
+    /// <inheritdoc />
+    public readonly bool IsArgumentSet(int index)
+    {
+        if ((uint)index >= Count)
+        {
+            ThrowArgumentOutOfRange();
+        }
+
+        // Check if the bit at the specified index is set in _setArguments.
+        return (_setArguments & (1UL << index)) != 0;
+    }
+
+    /// <summary>
+    /// Marks the argument at the specified index as set.
+    /// </summary>
+    /// <param name="index">The index of the argument to mark as set.</param>
+    public void MarkArgumentSet(int index)
+    {
+        if ((uint)index < Count)
+        {
+            _setArguments |= 1UL << index;
+        }
+    }
+
+    private static void ThrowArgumentOutOfRange() => throw new ArgumentOutOfRangeException("index");
+}

--- a/src/PolyType/SourceGenModel/Helpers/ValueBitArray.cs
+++ b/src/PolyType/SourceGenModel/Helpers/ValueBitArray.cs
@@ -21,7 +21,8 @@ public readonly struct ValueBitArray
     {
         if (length < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
+            Throw();
+            static void Throw() => throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
         }
 
         _length = (uint)length;
@@ -37,12 +38,14 @@ public readonly struct ValueBitArray
     {
         if (length < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
+            Throw();
+            static void Throw() => throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
         }
 
         if (length > bytes.Length * 8)
         {
-            throw new ArgumentOutOfRangeException(nameof(length), "The declared length exceeds the bit capacity of the byte buffer");
+            Throw();
+            static void Throw() => throw new ArgumentOutOfRangeException(nameof(length), "The declared length exceeds the bit capacity of the byte buffer");
         }
 
         byte[] array = new byte[(length + 7) >> 3];

--- a/src/PolyType/SourceGenModel/Helpers/ValueBitArray.cs
+++ b/src/PolyType/SourceGenModel/Helpers/ValueBitArray.cs
@@ -1,0 +1,132 @@
+﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace PolyType.SourceGenModel;
+
+/// <summary>
+/// A variant of BitArray that supports subset comparisons.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public readonly struct ValueBitArray
+{
+    private readonly byte[] _array;
+    private readonly uint _length;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValueBitArray"/> struct.
+    /// </summary>
+    /// <param name="length">Total number of bits in the array.</param>
+    public ValueBitArray(int length)
+    {
+        if (length < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
+        }
+
+        _length = (uint)length;
+        _array = new byte[(length + 7) >> 3];
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValueBitArray"/> struct.
+    /// </summary>
+    /// <param name="bytes">Byte data used to seed the bit array.</param>
+    /// <param name="length">Total number of bits in the array.</param>
+    public ValueBitArray(ReadOnlySpan<byte> bytes, int length)
+    {
+        if (length < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
+        }
+
+        if (length > bytes.Length * 8)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "The declared length exceeds the bit capacity of the byte buffer");
+        }
+
+        byte[] array = new byte[(length + 7) >> 3];
+        bytes[..array.Length].CopyTo(array);
+        int remainder = length & 7;
+        if (remainder > 0)
+        {
+            // Normalize by clearing any trailing bits.
+            array[^1] &= (byte)((1 << remainder) - 1);
+        }
+
+        _array = array;
+        _length = (uint)length;
+    }
+
+    /// <summary>
+    /// Gets the total number of bits tracked by the bit array.
+    /// </summary>
+    public int Length => (int)_length;
+
+    /// <summary>
+    /// Gets a read-only span of bytes representing the bit array.
+    /// </summary>
+    public ReadOnlySpan<byte> Bytes => _array;
+
+    /// <summary>
+    /// Gets or sets the bit in the specified index.
+    /// </summary>
+    /// <param name="index">The index at which to set the bit.</param>
+    /// <returns><see langword="true"/> if the bit is set, or <see langword="false"/> otherwise.</returns>
+    public bool this[int index]
+    {
+        get
+        {
+            if ((uint)index >= _length)
+            {
+                return false;
+            }
+
+            return (_array[index >> 3] & (1 << (index & 7))) != 0;
+        }
+        set
+        {
+            if ((uint)index >= _length)
+            {
+                return;
+            }
+
+            int byteIndex = index >> 3;
+            byte mask = (byte)(1 << (index & 7));
+
+            if (value)
+            {
+                _array[byteIndex] |= mask;
+            }
+            else
+            {
+                _array[byteIndex] &= (byte)~mask;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Checks if this bit array defines a subset over the other bit array.
+    /// </summary>
+    /// <param name="other">The other bit array to compare against.</param>
+    /// <returns><see cref="bool"/> indicating whether this bit array is a subset of the other.</returns>
+    public bool IsSubsetOf(ValueBitArray other)
+    {
+        if (_length != other._length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < _array.Length; i++)
+        {
+            var leftByte = _array[i];
+            var rightByte = other._array[i];
+            if ((leftByte & rightByte) != leftByte)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/PolyType/SourceGenModel/SourceGenConstructorShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenConstructorShape.cs
@@ -10,6 +10,7 @@ namespace PolyType.SourceGenModel;
 /// <typeparam name="TDeclaringType">The type being constructed.</typeparam>
 /// <typeparam name="TArgumentState">The mutable argument state for the constructor.</typeparam>
 public sealed class SourceGenConstructorShape<TDeclaringType, TArgumentState> : IConstructorShape<TDeclaringType, TArgumentState>
+    where TArgumentState : IArgumentState
 {
     /// <summary>
     /// Gets a value indicating whether the constructor is public.

--- a/src/PolyType/SourceGenModel/SourceGenParameterShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenParameterShape.cs
@@ -9,6 +9,7 @@ namespace PolyType.SourceGenModel;
 /// <typeparam name="TArgumentState">The mutable constructor argument state type.</typeparam>
 /// <typeparam name="TParameter">The constructor parameter type.</typeparam>
 public sealed class SourceGenParameterShape<TArgumentState, TParameter> : IParameterShape<TArgumentState, TParameter>
+    where TArgumentState : IArgumentState
 {
     /// <summary>
     /// Gets the position of the parameter in the constructor signature.

--- a/src/PolyType/SourceGenModel/SourceGenPropertyShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenPropertyShape.cs
@@ -11,6 +11,11 @@ namespace PolyType.SourceGenModel;
 public sealed class SourceGenPropertyShape<TDeclaringType, TPropertyType> : IPropertyShape<TDeclaringType, TPropertyType>
 {
     /// <summary>
+    /// Gets the 0-based position of the property in the declaring type.
+    /// </summary>
+    public required int Position { get; init; }
+
+    /// <summary>
     /// Gets the name of the property.
     /// </summary>
     public required string Name { get; init; }

--- a/src/Shared/Helpers/ReflectionHelpers.cs
+++ b/src/Shared/Helpers/ReflectionHelpers.cs
@@ -561,31 +561,6 @@ internal static class ReflectionHelpers
         };
     }
 
-    public static int GetValueTupleArity<TupleType>()
-    {
-        Debug.Assert(typeof(TupleType).IsValueTupleType());
-#if NET
-        return ((ITuple)default(TupleType)!).Length;
-#else
-        return GetArityCore(typeof(TupleType));
-        static int GetArityCore(Type type)
-        {
-            int count = 0;
-            while (true)
-            {
-                Type[] genericParams = type.GetGenericArguments();
-                if (genericParams.Length < 8)
-                {
-                    return count + genericParams.Length;
-                }
-
-                type = genericParams[7];
-                count += 7;
-            }
-        }
-#endif
-    }
-
     [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
     public static IEnumerable<(string LogicalName, MemberInfo Member, MemberInfo[]? ParentMembers)> EnumerateTupleMemberPaths(Type tupleType)
     {

--- a/tests/PolyType.Tests/CborTests.cs
+++ b/tests/PolyType.Tests/CborTests.cs
@@ -105,6 +105,38 @@ public abstract partial class CborTests(ProviderUnderTest providerUnderTest)
         }
     }
 
+    [Fact]
+    public void ThrowsOnMissingRequiredProperties()
+    {
+        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.Resolve<SimpleRecord>());
+        var ex = Assert.Throws<KeyNotFoundException>(() => converter.DecodeFromHex("A16376616C182A"));
+        Assert.Contains("'value'", ex.Message);
+    }
+
+    [Fact]
+    public void ThrowsOnDuplicateProperties_Mutable()
+    {
+        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.Resolve<SimplePoco>());
+        var ex = Assert.Throws<InvalidOperationException>(() => converter.DecodeFromHex("A26556616C7565182A6556616C7565182B"));
+        Assert.Contains("Duplicate", ex.Message);
+    }
+
+    [Fact]
+    public void ThrowsOnDuplicateProperties_Parameterized()
+    {
+        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.Resolve<SimpleRecord>());
+        var ex = Assert.Throws<InvalidOperationException>(() => converter.DecodeFromHex("A26576616C7565182A6576616C7565182B"));
+        Assert.Contains("Duplicate", ex.Message);
+    }
+
+    [Fact]
+    public void DoesNotThrowOnDuplicateUnboundProperties()
+    {
+        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.Resolve<SimplePoco>());
+        var result = converter.DecodeFromHex("A26576616C7565182A6576616C7565182B");
+        Assert.Equal(0, result?.Value);
+    }
+
     private CborConverter<T> GetConverterUnderTest<T>(TestCase<T> testCase) =>
         CborSerializer.CreateConverter(providerUnderTest.ResolveShape(testCase));
 }

--- a/tests/PolyType.Tests/SourceGenModel/LargeArgumentStateTests.cs
+++ b/tests/PolyType.Tests/SourceGenModel/LargeArgumentStateTests.cs
@@ -1,0 +1,436 @@
+using System;
+using PolyType.SourceGenModel;
+
+namespace PolyType.Tests.SourceGenModel;
+
+public static class LargeArgumentStateTests
+{
+    public struct TestArguments
+    {
+        public int Value1;
+        public string Value2;
+        public bool Value3;
+    }
+
+    [Fact]
+    public static void Constructor_WithValidParameters_InitializesCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments { Value1 = 42 };
+        int count = 100;
+        var requiredMask = new ValueBitArray(count);
+        requiredMask[0] = true;
+        requiredMask[50] = true;
+        requiredMask[99] = true;
+
+        // Act
+        var state = new LargeArgumentState<TestArguments>(arguments, count, requiredMask);
+
+        // Assert
+        Assert.Equal(count, state.Count);
+        Assert.Equal(42, state.Arguments.Value1);
+        Assert.False(state.AreRequiredArgumentsSet); // No arguments marked as set yet
+    }
+
+    [Fact]
+    public static void Constructor_WithMismatchedCountAndMask_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        int count = 100;
+        var requiredMask = new ValueBitArray(50); // Different length
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => 
+            new LargeArgumentState<TestArguments>(arguments, count, requiredMask));
+    }
+
+    [Fact]
+    public static void Constructor_WithZeroCount_Succeeds()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        int count = 0;
+        var requiredMask = new ValueBitArray(0);
+
+        // Act
+        var state = new LargeArgumentState<TestArguments>(arguments, count, requiredMask);
+
+        // Assert
+        Assert.Equal(0, state.Count);
+        Assert.True(state.AreRequiredArgumentsSet); // Vacuously true for empty set
+    }
+
+    [Fact]
+    public static void IsArgumentSet_InitiallyAllArgumentsAreNotSet()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(100);
+        var state = new LargeArgumentState<TestArguments>(arguments, 100, requiredMask);
+
+        // Act & Assert
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.False(state.IsArgumentSet(i));
+        }
+    }
+
+    [Fact]
+    public static void IsArgumentSet_WithIndexOutOfRange_ReturnsFalse()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(5);
+        var state = new LargeArgumentState<TestArguments>(arguments, 5, requiredMask);
+
+        // Act & Assert
+        Assert.False(state.IsArgumentSet(5));   // At boundary
+        Assert.False(state.IsArgumentSet(100)); // Beyond boundary
+        Assert.False(state.IsArgumentSet(-1));  // Negative index
+    }
+
+    [Fact]
+    public static void MarkArgumentSet_SetsArgumentCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(100);
+        var state = new LargeArgumentState<TestArguments>(arguments, 100, requiredMask);
+
+        // Act
+        state.MarkArgumentSet(0);
+        state.MarkArgumentSet(25);
+        state.MarkArgumentSet(50);
+        state.MarkArgumentSet(99);
+
+        // Assert
+        Assert.True(state.IsArgumentSet(0));
+        Assert.False(state.IsArgumentSet(1));
+        Assert.True(state.IsArgumentSet(25));
+        Assert.False(state.IsArgumentSet(26));
+        Assert.True(state.IsArgumentSet(50));
+        Assert.False(state.IsArgumentSet(51));
+        Assert.True(state.IsArgumentSet(99));
+        Assert.False(state.IsArgumentSet(98));
+    }
+
+    [Fact]
+    public static void MarkArgumentSet_WithIndexOutOfRange_DoesNotThrow()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(5);
+        var state = new LargeArgumentState<TestArguments>(arguments, 5, requiredMask);
+
+        // Act (should not throw, behavior defined by ValueBitArray)
+        state.MarkArgumentSet(5);
+        state.MarkArgumentSet(100);
+        state.MarkArgumentSet(-1);
+
+        // Assert - verify no valid arguments were accidentally set
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.False(state.IsArgumentSet(i));
+        }
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WithNoRequiredArguments_ReturnsTrue()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(100); // All bits false by default
+        var state = new LargeArgumentState<TestArguments>(arguments, 100, requiredMask);
+
+        // Act & Assert
+        Assert.True(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WithSomeRequiredArguments_InitiallyReturnsFalse()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(100);
+        requiredMask[0] = true;
+        requiredMask[50] = true;
+        requiredMask[99] = true;
+        var state = new LargeArgumentState<TestArguments>(arguments, 100, requiredMask);
+
+        // Act & Assert
+        Assert.False(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WhenAllRequiredArgumentsSet_ReturnsTrue()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(100);
+        requiredMask[10] = true;
+        requiredMask[30] = true;
+        requiredMask[70] = true;
+        var state = new LargeArgumentState<TestArguments>(arguments, 100, requiredMask);
+
+        // Act
+        state.MarkArgumentSet(10);
+        state.MarkArgumentSet(30);
+        state.MarkArgumentSet(70);
+
+        // Assert
+        Assert.True(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WhenSomeRequiredArgumentsMissing_ReturnsFalse()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(100);
+        requiredMask[10] = true;
+        requiredMask[30] = true;
+        requiredMask[70] = true;
+        var state = new LargeArgumentState<TestArguments>(arguments, 100, requiredMask);
+
+        // Act
+        state.MarkArgumentSet(10);
+        state.MarkArgumentSet(30);
+        // Missing argument 70
+
+        // Assert
+        Assert.False(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WithExtraArgumentsSet_StillReturnsTrue()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(100);
+        requiredMask[10] = true;
+        requiredMask[30] = true;
+        var state = new LargeArgumentState<TestArguments>(arguments, 100, requiredMask);
+
+        // Act
+        state.MarkArgumentSet(10);
+        state.MarkArgumentSet(20); // Extra argument
+        state.MarkArgumentSet(30);
+        state.MarkArgumentSet(50); // Extra argument
+
+        // Assert
+        Assert.True(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void Arguments_Property_AllowsModification()
+    {
+        // Arrange
+        var arguments = new TestArguments { Value1 = 42, Value2 = "test" };
+        var requiredMask = new ValueBitArray(3);
+        var state = new LargeArgumentState<TestArguments>(arguments, 3, requiredMask);
+
+        // Act
+        state.Arguments.Value1 = 100;
+        state.Arguments.Value3 = true;
+
+        // Assert
+        Assert.Equal(100, state.Arguments.Value1);
+        Assert.Equal("test", state.Arguments.Value2);
+        Assert.True(state.Arguments.Value3);
+    }
+
+    [Fact]
+    public static void MarkArgumentSet_WithLargeNumberOfArguments_WorksCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(1000);
+        var state = new LargeArgumentState<TestArguments>(arguments, 1000, requiredMask);
+
+        // Act - Set arguments across multiple bytes
+        var indicesToSet = new[] { 0, 63, 64, 127, 128, 255, 256, 511, 512, 999 };
+        foreach (int index in indicesToSet)
+        {
+            state.MarkArgumentSet(index);
+        }
+
+        // Assert
+        foreach (int index in indicesToSet)
+        {
+            Assert.True(state.IsArgumentSet(index));
+        }
+
+        // Verify adjacent arguments are not set
+        var indicesToCheck = new[] { 1, 62, 65, 126, 129, 254, 257, 510, 513, 998 };
+        foreach (int index in indicesToCheck)
+        {
+            Assert.False(state.IsArgumentSet(index));
+        }
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WithLargeNumberOfRequiredArguments_WorksCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(1000);
+        
+        // Set every 10th argument as required
+        for (int i = 0; i < 1000; i += 10)
+        {
+            requiredMask[i] = true;
+        }
+        
+        var state = new LargeArgumentState<TestArguments>(arguments, 1000, requiredMask);
+
+        // Initially not all required arguments are set
+        Assert.False(state.AreRequiredArgumentsSet);
+
+        // Act - Set all required arguments
+        for (int i = 0; i < 1000; i += 10)
+        {
+            state.MarkArgumentSet(i);
+        }
+
+        // Assert
+        Assert.True(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void MarkArgumentSet_CanSetSameArgumentMultipleTimes()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(100);
+        var state = new LargeArgumentState<TestArguments>(arguments, 100, requiredMask);
+
+        // Act
+        state.MarkArgumentSet(50);
+        state.MarkArgumentSet(50); // Set again
+        state.MarkArgumentSet(50); // Set again
+
+        // Assert
+        Assert.True(state.IsArgumentSet(50));
+        Assert.False(state.IsArgumentSet(49));
+        Assert.False(state.IsArgumentSet(51));
+    }
+
+    [Fact]
+    public static void StructBehavior_IsValueType()
+    {
+        // Arrange
+        var arguments1 = new TestArguments { Value1 = 42 };
+        var requiredMask = new ValueBitArray(3);
+        var state1 = new LargeArgumentState<TestArguments>(arguments1, 3, requiredMask);
+        
+        // Act - Modify copy
+        var state2 = state1;
+        state2.MarkArgumentSet(0);
+        state2.Arguments.Value1 = 100;
+
+        // Assert - Original should be unchanged for Arguments field (value semantics)
+        // but shared BitArray references mean both will see the set argument
+        Assert.Equal(42, state1.Arguments.Value1);
+        Assert.Equal(100, state2.Arguments.Value1);
+        
+        // Both will see the argument as set due to shared ValueBitArray reference
+        Assert.True(state1.IsArgumentSet(0));
+        Assert.True(state2.IsArgumentSet(0));
+    }
+
+    [Fact]
+    public static void IArgumentState_Interface_ImplementedCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(100);
+        requiredMask[0] = true;
+        requiredMask[50] = true;
+        IArgumentState state = new LargeArgumentState<TestArguments>(arguments, 100, requiredMask);
+
+        // Act & Assert
+        Assert.Equal(100, state.Count);
+        Assert.False(state.AreRequiredArgumentsSet);
+        Assert.False(state.IsArgumentSet(0));
+        Assert.False(state.IsArgumentSet(50));
+    }
+
+    [Fact]
+    public static void Constructor_WithLargeRequiredMask_WorksCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        int count = 500;
+        var requiredMask = new ValueBitArray(count);
+        
+        // Set multiple arguments as required across byte boundaries
+        for (int i = 0; i < count; i += 7) // Every 7th argument
+        {
+            requiredMask[i] = true;
+        }
+
+        // Act
+        var state = new LargeArgumentState<TestArguments>(arguments, count, requiredMask);
+
+        // Assert
+        Assert.Equal(count, state.Count);
+        Assert.False(state.AreRequiredArgumentsSet);
+        
+        // Verify the required mask was properly set
+        for (int i = 0; i < count; i++)
+        {
+            bool expectedRequired = (i % 7) == 0;
+            if (expectedRequired)
+            {
+                // We can't directly test the required mask, but we can verify
+                // by setting only this argument and checking if requirements are met
+                var testState = new LargeArgumentState<TestArguments>(arguments, count, requiredMask);
+                testState.MarkArgumentSet(i);
+                
+                // If this was the only required argument, requirements would be met
+                // We'll test this indirectly by the overall behavior
+            }
+        }
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WithByteAlignedArguments_WorksCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var requiredMask = new ValueBitArray(200);
+        
+        // Set arguments at byte boundaries as required
+        requiredMask[0] = true;   // First bit of first byte
+        requiredMask[7] = true;   // Last bit of first byte
+        requiredMask[8] = true;   // First bit of second byte
+        requiredMask[63] = true;  // Last bit of 8th byte
+        requiredMask[64] = true;  // First bit of 9th byte
+        requiredMask[199] = true; // Last argument
+        
+        var state = new LargeArgumentState<TestArguments>(arguments, 200, requiredMask);
+
+        // Initially not satisfied
+        Assert.False(state.AreRequiredArgumentsSet);
+
+        // Act - Set required arguments one by one
+        state.MarkArgumentSet(0);
+        Assert.False(state.AreRequiredArgumentsSet);
+        
+        state.MarkArgumentSet(7);
+        Assert.False(state.AreRequiredArgumentsSet);
+        
+        state.MarkArgumentSet(8);
+        Assert.False(state.AreRequiredArgumentsSet);
+        
+        state.MarkArgumentSet(63);
+        Assert.False(state.AreRequiredArgumentsSet);
+        
+        state.MarkArgumentSet(64);
+        Assert.False(state.AreRequiredArgumentsSet);
+        
+        state.MarkArgumentSet(199);
+        Assert.True(state.AreRequiredArgumentsSet); // Now all required are set
+    }
+}

--- a/tests/PolyType.Tests/SourceGenModel/SmallArgumentStateTests.cs
+++ b/tests/PolyType.Tests/SourceGenModel/SmallArgumentStateTests.cs
@@ -1,0 +1,361 @@
+using System;
+using PolyType.SourceGenModel;
+
+namespace PolyType.Tests.SourceGenModel;
+
+public static class SmallArgumentStateTests
+{
+    public struct TestArguments
+    {
+        public int Value1;
+        public string Value2;
+        public bool Value3;
+    }
+
+    [Fact]
+    public static void Constructor_WithValidParameters_InitializesCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments { Value1 = 42 };
+        int count = 5;
+        ulong requiredMask = 0b10101; // Arguments 0, 2, and 4 are required
+
+        // Act
+        var state = new SmallArgumentState<TestArguments>(arguments, count, requiredMask);
+
+        // Assert
+        Assert.Equal(count, state.Count);
+        Assert.Equal(42, state.Arguments.Value1);
+        Assert.False(state.AreRequiredArgumentsSet); // No arguments marked as set yet
+    }
+
+    [Fact]
+    public static void Constructor_WithCountGreaterThan64_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        int count = 65;
+        ulong requiredMask = 0;
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => 
+            new SmallArgumentState<TestArguments>(arguments, count, requiredMask));
+    }
+
+    [Fact]
+    public static void Constructor_WithCount64_Succeeds()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        int count = 64;
+        ulong requiredMask = 0;
+
+        // Act
+        var state = new SmallArgumentState<TestArguments>(arguments, count, requiredMask);
+
+        // Assert
+        Assert.Equal(64, state.Count);
+    }
+
+    [Fact]
+    public static void Constructor_WithNegativeCount_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        int count = -1;
+        ulong requiredMask = 0;
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => 
+            new SmallArgumentState<TestArguments>(arguments, count, requiredMask));
+    }
+
+    [Fact]
+    public static void Constructor_WithZeroCount_Succeeds()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        int count = 0;
+        ulong requiredMask = 0;
+
+        // Act
+        var state = new SmallArgumentState<TestArguments>(arguments, count, requiredMask);
+
+        // Assert
+        Assert.Equal(0, state.Count);
+        Assert.True(state.AreRequiredArgumentsSet); // Vacuously true for empty set
+    }
+
+    [Fact]
+    public static void IsArgumentSet_InitiallyAllArgumentsAreNotSet()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var state = new SmallArgumentState<TestArguments>(arguments, 5, 0);
+
+        // Act & Assert
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.False(state.IsArgumentSet(i));
+        }
+    }
+
+    [Fact]
+    public static void IsArgumentSet_WithIndexOutOfRange_ReturnsFalse()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var state = new SmallArgumentState<TestArguments>(arguments, 5, 0);
+
+        // Act & Assert
+        Assert.False(state.IsArgumentSet(5));  // At boundary
+        Assert.False(state.IsArgumentSet(10)); // Beyond boundary
+        Assert.False(state.IsArgumentSet(-1)); // Negative index (treated as very large uint)
+    }
+
+    [Fact]
+    public static void MarkArgumentSet_SetsArgumentCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var state = new SmallArgumentState<TestArguments>(arguments, 5, 0);
+
+        // Act
+        state.MarkArgumentSet(0);
+        state.MarkArgumentSet(2);
+        state.MarkArgumentSet(4);
+
+        // Assert
+        Assert.True(state.IsArgumentSet(0));
+        Assert.False(state.IsArgumentSet(1));
+        Assert.True(state.IsArgumentSet(2));
+        Assert.False(state.IsArgumentSet(3));
+        Assert.True(state.IsArgumentSet(4));
+    }
+
+    [Fact]
+    public static void MarkArgumentSet_WithIndexOutOfRange_DoesNothing()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var state = new SmallArgumentState<TestArguments>(arguments, 5, 0);
+
+        // Act (should not throw)
+        state.MarkArgumentSet(5);
+        state.MarkArgumentSet(10);
+        state.MarkArgumentSet(-1);
+
+        // Assert - no arguments should be set
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.False(state.IsArgumentSet(i));
+        }
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WithNoRequiredArguments_ReturnsTrue()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var state = new SmallArgumentState<TestArguments>(arguments, 5, 0); // No required arguments
+
+        // Act & Assert
+        Assert.True(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WithSomeRequiredArguments_InitiallyReturnsFalse()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        ulong requiredMask = 0b10101; // Arguments 0, 2, and 4 are required
+        var state = new SmallArgumentState<TestArguments>(arguments, 5, requiredMask);
+
+        // Act & Assert
+        Assert.False(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WhenAllRequiredArgumentsSet_ReturnsTrue()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        ulong requiredMask = 0b10101; // Arguments 0, 2, and 4 are required
+        var state = new SmallArgumentState<TestArguments>(arguments, 5, requiredMask);
+
+        // Act
+        state.MarkArgumentSet(0);
+        state.MarkArgumentSet(2);
+        state.MarkArgumentSet(4);
+
+        // Assert
+        Assert.True(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WhenSomeRequiredArgumentsMissing_ReturnsFalse()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        ulong requiredMask = 0b10101; // Arguments 0, 2, and 4 are required
+        var state = new SmallArgumentState<TestArguments>(arguments, 5, requiredMask);
+
+        // Act
+        state.MarkArgumentSet(0);
+        state.MarkArgumentSet(2);
+        // Missing argument 4
+
+        // Assert
+        Assert.False(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WithExtraArgumentsSet_StillReturnsTrue()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        ulong requiredMask = 0b101; // Arguments 0 and 2 are required
+        var state = new SmallArgumentState<TestArguments>(arguments, 5, requiredMask);
+
+        // Act
+        state.MarkArgumentSet(0);
+        state.MarkArgumentSet(1); // Extra argument
+        state.MarkArgumentSet(2);
+        state.MarkArgumentSet(3); // Extra argument
+
+        // Assert
+        Assert.True(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void Arguments_Property_AllowsModification()
+    {
+        // Arrange
+        var arguments = new TestArguments { Value1 = 42, Value2 = "test" };
+        var state = new SmallArgumentState<TestArguments>(arguments, 3, 0);
+
+        // Act
+        state.Arguments.Value1 = 100;
+        state.Arguments.Value3 = true;
+
+        // Assert
+        Assert.Equal(100, state.Arguments.Value1);
+        Assert.Equal("test", state.Arguments.Value2);
+        Assert.True(state.Arguments.Value3);
+    }
+
+    [Fact]
+    public static void MarkArgumentSet_WithAllBitsInUlong_WorksCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var state = new SmallArgumentState<TestArguments>(arguments, 64, 0);
+
+        // Act - Set all 64 arguments
+        for (int i = 0; i < 64; i++)
+        {
+            state.MarkArgumentSet(i);
+        }
+
+        // Assert
+        for (int i = 0; i < 64; i++)
+        {
+            Assert.True(state.IsArgumentSet(i));
+        }
+    }
+
+    [Fact]
+    public static void AreRequiredArgumentsSet_WithAllBitsRequired_WorksCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        ulong requiredMask = ulong.MaxValue; // All 64 bits required
+        var state = new SmallArgumentState<TestArguments>(arguments, 64, requiredMask);
+
+        // Initially no arguments set
+        Assert.False(state.AreRequiredArgumentsSet);
+
+        // Act - Set all arguments
+        for (int i = 0; i < 64; i++)
+        {
+            state.MarkArgumentSet(i);
+        }
+
+        // Assert
+        Assert.True(state.AreRequiredArgumentsSet);
+    }
+
+    [Fact]
+    public static void MarkArgumentSet_CanSetSameArgumentMultipleTimes()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var state = new SmallArgumentState<TestArguments>(arguments, 3, 0);
+
+        // Act
+        state.MarkArgumentSet(1);
+        state.MarkArgumentSet(1); // Set again
+        state.MarkArgumentSet(1); // Set again
+
+        // Assert
+        Assert.True(state.IsArgumentSet(1));
+        Assert.False(state.IsArgumentSet(0));
+        Assert.False(state.IsArgumentSet(2));
+    }
+
+    [Theory]
+    [InlineData(0, 0b1)]
+    [InlineData(1, 0b10)]
+    [InlineData(2, 0b100)]
+    [InlineData(5, 0b100000)]
+    [InlineData(63, 0x8000000000000000UL)]
+    public static void MarkArgumentSet_SetsSingleBitCorrectly(int index, ulong _)
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        var state = new SmallArgumentState<TestArguments>(arguments, 64, 0);
+
+        // Act
+        state.MarkArgumentSet(index);
+
+        // Assert
+        Assert.True(state.IsArgumentSet(index));
+        
+        // Verify only the expected bit is set by checking adjacent bits
+        if (index > 0) Assert.False(state.IsArgumentSet(index - 1));
+        if (index < 63) Assert.False(state.IsArgumentSet(index + 1));
+    }
+
+    [Fact]
+    public static void StructBehavior_IsValueType()
+    {
+        // Arrange
+        var arguments1 = new TestArguments { Value1 = 42 };
+        var state1 = new SmallArgumentState<TestArguments>(arguments1, 3, 0);
+        
+        // Act - Modify copy
+        var state2 = state1;
+        state2.MarkArgumentSet(0);
+        state2.Arguments.Value1 = 100;
+
+        // Assert - Original should be unchanged (value semantics)
+        Assert.False(state1.IsArgumentSet(0));
+        Assert.Equal(42, state1.Arguments.Value1);
+        Assert.True(state2.IsArgumentSet(0));
+        Assert.Equal(100, state2.Arguments.Value1);
+    }
+
+    [Fact]
+    public static void IArgumentState_Interface_ImplementedCorrectly()
+    {
+        // Arrange
+        var arguments = new TestArguments();
+        IArgumentState state = new SmallArgumentState<TestArguments>(arguments, 5, 0b101);
+
+        // Act & Assert
+        Assert.Equal(5, state.Count);
+        Assert.False(state.AreRequiredArgumentsSet);
+        Assert.False(state.IsArgumentSet(0));
+        Assert.False(state.IsArgumentSet(2));
+    }
+}

--- a/tests/PolyType.Tests/SourceGenModel/ValueBitArrayTests.cs
+++ b/tests/PolyType.Tests/SourceGenModel/ValueBitArrayTests.cs
@@ -1,0 +1,360 @@
+using System;
+using PolyType.SourceGenModel;
+
+namespace PolyType.Tests.SourceGenModel;
+
+public static class ValueBitArrayTests
+{
+    [Fact]
+    public static void Constructor_WithLength_CreatesArrayWithCorrectLength()
+    {
+        // Arrange & Act
+        var bitArray = new ValueBitArray(10);
+
+        // Assert
+        Assert.Equal(10, bitArray.Length);
+    }
+
+    [Fact]
+    public static void Constructor_WithNegativeLength_ThrowsArgumentOutOfRangeException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ValueBitArray(-1));
+    }
+
+    [Fact]
+    public static void Constructor_WithZeroLength_CreatesEmptyArray()
+    {
+        // Arrange & Act
+        var bitArray = new ValueBitArray(0);
+
+        // Assert
+        Assert.Equal(0, bitArray.Length);
+        Assert.True(bitArray.Bytes.IsEmpty);
+    }
+
+    [Fact]
+    public static void Constructor_WithBytesAndLength_InitializesCorrectly()
+    {
+        // Arrange
+        byte[] bytes = [0b10101010, 0b11110000];
+        int length = 12;
+
+        // Act
+        var bitArray = new ValueBitArray(bytes, length);
+
+        // Assert
+        Assert.Equal(length, bitArray.Length);
+        Assert.Equal(2, bitArray.Bytes.Length);
+        Assert.True(bitArray[1]); // Second bit should be set
+        Assert.False(bitArray[0]); // First bit should not be set
+    }
+
+    [Fact]
+    public static void Constructor_WithBytesAndNegativeLength_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        byte[] bytes = [0xFF];
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ValueBitArray(bytes, -1));
+    }
+
+    [Fact]
+    public static void Constructor_WithLengthExceedingByteCapacity_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        byte[] bytes = [0xFF]; // 1 byte = 8 bits capacity
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ValueBitArray(bytes, 9));
+    }
+
+    [Fact]
+    public static void Constructor_WithBytesAndLength_NormalizesTrailingBits()
+    {
+        // Arrange
+        byte[] bytes = [0xFF]; // All bits set
+        int length = 5; // Only first 5 bits should be valid
+
+        // Act
+        var bitArray = new ValueBitArray(bytes, length);
+
+        // Assert
+        // The trailing 3 bits should be cleared
+        Assert.Equal(0b00011111, bitArray.Bytes[0]);
+    }
+
+    [Fact]
+    public static void Indexer_Get_WithValidIndex_ReturnsCorrectBit()
+    {
+        // Arrange
+        byte[] bytes = [0b10101010];
+        var bitArray = new ValueBitArray(bytes, 8);
+
+        // Act & Assert
+        Assert.False(bitArray[0]); // LSB is 0
+        Assert.True(bitArray[1]);  // Second bit is 1
+        Assert.False(bitArray[2]); // Third bit is 0
+        Assert.True(bitArray[3]);  // Fourth bit is 1
+    }
+
+    [Fact]
+    public static void Indexer_Get_WithIndexOutOfRange_ReturnsFalse()
+    {
+        // Arrange
+        var bitArray = new ValueBitArray(5);
+
+        // Act & Assert
+        Assert.False(bitArray[10]); // Index beyond length
+        Assert.False(bitArray[-1]); // Negative index (treated as very large uint)
+    }
+
+    [Fact]
+    public static void Indexer_Set_WithValidIndex_UpdatesBitCorrectly()
+    {
+        // Arrange
+        var bitArray = new ValueBitArray(8);
+
+        // Act
+        bitArray[0] = true;
+        bitArray[3] = true;
+        bitArray[7] = true;
+
+        // Assert
+        Assert.True(bitArray[0]);
+        Assert.False(bitArray[1]);
+        Assert.False(bitArray[2]);
+        Assert.True(bitArray[3]);
+        Assert.False(bitArray[4]);
+        Assert.False(bitArray[5]);
+        Assert.False(bitArray[6]);
+        Assert.True(bitArray[7]);
+    }
+
+    [Fact]
+    public static void Indexer_Set_WithIndexOutOfRange_DoesNothing()
+    {
+        // Arrange
+        var bitArray = new ValueBitArray(5);
+
+        // Act (should not throw)
+        bitArray[10] = true;
+        bitArray[-1] = true;
+
+        // Assert - all bits should still be false
+        for (int i = 0; i < bitArray.Length; i++)
+        {
+            Assert.False(bitArray[i]);
+        }
+    }
+
+    [Fact]
+    public static void Indexer_SetFalse_ClearsBitCorrectly()
+    {
+        // Arrange
+        var bitArray = new ValueBitArray(8);
+        bitArray[3] = true; // Set a bit first
+
+        // Act
+        bitArray[3] = false; // Clear the bit
+
+        // Assert
+        Assert.False(bitArray[3]);
+    }
+
+    [Fact]
+    public static void IsSubsetOf_WithEqualArrays_ReturnsTrue()
+    {
+        // Arrange
+        byte[] bytes = [0b10101010];
+        var bitArray1 = new ValueBitArray(bytes, 8);
+        var bitArray2 = new ValueBitArray(bytes, 8);
+
+        // Act
+        bool result = bitArray1.IsSubsetOf(bitArray2);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public static void IsSubsetOf_WithDifferentLengths_ReturnsFalse()
+    {
+        // Arrange
+        var bitArray1 = new ValueBitArray(5);
+        var bitArray2 = new ValueBitArray(10);
+
+        // Act
+        bool result = bitArray1.IsSubsetOf(bitArray2);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public static void IsSubsetOf_WithActualSubset_ReturnsTrue()
+    {
+        // Arrange
+        var bitArray1 = new ValueBitArray(8);
+        var bitArray2 = new ValueBitArray(8);
+        
+        bitArray1[1] = true;
+        bitArray1[3] = true;
+        
+        bitArray2[1] = true;
+        bitArray2[3] = true;
+        bitArray2[5] = true; // Additional bit set in superset
+
+        // Act
+        bool result = bitArray1.IsSubsetOf(bitArray2);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public static void IsSubsetOf_WithNotSubset_ReturnsFalse()
+    {
+        // Arrange
+        var bitArray1 = new ValueBitArray(8);
+        var bitArray2 = new ValueBitArray(8);
+        
+        bitArray1[1] = true;
+        bitArray1[3] = true;
+        bitArray1[5] = true; // This bit is not set in bitArray2
+        
+        bitArray2[1] = true;
+        bitArray2[3] = true;
+
+        // Act
+        bool result = bitArray1.IsSubsetOf(bitArray2);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public static void IsSubsetOf_WithEmptyArrays_ReturnsTrue()
+    {
+        // Arrange
+        var bitArray1 = new ValueBitArray(0);
+        var bitArray2 = new ValueBitArray(0);
+
+        // Act
+        bool result = bitArray1.IsSubsetOf(bitArray2);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public static void IsSubsetOf_WithMultiByteArrays_WorksCorrectly()
+    {
+        // Arrange
+        var bitArray1 = new ValueBitArray(16);
+        var bitArray2 = new ValueBitArray(16);
+        
+        // Set some bits across multiple bytes
+        bitArray1[1] = true;   // First byte
+        bitArray1[9] = true;   // Second byte
+        
+        bitArray2[1] = true;   // First byte
+        bitArray2[9] = true;   // Second byte
+        bitArray2[15] = true;  // Additional bit in second byte
+
+        // Act
+        bool result = bitArray1.IsSubsetOf(bitArray2);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public static void Bytes_Property_ReturnsCorrectSpan()
+    {
+        // Arrange
+        byte[] initialBytes = [0b10101010, 0b11110000];
+        var bitArray = new ValueBitArray(initialBytes, 16);
+
+        // Act
+        var bytes = bitArray.Bytes;
+
+        // Assert
+        Assert.Equal(2, bytes.Length);
+        Assert.Equal(0b10101010, bytes[0]);
+        Assert.Equal(0b11110000, bytes[1]);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(8, 1)]
+    [InlineData(9, 2)]
+    [InlineData(16, 2)]
+    [InlineData(17, 3)]
+    [InlineData(64, 8)]
+    [InlineData(65, 9)]
+    public static void Constructor_CalculatesCorrectByteArraySize(int bitLength, int expectedByteCount)
+    {
+        // Act
+        var bitArray = new ValueBitArray(bitLength);
+
+        // Assert
+        Assert.Equal(expectedByteCount, bitArray.Bytes.Length);
+    }
+
+    [Fact]
+    public static void IsSubsetOf_WithAllBitsSet_WorksCorrectly()
+    {
+        // Arrange
+        var subset = new ValueBitArray(8);
+        var superset = new ValueBitArray(8);
+        
+        // Set all bits in superset
+        for (int i = 0; i < 8; i++)
+        {
+            superset[i] = true;
+        }
+        
+        // Set some bits in subset
+        subset[1] = true;
+        subset[4] = true;
+        subset[7] = true;
+
+        // Act
+        bool result = subset.IsSubsetOf(superset);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public static void IsSubsetOf_SelfReference_ReturnsTrue()
+    {
+        // Arrange
+        var bitArray = new ValueBitArray(8);
+        bitArray[1] = true;
+        bitArray[3] = true;
+
+        // Act
+        bool result = bitArray.IsSubsetOf(bitArray);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public static void ByteArrayAccess_AfterModification_ReflectsChanges()
+    {
+        // Arrange
+        var bitArray = new ValueBitArray(8);
+
+        // Act
+        bitArray[0] = true;
+        bitArray[7] = true;
+
+        // Assert
+        var bytes = bitArray.Bytes;
+        Assert.Equal(0b10000001, bytes[0]); // LSB and MSB set
+    }
+}

--- a/tests/PolyType.Tests/TypeShapeVisitorTests.cs
+++ b/tests/PolyType.Tests/TypeShapeVisitorTests.cs
@@ -35,10 +35,10 @@ public class TypeShapeVisitorTests(ITestOutputHelper logger)
     public void VisitProperty() => AssertVisitor(v => v.VisitProperty<object, object>(default!));
 
     [Fact]
-    public void VisitConstructor() => AssertVisitor(v => v.VisitConstructor<object, object>(default!));
+    public void VisitConstructor() => AssertVisitor(v => v.VisitConstructor<object, IArgumentState>(default!));
 
     [Fact]
-    public void VisitParameter() => AssertVisitor(v => v.VisitParameter<object, object>(default!));
+    public void VisitParameter() => AssertVisitor(v => v.VisitParameter<IArgumentState, object>(default!));
 
     [Fact]
     public void VisitOptional() => AssertVisitor(v => v.VisitOptional<object, object>(default!));


### PR DESCRIPTION
Introduces an `IArgumentState` interface for constructor shapes that supports tracking of required parameters and detecting duplicate parameter assignments. Introduces a binary but not source breaking change.

Fix #140. cc @AArnott