### PR TITLE
Suppress CS0436 warning in generated code

### DIFF
--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
@@ -99,6 +99,7 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
 
         writer.WriteLine("""
             #pragma warning disable CS0612, CS0618 // Use of obsolete APIs is natural when we're emitting delegates for obsolete properties.
+            #pragma warning disable CS0436 // Use of local types when imported types by the same name exist.
 
             """);
 

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
@@ -1416,6 +1416,31 @@ public static partial class CompilationTests
     }
 
     [Fact]
+    public static void ImportedTypes()
+    {
+        Compilation referencedProject = CompilationHelpers.CreateCompilation("""
+            public class SomeType { }
+            """);
+
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            #pragma warning disable CS0436 // user code would have this pragma to deal with their conflicting type
+
+            public class SomeType { } // local declaration that collides with an imported type.
+
+            [GenerateShape]
+            public partial class ServiceWithImportedTypes
+            {
+                public SomeType? SomeProperty { get; set; }
+            }
+            """,
+            [referencedProject.ToMetadataReference()]);
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public static void NamedTupleProperties()
     {
         // Regression test for https://github.com/eiriktsarpalis/PolyType/issues/241


### PR DESCRIPTION
In such an event, the user's project _already_ has to deal with such type name collisions and has likely suppressed the warning in their own usages of the types. But they can't do that within generated code, so PolyType should.