### PR TITLE
Use consistent terminology for default constructor delegates.

### DIFF
--- a/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
@@ -93,7 +93,7 @@ public static partial class CborSerializer
                     new CborMutableEnumerableConverter<TEnumerable, TElement>(
                         elementConverter,
                         getEnumerable,
-                        enumerableShape.GetMutableConstructor(),
+                        enumerableShape.GetDefaultConstructor(),
                         enumerableShape.GetAppender()),
 
                 CollectionConstructionStrategy.Parameterized =>
@@ -119,7 +119,7 @@ public static partial class CborSerializer
                         keyConverter,
                         valueConverter,
                         getDictionary,
-                        dictionaryShape.GetMutableConstructor(),
+                        dictionaryShape.GetDefaultConstructor(),
                         dictionaryShape.GetInserter(DictionaryInsertionMode.Discard)),
 
                 CollectionConstructionStrategy.Parameterized =>

--- a/src/PolyType.Examples/Cloner/Cloner.Builder.cs
+++ b/src/PolyType.Examples/Cloner/Cloner.Builder.cs
@@ -143,7 +143,7 @@ public static partial class Cloner
             switch (enumerableShape.ConstructionStrategy)
             {
                 case CollectionConstructionStrategy.Mutable:
-                    var defaultCtor = enumerableShape.GetMutableConstructor();
+                    var defaultCtor = enumerableShape.GetDefaultConstructor();
                     var appender = enumerableShape.GetAppender();
                     return new Func<TEnumerable?, TEnumerable?>(source =>
                     {
@@ -192,7 +192,7 @@ public static partial class Cloner
             switch (dictionaryShape.ConstructionStrategy)
             {
                 case CollectionConstructionStrategy.Mutable:
-                    var defaultCtor = dictionaryShape.GetMutableConstructor();
+                    var defaultCtor = dictionaryShape.GetDefaultConstructor();
                     var inserter = dictionaryShape.GetInserter();
                     return new Func<TDictionary?, TDictionary?>(source =>
                     {

--- a/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
+++ b/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
@@ -120,7 +120,7 @@ public static partial class ConfigurationBinderTS
             switch (enumerableShape.ConstructionStrategy)
             {
                 case CollectionConstructionStrategy.Mutable:
-                    MutableCollectionConstructor<TElement, TEnumerable> defaultCtor = enumerableShape.GetMutableConstructor();
+                    MutableCollectionConstructor<TElement, TEnumerable> defaultCtor = enumerableShape.GetDefaultConstructor();
                     EnumerableAppender<TEnumerable, TElement> appender = enumerableShape.GetAppender();
                     return new Func<IConfiguration, TEnumerable?>(configuration =>
                     {
@@ -176,7 +176,7 @@ public static partial class ConfigurationBinderTS
             switch (dictionaryShape.ConstructionStrategy)
             {
                 case CollectionConstructionStrategy.Mutable:
-                    MutableCollectionConstructor<TKey, TDictionary> defaultCtor = dictionaryShape.GetMutableConstructor();
+                    MutableCollectionConstructor<TKey, TDictionary> defaultCtor = dictionaryShape.GetDefaultConstructor();
                     var inserter = dictionaryShape.GetInserter();
                     return new Func<IConfiguration, TDictionary?>(configuration =>
                     {

--- a/src/PolyType.Examples/DependencyInjection/ServiceProviderContext.Builder.cs
+++ b/src/PolyType.Examples/DependencyInjection/ServiceProviderContext.Builder.cs
@@ -93,7 +93,7 @@ public sealed partial class ServiceProviderContext
         {
             if (dictionaryShape.ConstructionStrategy is CollectionConstructionStrategy.Mutable)
             {
-                MutableCollectionConstructor<TKey, TDictionary> defaultCtor = dictionaryShape.GetMutableConstructor();
+                MutableCollectionConstructor<TKey, TDictionary> defaultCtor = dictionaryShape.GetDefaultConstructor();
                 return ServiceFactory.FromFunc(_ => defaultCtor(), ResolveLifetime(state));
             }
 
@@ -104,7 +104,7 @@ public sealed partial class ServiceProviderContext
         {
             if (enumerableShape.ConstructionStrategy is CollectionConstructionStrategy.Mutable)
             {
-                MutableCollectionConstructor<TElement, TEnumerable> defaultCtor = enumerableShape.GetMutableConstructor();
+                MutableCollectionConstructor<TElement, TEnumerable> defaultCtor = enumerableShape.GetDefaultConstructor();
                 return ServiceFactory.FromFunc(_ => defaultCtor(), ResolveLifetime(state));
             }
 

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
@@ -91,7 +91,7 @@ public static partial class JsonSerializerTS
                     new JsonMutableEnumerableConverter<TEnumerable, TElement>(
                         elementConverter,
                         enumerableShape,
-                        enumerableShape.GetMutableConstructor(),
+                        enumerableShape.GetDefaultConstructor(),
                         enumerableShape.GetAppender()),
 
                 CollectionConstructionStrategy.Parameterized => 
@@ -115,7 +115,7 @@ public static partial class JsonSerializerTS
                         keyConverter,
                         valueConverter,
                         dictionaryShape,
-                        dictionaryShape.GetMutableConstructor(),
+                        dictionaryShape.GetDefaultConstructor(),
                         dictionaryShape.GetInserter(DictionaryInsertionMode.Overwrite)),
 
                 CollectionConstructionStrategy.Parameterized => 

--- a/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
+++ b/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
@@ -249,7 +249,7 @@ public static partial class Mapper
                 switch (enumerableShape.ConstructionStrategy)
                 {
                     case CollectionConstructionStrategy.Mutable:
-                        var defaultCtor = enumerableShape.GetMutableConstructor();
+                        var defaultCtor = enumerableShape.GetDefaultConstructor();
                         var appender = enumerableShape.GetAppender();
                         return new Mapper<TSourceEnumerable, TTargetEnumerable>(source =>
                         {
@@ -299,7 +299,7 @@ public static partial class Mapper
                 switch (targetDictionary.ConstructionStrategy)
                 {
                     case CollectionConstructionStrategy.Mutable:
-                        var defaultCtor = targetDictionary.GetMutableConstructor();
+                        var defaultCtor = targetDictionary.GetDefaultConstructor();
                         var inserter = targetDictionary.GetInserter();
                         return new Mapper<TSourceDictionary, TTargetDictionary>(source =>
                         {

--- a/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
+++ b/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
@@ -164,7 +164,7 @@ public partial class RandomGenerator
             switch (enumerableShape.ConstructionStrategy)
             {
                 case CollectionConstructionStrategy.Mutable:
-                    MutableCollectionConstructor<TElement, TEnumerable> defaultCtor = enumerableShape.GetMutableConstructor();
+                    MutableCollectionConstructor<TElement, TEnumerable> defaultCtor = enumerableShape.GetDefaultConstructor();
                     EnumerableAppender<TEnumerable, TElement> addElementFunc = enumerableShape.GetAppender();
                     return new RandomGenerator<TEnumerable>((Random random, int size) =>
                     {
@@ -219,7 +219,7 @@ public partial class RandomGenerator
             switch (dictionaryShape.ConstructionStrategy)
             {
                 case CollectionConstructionStrategy.Mutable:
-                    MutableCollectionConstructor<TKey, TDictionary> defaultCtorFunc = dictionaryShape.GetMutableConstructor();
+                    MutableCollectionConstructor<TKey, TDictionary> defaultCtorFunc = dictionaryShape.GetDefaultConstructor();
                     DictionaryInserter<TDictionary, TKey, TValue> inserter = dictionaryShape.GetInserter();
                     return new RandomGenerator<TDictionary>((Random random, int size) =>
                     {

--- a/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
+++ b/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
@@ -84,7 +84,7 @@ public static partial class XmlSerializer
                     new XmlMutableEnumerableConverter<TEnumerable, TElement>(
                         elementConverter,
                         getEnumerable,
-                        enumerableShape.GetMutableConstructor(),
+                        enumerableShape.GetDefaultConstructor(),
                         enumerableShape.GetAppender()),
                 CollectionConstructionStrategy.Parameterized => 
                     new XmlParameterizedEnumerableConverter<TEnumerable, TElement>(
@@ -108,7 +108,7 @@ public static partial class XmlSerializer
                         keyConverter,
                         valueConverter,
                         getEnumerable,
-                        dictionaryShape.GetMutableConstructor(),
+                        dictionaryShape.GetDefaultConstructor(),
                         dictionaryShape.GetInserter(DictionaryInsertionMode.Throw)),
 
                 CollectionConstructionStrategy.Parameterized => 

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
@@ -25,7 +25,7 @@ internal sealed partial class SourceFormatter
                     GetDictionaryFunc = {{FormatGetDictionaryFunc(dictionaryShapeModel)}},
                     SupportedComparer = {{FormatComparerOptions(dictionaryShapeModel.ConstructorParameters)}},
                     ConstructionStrategy = {{FormatCollectionConstructionStrategy(dictionaryShapeModel.ConstructionStrategy)}},
-                    MutableConstructorFunc = {{FormatDefaultConstructorFunc(dictionaryShapeModel)}},
+                    DefaultConstructorFunc = {{FormatDefaultConstructorFunc(dictionaryShapeModel)}},
                     OverwritingInserter = {{FormatOverwritingInserter(dictionaryShapeModel)}},
                     DiscardingInserter = {{FormatDiscardingInserter(dictionaryShapeModel)}},
                     ThrowingInserter = {{FormatThrowingInserter(dictionaryShapeModel)}},

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
@@ -29,7 +29,7 @@ internal sealed partial class SourceFormatter
                     OverwritingInserter = {{FormatOverwritingInserter(dictionaryShapeModel)}},
                     DiscardingInserter = {{FormatDiscardingInserter(dictionaryShapeModel)}},
                     ThrowingInserter = {{FormatThrowingInserter(dictionaryShapeModel)}},
-                    SpanConstructorFunc = {{FormatSpanConstructorFunc(dictionaryShapeModel)}},
+                    ParameterizedConstructorFunc = {{FormatParameterizedConstructorFunc(dictionaryShapeModel)}},
                     AssociatedTypeShapes = {{FormatAssociatedTypeShapes(dictionaryShapeModel)}},
                     Provider = this,
                 };
@@ -149,7 +149,7 @@ internal sealed partial class SourceFormatter
         static string FormatKeyValueTypeName(DictionaryShapeModel dictionaryType)
             => $"global::System.Collections.Generic.KeyValuePair<{dictionaryType.KeyType}, {dictionaryType.ValueType}>";
 
-        static string FormatSpanConstructorFunc(DictionaryShapeModel dictionaryType)
+        static string FormatParameterizedConstructorFunc(DictionaryShapeModel dictionaryType)
         {
             if (dictionaryType.ConstructionStrategy is not CollectionConstructionStrategy.Parameterized)
             {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
@@ -15,8 +15,8 @@ internal sealed partial class SourceFormatter
                 {
                     ElementType = {{GetShapeModel(enumerableShapeModel.ElementType).SourceIdentifier}},
                     ConstructionStrategy = {{FormatCollectionConstructionStrategy(enumerableShapeModel.ConstructionStrategy)}},
-                    DefaultConstructorFunc = {{FormatMutableConstructorFunc(enumerableShapeModel)}},
-                    SpanConstructorFunc = {{FormatSpanConstructorFunc(enumerableShapeModel)}},
+                    DefaultConstructorFunc = {{FormatDefaultConstructorFunc(enumerableShapeModel)}},
+                    ParameterizedConstructorFunc = {{FormatParameterizedConstructorFunc(enumerableShapeModel)}},
                     SupportedComparer = {{FormatComparerOptions(enumerableShapeModel.ConstructorParameters)}},
                     GetEnumerableFunc = {{FormatGetEnumerableFunc(enumerableShapeModel)}},
                     AppenderFunc = {{FormatAppenderFunc(enumerableShapeModel)}},
@@ -45,7 +45,7 @@ internal sealed partial class SourceFormatter
             };
         }
 
-        static string FormatMutableConstructorFunc(EnumerableShapeModel enumerableType)
+        static string FormatDefaultConstructorFunc(EnumerableShapeModel enumerableType)
         {
             if (enumerableType.ConstructionStrategy is not CollectionConstructionStrategy.Mutable)
             {
@@ -73,7 +73,7 @@ internal sealed partial class SourceFormatter
             };
         }
 
-        static string FormatSpanConstructorFunc(EnumerableShapeModel enumerableType)
+        static string FormatParameterizedConstructorFunc(EnumerableShapeModel enumerableType)
         {
             if (enumerableType.ConstructionStrategy is not CollectionConstructionStrategy.Parameterized)
             {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
@@ -15,7 +15,7 @@ internal sealed partial class SourceFormatter
                 {
                     ElementType = {{GetShapeModel(enumerableShapeModel.ElementType).SourceIdentifier}},
                     ConstructionStrategy = {{FormatCollectionConstructionStrategy(enumerableShapeModel.ConstructionStrategy)}},
-                    MutableConstructorFunc = {{FormatMutableConstructorFunc(enumerableShapeModel)}},
+                    DefaultConstructorFunc = {{FormatMutableConstructorFunc(enumerableShapeModel)}},
                     SpanConstructorFunc = {{FormatSpanConstructorFunc(enumerableShapeModel)}},
                     SupportedComparer = {{FormatComparerOptions(enumerableShapeModel.ConstructorParameters)}},
                     GetEnumerableFunc = {{FormatGetEnumerableFunc(enumerableShapeModel)}},

--- a/src/PolyType/Abstractions/Delegates.cs
+++ b/src/PolyType/Abstractions/Delegates.cs
@@ -30,7 +30,7 @@ public delegate void Setter<TDeclaringType, TPropertyType>(ref TDeclaringType ob
 public delegate TDeclaringType Constructor<TArgumentState, TDeclaringType>(ref TArgumentState state);
 
 /// <summary>
-/// Delegate representing a constructor for a mutable collection.
+/// Delegate representing a default constructor for a mutable collection.
 /// </summary>
 /// <typeparam name="TKey">The type of keys or elements in the collection.</typeparam>
 /// <typeparam name="TDeclaringType">The type of the collection to be constructed.</typeparam>

--- a/src/PolyType/Abstractions/IDictionaryTypeShape.cs
+++ b/src/PolyType/Abstractions/IDictionaryTypeShape.cs
@@ -84,11 +84,11 @@ public interface IDictionaryTypeShape<TDictionary, TKey, TValue> : ITypeShape<TD
     Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> GetGetDictionary();
 
     /// <summary>
-    /// Creates a delegate for creating an empty, mutable collection.
+    /// Creates a delegate for creating an empty, mutable dictionary.
     /// </summary>
     /// <exception cref="InvalidOperationException">The collection is not <see cref="CollectionConstructionStrategy.Mutable"/>.</exception>
-    /// <returns>A delegate for creating an empty mutable collection.</returns>
-    MutableCollectionConstructor<TKey, TDictionary> GetMutableConstructor();
+    /// <returns>A delegate for creating an empty mutable dictionary.</returns>
+    MutableCollectionConstructor<TKey, TDictionary> GetDefaultConstructor();
 
     /// <summary>
     /// Creates a delegate used for inserting a new key/value pair to a mutable dictionary.

--- a/src/PolyType/Abstractions/IEnumerableTypeShape.cs
+++ b/src/PolyType/Abstractions/IEnumerableTypeShape.cs
@@ -91,8 +91,8 @@ public interface IEnumerableTypeShape<TEnumerable, TElement> : ITypeShape<TEnume
     /// Creates a delegate for creating an empty, mutable collection.
     /// </summary>
     /// <exception cref="InvalidOperationException">The collection is not <see cref="CollectionConstructionStrategy.Mutable"/>.</exception>
-    /// <returns>A delegate wrapping a constructor that takes no elements.</returns>
-    MutableCollectionConstructor<TElement, TEnumerable> GetMutableConstructor();
+    /// <returns>A delegate for creating an empty mutable collection.</returns>
+    MutableCollectionConstructor<TElement, TEnumerable> GetDefaultConstructor();
 
     /// <summary>
     /// Creates a delegate used for appending a <typeparamref name="TElement"/> to a mutable collection.

--- a/src/PolyType/Abstractions/IObjectTypeShape.cs
+++ b/src/PolyType/Abstractions/IObjectTypeShape.cs
@@ -20,14 +20,12 @@ public interface IObjectTypeShape : ITypeShape
     /// Gets all available property/field shapes for the given type.
     /// </summary>
     /// <returns>An enumeration of all available property/field shapes.</returns>
-    /// <exception cref="NotImplementedException">Thrown on a partial shape that was not generated to include properties.</exception>
     IReadOnlyList<IPropertyShape> Properties { get; }
 
     /// <summary>
     /// Gets the constructor shape for the given type, if available.
     /// </summary>
     /// <returns>An <see cref="IConstructorShape"/> representation of the constructor.</returns>
-    /// <exception cref="NotImplementedException">Thrown on a partial shape that was not generated to include a constructor.</exception>
     IConstructorShape? Constructor { get; }
 }
 

--- a/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
@@ -68,7 +68,7 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
         }
     }
 
-    public MutableCollectionConstructor<TKey, TDictionary> GetMutableConstructor()
+    public MutableCollectionConstructor<TKey, TDictionary> GetDefaultConstructor()
     {
         if (ConstructionStrategy is not CollectionConstructionStrategy.Mutable)
         {

--- a/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
@@ -53,7 +53,7 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
         }
     }
 
-    public virtual MutableCollectionConstructor<TElement, TEnumerable> GetMutableConstructor()
+    public virtual MutableCollectionConstructor<TElement, TEnumerable> GetDefaultConstructor()
     {
         if (ConstructionStrategy is not CollectionConstructionStrategy.Mutable)
         {

--- a/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
@@ -55,7 +55,7 @@ public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : So
     /// <summary>
     /// Gets the function that constructs a dictionary from a span of key-value pairs.
     /// </summary>
-    public ParameterizedCollectionConstructor<TKey, KeyValuePair<TKey, TValue>, TDictionary>? SpanConstructorFunc { get; init; }
+    public ParameterizedCollectionConstructor<TKey, KeyValuePair<TKey, TValue>, TDictionary>? ParameterizedConstructorFunc { get; init; }
 
     /// <inheritdoc/>
     public override TypeShapeKind Kind => TypeShapeKind.Dictionary;
@@ -130,5 +130,5 @@ public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : So
     }
 
     ParameterizedCollectionConstructor<TKey, KeyValuePair<TKey, TValue>, TDictionary> IDictionaryTypeShape<TDictionary, TKey, TValue>.GetParameterizedConstructor()
-        => SpanConstructorFunc ?? throw new InvalidOperationException("Dictionary shape does not specify a span constructor.");
+        => ParameterizedConstructorFunc ?? throw new InvalidOperationException("Dictionary shape does not specify a span constructor.");
 }

--- a/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
@@ -33,9 +33,9 @@ public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : So
     public required CollectionComparerOptions SupportedComparer { get; init; }
 
     /// <summary>
-    /// Gets the function that constructs a default instance of the dictionary type.
+    /// Gets the function that constructs an empty instance of the dictionary type.
     /// </summary>
-    public MutableCollectionConstructor<TKey, TDictionary>? MutableConstructorFunc { get; init; }
+    public MutableCollectionConstructor<TKey, TDictionary>? DefaultConstructorFunc { get; init; }
 
     /// <summary>
     /// Gets the inserter function for adding key-value pairs to the dictionary with overwrite semantics.
@@ -69,8 +69,8 @@ public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : So
     Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> IDictionaryTypeShape<TDictionary, TKey, TValue>.GetGetDictionary()
         => GetDictionaryFunc;
 
-    MutableCollectionConstructor<TKey, TDictionary> IDictionaryTypeShape<TDictionary, TKey, TValue>.GetMutableConstructor()
-        => MutableConstructorFunc ?? throw new InvalidOperationException("Dictionary shape does not specify a default constructor.");
+    MutableCollectionConstructor<TKey, TDictionary> IDictionaryTypeShape<TDictionary, TKey, TValue>.GetDefaultConstructor()
+        => DefaultConstructorFunc ?? throw new InvalidOperationException("Dictionary shape does not specify a default constructor.");
 
     /// <inheritdoc/>
     public DictionaryInsertionMode AvailableInsertionModes

--- a/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
@@ -43,9 +43,9 @@ public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : Source
     public required CollectionConstructionStrategy ConstructionStrategy { get; init; }
 
     /// <summary>
-    /// Gets the function that constructs a default instance of the collection.
+    /// Gets the function that constructs an empty instance of the collection.
     /// </summary>
-    public MutableCollectionConstructor<TElement, TEnumerable>? MutableConstructorFunc { get; init; }
+    public MutableCollectionConstructor<TElement, TEnumerable>? DefaultConstructorFunc { get; init; }
 
     /// <summary>
     /// Gets the function that appends an element to the collection.
@@ -68,8 +68,8 @@ public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : Source
     Func<TEnumerable, IEnumerable<TElement>> IEnumerableTypeShape<TEnumerable, TElement>.GetGetEnumerable()
         => GetEnumerableFunc;
 
-    MutableCollectionConstructor<TElement, TEnumerable> IEnumerableTypeShape<TEnumerable, TElement>.GetMutableConstructor()
-        => MutableConstructorFunc ?? throw new InvalidOperationException("Enumerable shape does not specify a default constructor.");
+    MutableCollectionConstructor<TElement, TEnumerable> IEnumerableTypeShape<TEnumerable, TElement>.GetDefaultConstructor()
+        => DefaultConstructorFunc ?? throw new InvalidOperationException("Enumerable shape does not specify a default constructor.");
 
     EnumerableAppender<TEnumerable, TElement> IEnumerableTypeShape<TEnumerable, TElement>.GetAppender()
         => AppenderFunc ?? throw new InvalidOperationException("Enumerable shape does not specify an append delegate.");

--- a/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenEnumerableTypeShape.cs
@@ -55,7 +55,7 @@ public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : Source
     /// <summary>
     /// Gets the function that constructs a collection from a span.
     /// </summary>
-    public ParameterizedCollectionConstructor<TElement, TElement, TEnumerable>? SpanConstructorFunc { get; init; }
+    public ParameterizedCollectionConstructor<TElement, TElement, TEnumerable>? ParameterizedConstructorFunc { get; init; }
 
     /// <inheritdoc/>
     public override TypeShapeKind Kind => TypeShapeKind.Enumerable;
@@ -75,5 +75,5 @@ public sealed class SourceGenEnumerableTypeShape<TEnumerable, TElement> : Source
         => AppenderFunc ?? throw new InvalidOperationException("Enumerable shape does not specify an append delegate.");
 
     ParameterizedCollectionConstructor<TElement, TElement, TEnumerable> IEnumerableTypeShape<TEnumerable, TElement>.GetParameterizedConstructor()
-        => SpanConstructorFunc ?? throw new InvalidOperationException("Enumerable shape does not specify a span constructor.");
+        => ParameterizedConstructorFunc ?? throw new InvalidOperationException("Enumerable shape does not specify a span constructor.");
 }

--- a/tests/PolyType.Tests/CollectionShapeTests.cs
+++ b/tests/PolyType.Tests/CollectionShapeTests.cs
@@ -16,7 +16,7 @@ public abstract partial class CollectionShapeTests(ProviderUnderTest providerUnd
         var shape = (IEnumerableTypeShape<InternalListOfIntWithPublicConstructor, int>?)providerUnderTest.Provider.GetShape(typeof(InternalListOfIntWithPublicConstructor));
         Assert.NotNull(shape);
         Assert.Equal(CollectionConstructionStrategy.Mutable, shape.ConstructionStrategy);
-        Assert.NotNull(shape.GetMutableConstructor()());
+        Assert.NotNull(shape.GetDefaultConstructor()());
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public abstract partial class CollectionShapeTests(ProviderUnderTest providerUnd
         var shape = (IDictionaryTypeShape<InternalDictionaryOfIntWithPublicConstructor, int, bool>?)providerUnderTest.Provider.GetShape(typeof(InternalDictionaryOfIntWithPublicConstructor));
         Assert.NotNull(shape);
         Assert.Equal(CollectionConstructionStrategy.Mutable, shape.ConstructionStrategy);
-        Assert.NotNull(shape.GetMutableConstructor()());
+        Assert.NotNull(shape.GetDefaultConstructor()());
     }
 
     [GenerateShape]

--- a/tests/PolyType.Tests/CollectionsWithCapacityTests.cs
+++ b/tests/PolyType.Tests/CollectionsWithCapacityTests.cs
@@ -6,7 +6,7 @@ public abstract partial class CollectionsWithCapacityTests(ProviderUnderTest pro
     public void List_OfInt()
     {
         IEnumerableTypeShape<List<int>, int> shape = (IEnumerableTypeShape<List<int>, int>)providerUnderTest.Provider.Resolve<List<int>>();
-        List<int> list = shape.GetMutableConstructor()(new() { Capacity = 11 });
+        List<int> list = shape.GetDefaultConstructor()(new() { Capacity = 11 });
         Assert.Equal(11, list.Capacity);
     }
 
@@ -14,7 +14,7 @@ public abstract partial class CollectionsWithCapacityTests(ProviderUnderTest pro
     public void List_OfString()
     {
         IEnumerableTypeShape<List<string>, string> shape = (IEnumerableTypeShape<List<string>, string>)providerUnderTest.Provider.Resolve<List<string>>();
-        List<string> list = shape.GetMutableConstructor()(new() { Capacity = 11 });
+        List<string> list = shape.GetDefaultConstructor()(new() { Capacity = 11 });
         Assert.Equal(11, list.Capacity);
     }
 
@@ -22,7 +22,7 @@ public abstract partial class CollectionsWithCapacityTests(ProviderUnderTest pro
     public void Dictionary()
     {
         IDictionaryTypeShape<Dictionary<int, bool>, int, bool> shape = (IDictionaryTypeShape<Dictionary<int, bool>, int, bool>)providerUnderTest.Provider.Resolve<Dictionary<int, bool>>();
-        Dictionary<int, bool> dict = shape.GetMutableConstructor()(new() { Capacity = 11 });
+        Dictionary<int, bool> dict = shape.GetDefaultConstructor()(new() { Capacity = 11 });
 #if NET9_0_OR_GREATER
         Assert.Equal(11, dict.Capacity);
 #else
@@ -34,7 +34,7 @@ public abstract partial class CollectionsWithCapacityTests(ProviderUnderTest pro
     public void HashSet()
     {
         IEnumerableTypeShape<HashSet<int>, int> shape = (IEnumerableTypeShape<HashSet<int>, int>)providerUnderTest.Provider.Resolve<HashSet<int>>();
-        HashSet<int> set = shape.GetMutableConstructor()(new() { Capacity = 11 });
+        HashSet<int> set = shape.GetDefaultConstructor()(new() { Capacity = 11 });
 #if NET9_0_OR_GREATER
         Assert.Equal(11, set.Capacity);
 #else

--- a/tests/PolyType.Tests/CollectionsWithComparersTests.cs
+++ b/tests/PolyType.Tests/CollectionsWithComparersTests.cs
@@ -196,7 +196,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     {
         IDictionaryTypeShape<T, K, V> shape = this.GetDictionaryShape<T, K, V>();
         Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparer);
-        return shape.GetMutableConstructor()(new() { Comparer = comparer });
+        return shape.GetDefaultConstructor()(new() { Comparer = comparer });
     }
 
     private T CreateDefaultDictionary<T, K, V>(IEqualityComparer<K>? equalityComparer)
@@ -204,7 +204,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     {
         IDictionaryTypeShape<T, K, V> shape = this.GetDictionaryShape<T, K, V>();
         Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparer);
-        return shape.GetMutableConstructor()(new() { EqualityComparer = equalityComparer });
+        return shape.GetDefaultConstructor()(new() { EqualityComparer = equalityComparer });
     }
 
     private T CreateParameterizedDictionary<T, K, V>(ReadOnlySpan<KeyValuePair<K, V>> values, IComparer<K>? comparer)
@@ -289,7 +289,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
         IEnumerableTypeShape<T, K> shape = this.GetEnumerableShape<T, K>();
         Assert.Equal(CollectionComparerOptions.Comparer, shape.SupportedComparer);
         Assert.Equal(CollectionConstructionStrategy.Mutable, shape.ConstructionStrategy);
-        return shape.GetMutableConstructor()(new() { Comparer = comparer });
+        return shape.GetDefaultConstructor()(new() { Comparer = comparer });
     }
 
     private T CreateDefaultEnumerable<T, K>(IEqualityComparer<K>? equalityComparer)
@@ -297,7 +297,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
         IEnumerableTypeShape<T, K> shape = this.GetEnumerableShape<T, K>();
         Assert.Equal(CollectionComparerOptions.EqualityComparer, shape.SupportedComparer);
         Assert.Equal(CollectionConstructionStrategy.Mutable, shape.ConstructionStrategy);
-        return shape.GetMutableConstructor()(new() { EqualityComparer = equalityComparer });
+        return shape.GetDefaultConstructor()(new() { EqualityComparer = equalityComparer });
     }
 
     private T CreateParameterizedEnumerable<T, K>(ReadOnlySpan<K> values, IComparer<K>? comparer)

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -399,8 +399,8 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
 
             if (dictionaryShape.ConstructionStrategy is CollectionConstructionStrategy.Mutable)
             {
-                var defaultCtor = dictionaryShape.GetMutableConstructor();
-                Assert.Same(dictionaryShape.GetMutableConstructor(), dictionaryShape.GetMutableConstructor());
+                var defaultCtor = dictionaryShape.GetDefaultConstructor();
+                Assert.Same(dictionaryShape.GetDefaultConstructor(), dictionaryShape.GetDefaultConstructor());
 
                 ReadOnlySpan<DictionaryInsertionMode> allInsertionModes = [
                     DictionaryInsertionMode.None,
@@ -446,7 +446,7 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
             }
             else
             {
-                Assert.Throws<InvalidOperationException>(() => dictionaryShape.GetMutableConstructor());
+                Assert.Throws<InvalidOperationException>(() => dictionaryShape.GetDefaultConstructor());
                 Assert.Throws<InvalidOperationException>(() => dictionaryShape.GetInserter());
             }
 
@@ -555,9 +555,9 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
             
             if (enumerableShape.ConstructionStrategy is CollectionConstructionStrategy.Mutable)
             {
-                var defaultCtor = enumerableShape.GetMutableConstructor();
+                var defaultCtor = enumerableShape.GetDefaultConstructor();
                 var appender = enumerableShape.GetAppender();
-                Assert.Same(enumerableShape.GetMutableConstructor(), enumerableShape.GetMutableConstructor());
+                Assert.Same(enumerableShape.GetDefaultConstructor(), enumerableShape.GetDefaultConstructor());
                 Assert.Same(enumerableShape.GetAppender(), enumerableShape.GetAppender());
 
                 enumerable = defaultCtor();
@@ -580,7 +580,7 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
             }
             else
             {
-                Assert.Throws<InvalidOperationException>(() => enumerableShape.GetMutableConstructor());
+                Assert.Throws<InvalidOperationException>(() => enumerableShape.GetDefaultConstructor());
                 Assert.Throws<InvalidOperationException>(() => enumerableShape.GetAppender());
             }
 


### PR DESCRIPTION
Uses consistent terminology in default constructor delegates in both object and collection shapes. I've settled towards keeping `MutableCollectionConstructor` for the delegate type but `GetDefaultConstructor()` for the method that returns the mutable collection constructor. This keeps it consistent with `IConstructorShape` APIs and related helpers.

Contributes to #206.