### PR TITLE
Extend associated type support to all type shape kinds.

### DIFF
--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Object.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Object.cs
@@ -121,7 +121,13 @@ public partial class TypeDataModelGenerator
         return true;
     }
 
-    private void IncludeAssociatedShapes(ITypeSymbol type, ImmutableArray<AssociatedTypeModel> associatedTypes, ref TypeDataModelGenerationContext ctx)
+    /// <summary>
+    /// Includes the specified associated types to the type graph traversal.
+    /// </summary>
+    /// <param name="type">The type from which the associated types originate.</param>
+    /// <param name="associatedTypes">The associated types to include.</param>
+    /// <param name="ctx">The type graph traversal context.</param>
+    protected void IncludeAssociatedShapes(ITypeSymbol type, ImmutableArray<AssociatedTypeModel> associatedTypes, ref TypeDataModelGenerationContext ctx)
     {
         _associatedTypes = _associatedTypes.SetItem(
             type,

--- a/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
@@ -119,14 +119,6 @@ public sealed partial class Parser
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    private static DiagnosticDescriptor AssociatedTypeInExternalAssembly { get; } = new DiagnosticDescriptor(
-        id: "PT0017",
-        title: "Associated type must be declared in same assembly.",
-        messageFormat: "The associated type '{0}' is not declared in the same assembly as the attribute annotation specifying it.",
-        category: "PolyType.SourceGenerator",
-        defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
-
     internal static DiagnosticDescriptor ConflictingMarshalers { get; } = new DiagnosticDescriptor(
         id: "PT0018",
         title: "Multiple marshalers specified.",

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -278,12 +278,6 @@ public sealed partial class Parser
         ITypeSymbol[] typeArgs = namedType?.GetRecursiveTypeArguments() ?? [];
         foreach ((INamedTypeSymbol openType, IAssemblySymbol associatedAssembly, Location? location, TypeShapeRequirements requirements) in associatedTypeSymbols)
         {
-            if (!SymbolEqualityComparer.Default.Equals(openType.ContainingAssembly, associatedAssembly))
-            {
-                ReportDiagnostic(AssociatedTypeInExternalAssembly, location, openType.GetFullyQualifiedName());
-                continue;
-            }
-
             if (!IsAccessibleSymbol(openType))
             {
                 // Skip types that are not accessible in the current scope

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -685,9 +685,12 @@ public sealed partial class Parser : TypeDataModelGenerator
                 MarshalerType = namedMarshaler,
                 Methods = MapMethods(type, ref ctx, methodFlags),
                 Events = MapEvents(type, ref ctx, methodFlags),
+                AssociatedTypes = associatedTypes,
             };
         }
 
+        // Include any associated shapes.
+        IncludeAssociatedShapes(type, associatedTypes, ref ctx);
         return status;
 
         TypeDataModelGenerationStatus ReportInvalidMarshalerAndExit()

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enum.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enum.cs
@@ -13,6 +13,7 @@ internal sealed partial class SourceFormatter
                 return new global::PolyType.SourceGenModel.SourceGenEnumTypeShape<{{enumShapeType.Type.FullyQualifiedName}}, {{enumShapeType.UnderlyingType.FullyQualifiedName}}>
                 {
                     UnderlyingType = {{GetShapeModel(enumShapeType.UnderlyingType).SourceIdentifier}},
+                    AssociatedTypeShapes = {{FormatAssociatedTypeShapes(enumShapeType)}},
                     Provider = this,
                     Members = new global::System.Collections.Generic.Dictionary<string, {{enumShapeType.UnderlyingType.FullyQualifiedName}}>({{enumShapeType.Members.Count}}, global::System.StringComparer.Ordinal)
                     {
@@ -20,6 +21,6 @@ internal sealed partial class SourceFormatter
                     }
                 };
             }
-            """);
+            """, trimNullAssignmentLines: true);
     }
 }

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.FSharpUnion.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.FSharpUnion.cs
@@ -21,6 +21,7 @@ internal sealed partial class SourceFormatter
                     GetUnionCaseIndexFunc = {{FormatFSharpUnionTagReader(unionShapeModel)}},
                     CreateMethodsFunc = {{FormatNull(methodFactoryMethodName)}},
                     CreateEventsFunc = {{FormatNull(eventFactoryMethodName)}},
+                    AssociatedTypeShapes = {{FormatAssociatedTypeShapes(unionShapeModel)}},
                     Provider = this,
                 };
             }

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Function.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Function.cs
@@ -26,6 +26,7 @@ internal sealed partial class SourceFormatter
                     FunctionInvoker = {{FormatFunctionInvoker(functionShapeModel, functionArgumentStateFQN)}},
                     FromDelegateFunc = {{FormatNull(FormatFromDelegateFunc(functionShapeModel, functionArgumentStateFQN, requiredParametersMaskFieldName, requireAsync: false))}},
                     FromAsyncDelegateFunc = {{FormatNull(FormatFromDelegateFunc(functionShapeModel, functionArgumentStateFQN, requiredParametersMaskFieldName, requireAsync: true))}},
+                    AssociatedTypeShapes = {{FormatAssociatedTypeShapes(functionShapeModel)}},
                     Provider = this,
                 };
             }

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Optional.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Optional.cs
@@ -23,10 +23,11 @@ internal sealed partial class SourceFormatter
                     Deconstructor = {{FormatDeconstructor()}},
                     CreateMethodsFunc = {{FormatNull(methodFactoryMethodName)}},
                     CreateEventsFunc = {{FormatNull(eventFactoryMethodName)}},
+                    AssociatedTypeShapes = {{FormatAssociatedTypeShapes(optionalShapeModel)}},
                     Provider = this,
                 };
             }
-            """);
+            """, trimNullAssignmentLines: true);
         writer.WriteLine("#pragma warning restore CS8767", disableIndentation: true);
 
         if (methodFactoryMethodName is not null)

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Surrogate.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Surrogate.cs
@@ -15,14 +15,15 @@ internal sealed partial class SourceFormatter
             {
                 return new global::PolyType.SourceGenModel.SourceGenSurrogateTypeShape<{{surrogateShapeModel.Type.FullyQualifiedName}}, {{surrogateShapeModel.SurrogateType.FullyQualifiedName}}>
                 {
-                    Marshaler = new {{surrogateShapeModel.MarshalerType.FullyQualifiedName}}(),
+                    Marshaler = new {{surrogateShapeModel.MarshalerType.FullyQualifiedName}}()!,
                     SurrogateType = {{GetShapeModel(surrogateShapeModel.SurrogateType).SourceIdentifier}},
                     CreateMethodsFunc = {{FormatNull(methodFactoryMethodName)}},
                     CreateEventsFunc = {{FormatNull(eventFactoryMethodName)}},
+                    AssociatedTypeShapes = {{FormatAssociatedTypeShapes(surrogateShapeModel)}},
                     Provider = this,
                 };
             }
-            """);
+            """, trimNullAssignmentLines: true);
 
         if (methodFactoryMethodName is not null)
         {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Union.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Union.cs
@@ -23,10 +23,11 @@ internal sealed partial class SourceFormatter
                     GetUnionCaseIndexFunc = {{getUnionCaseIndexMethod}},
                     CreateMethodsFunc = {{FormatNull(methodFactoryMethodName)}},
                     CreateEventsFunc = {{FormatNull(eventFactoryMethodName)}},
+                    AssociatedTypeShapes = {{FormatAssociatedTypeShapes(unionShapeModel)}},
                     Provider = this,
                 };
             }
-            """);
+            """, trimNullAssignmentLines: true);
 
         writer.WriteLine();
         FormatUnionCasesFactory(writer, unionShapeModel, createUnionCasesMethodName);


### PR DESCRIPTION
* Extends associated type support to all type shape kinds, including surrogate types.
* Removes the restriction of associated types needing to be in the same assembly as the associating type.

Fix #239.