### PR TITLE
Review and tweak API naming conventions.

### DIFF
--- a/docs/core-abstractions.md
+++ b/docs/core-abstractions.md
@@ -83,7 +83,7 @@ partial class CounterVisitor : TypeShapeVisitor
 Given an `ITypeShape<T>` instance we can now construct a counter delegate like so:
 
 ```C#
-ITypeShape<MyPoco> shape = provider.GetShape<MyPoco>();
+ITypeShape<MyPoco> shape = provider.GetTypeShape<MyPoco>();
 CounterVisitor visitor = new();
 var pocoCounter = (Func<MyPoco, int>)shape.Accept(visitor)!;
 
@@ -444,7 +444,7 @@ class MutatorVisitor : TypeShapeVisitor
 which can be consumed as follows:
 
 ```C#
-ITypeShape<MyPoco> shape = provider.GetShape<MyPoco>();
+ITypeShape<MyPoco> shape = provider.GetTypeShape<MyPoco>();
 MutatorVisitor visitor = new();
 var mutator = (Mutator<MyPoco>)shape.Accept(visitor)!;
 
@@ -556,7 +556,7 @@ class EmptyConstructorVisitor : TypeShapeVisitor
 We can now use the visitor to construct an empty instance factory:
 
 ```C#
-ITypeShape<MyPoco> shape = provider.GetShape<MyPoco>();
+ITypeShape<MyPoco> shape = provider.GetTypeShape<MyPoco>();
 EmptyConstructorVisitor visitor = new();
 var factory = (Func<MyPoco>)shape.Accept(visitor)!;
 

--- a/docs/shape-providers.md
+++ b/docs/shape-providers.md
@@ -52,7 +52,7 @@ PolyType includes a reflection-based provider that resolves shape metadata at ru
 using PolyType.ReflectionProvider;
 
 ITypeShapeProvider provider = ReflectionTypeShapeProvider.Default;
-var shape = (ITypeShape<Person>)provider.GetShape(typeof(Person));
+var shape = (ITypeShape<Person>)provider.GetTypeShape(typeof(Person));
 ```
 
 Which can be consumed by supported libraries as follows:
@@ -167,12 +167,12 @@ public record MyPoco<T>(T Value)
 #### Associated types
 
 The `TypeShape` attribute can also be used to specify associated types for the target type.
-In the context of source generated/AOT applications, this provides a Reflection-free way to leap from one @PolyType.Abstractions.ITypeShape to an associated shape, and get all the functionality of the associated shape.
+In the context of source generated/AOT applications, this provides a Reflection-free way to leap from one @PolyType.ITypeShape to an associated shape, and get all the functionality of the associated shape.
 For example, serializers may need to jump from a type shape to its converter.
 
 [!code-csharp[](CSharpSamples/AssociatedTypes.cs#TypeShapeOneType)]
 
-Use the @PolyType.Abstractions.ITypeShape.GetAssociatedTypeShape*?displayProperty=nameWithType method to obtain the shape of an associated type.
+Use the @PolyType.ITypeShape.GetAssociatedTypeShape*?displayProperty=nameWithType method to obtain the shape of an associated type.
 The @PolyType.SourceGenModel.SourceGenTypeShapeProvider implementation of this method requires that the associated types be pre-determined at compile time via attributes.
 The @PolyType.ReflectionProvider.ReflectionTypeShapeProvider is guaranteed to work with all types and therefore does _not_ require these attributes.
 Thus, it can be valuable to test your associated types code with the source generation provider to ensure your code is AOT-compatible.

--- a/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.Builder.cs
@@ -172,7 +172,7 @@ public static partial class CborSerializer
         public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state)
         {
             // NB: don't use the cached converter for TUnionCase, as it might equal TUnion.
-            var caseConverter = (CborConverter<TUnionCase>)unionCaseShape.Type.Invoke(this)!;
+            var caseConverter = (CborConverter<TUnionCase>)unionCaseShape.UnionCaseType.Invoke(this)!;
             return new CborUnionCaseConverter<TUnionCase, TUnion>(caseConverter, unionCaseShape.Marshaler);
         }
 

--- a/src/PolyType.Examples/CborSerializer/CborSerializer.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.cs
@@ -33,10 +33,10 @@ public static partial class CborSerializer
     /// Builds an <see cref="CborConverter{T}"/> instance from the specified shape provider.
     /// </summary>
     /// <typeparam name="T">The type for which to build the converter.</typeparam>
-    /// <param name="shapeProvider">The shape provider converter construction.</param>
+    /// <param name="typeShapeProvider">The shape provider converter construction.</param>
     /// <returns>An <see cref="CborConverter{T}"/> instance.</returns>
-    public static CborConverter<T> CreateConverter<T>(ITypeShapeProvider shapeProvider) =>
-        (CborConverter<T>)s_converterCaches.GetOrAdd(typeof(T), shapeProvider)!;
+    public static CborConverter<T> CreateConverter<T>(ITypeShapeProvider typeShapeProvider) =>
+        (CborConverter<T>)s_converterCaches.GetOrAdd(typeof(T), typeShapeProvider)!;
 
     /// <summary>
     /// Builds a <see cref="JsonConverter"/> instance from the reflection-based shape provider.
@@ -196,7 +196,7 @@ public static partial class CborSerializer
 
     private static class CborSerializerCache<T, TProvider> where TProvider : IShapeable<T>
     {
-        public static CborConverter<T> Value => s_value ??= CreateConverter(TProvider.GetShape());
+        public static CborConverter<T> Value => s_value ??= CreateConverter(TProvider.GetTypeShape());
         private static CborConverter<T>? s_value;
     }
 #endif

--- a/src/PolyType.Examples/Cloner/Cloner.Builder.cs
+++ b/src/PolyType.Examples/Cloner/Cloner.Builder.cs
@@ -278,7 +278,7 @@ public static partial class Cloner
 
         public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state = null)
         {
-            var cloner = (Func<TUnionCase?, TUnionCase?>)unionCaseShape.Type.Invoke(this)!;
+            var cloner = (Func<TUnionCase?, TUnionCase?>)unionCaseShape.UnionCaseType.Invoke(this)!;
             var marshaler = unionCaseShape.Marshaler;
             return new Func<TUnion?, TUnion?>(t => marshaler.Marshal(cloner(marshaler.Unmarshal(t))));
         }

--- a/src/PolyType.Examples/Cloner/Cloner.cs
+++ b/src/PolyType.Examples/Cloner/Cloner.cs
@@ -27,10 +27,10 @@ public static partial class Cloner
     /// Builds a deep cloning delegate from the specified shape provider.
     /// </summary>
     /// <typeparam name="T">The type for which to build the cloner.</typeparam>
-    /// <param name="shapeProvider">The shape provider guiding cloner construction.</param>
+    /// <param name="typeShapeProvider">The shape provider guiding cloner construction.</param>
     /// <returns>A delegate for cloning instances of type <typeparamref name="T"/>.</returns>
-    public static Func<T?, T?> CreateCloner<T>(ITypeShapeProvider shapeProvider) =>
-        (Func<T?, T?>)s_clonerCache.GetOrAdd(typeof(T), shapeProvider)!;
+    public static Func<T?, T?> CreateCloner<T>(ITypeShapeProvider typeShapeProvider) =>
+        (Func<T?, T?>)s_clonerCache.GetOrAdd(typeof(T), typeShapeProvider)!;
 
 #if NET
     /// <summary>
@@ -54,7 +54,7 @@ public static partial class Cloner
 
     private static class ClonerCache<T, TProvider> where TProvider : IShapeable<T>
     {
-        public static Func<T?, T?> Value => s_value ??= CreateCloner(TProvider.GetShape());
+        public static Func<T?, T?> Value => s_value ??= CreateCloner(TProvider.GetTypeShape());
         private static Func<T?, T?>? s_value;
     }
 #endif

--- a/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
+++ b/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
@@ -283,8 +283,8 @@ public static partial class ConfigurationBinderTS
 
         public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state = null)
         {
-            var caseBinder = (Func<IConfiguration, TUnion>)unionCaseShape.Type.Accept(this)!;
-            if (unionCaseShape.Type is IObjectTypeShape or IDictionaryTypeShape)
+            var caseBinder = (Func<IConfiguration, TUnion>)unionCaseShape.UnionCaseType.Accept(this)!;
+            if (unionCaseShape.UnionCaseType is IObjectTypeShape or IDictionaryTypeShape)
             {
                 return caseBinder;
             }

--- a/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.cs
+++ b/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.cs
@@ -27,10 +27,10 @@ public static partial class ConfigurationBinderTS
     /// Builds a configuration binder delegate instance from the specified shape provider.
     /// </summary>
     /// <typeparam name="T">The type for which to build the binder.</typeparam>
-    /// <param name="shapeProvider">The shape provider guiding binder construction.</param>
+    /// <param name="typeShapeProvider">The shape provider guiding binder construction.</param>
     /// <returns>A configuration binder delegate.</returns>
-    public static Func<IConfiguration, T?> Create<T>(ITypeShapeProvider shapeProvider) =>
-        (Func<IConfiguration, T?>)s_cache.GetOrAdd(typeof(T), shapeProvider)!;
+    public static Func<IConfiguration, T?> Create<T>(ITypeShapeProvider typeShapeProvider) =>
+        (Func<IConfiguration, T?>)s_cache.GetOrAdd(typeof(T), typeShapeProvider)!;
 
     /// <summary>
     /// Builds a configuration binder delegate instance from the specified shape provider.
@@ -75,7 +75,7 @@ public static partial class ConfigurationBinderTS
 
     private static class ConfigurationBinderCache<T, TProvider> where TProvider : IShapeable<T>
     {
-        public static Func<IConfiguration, T?> Value => s_value ??= Create(TProvider.GetShape());
+        public static Func<IConfiguration, T?> Value => s_value ??= Create(TProvider.GetTypeShape());
         private static Func<IConfiguration, T?>? s_value;
     }
 #endif

--- a/src/PolyType.Examples/Counter/Counter.Builder.cs
+++ b/src/PolyType.Examples/Counter/Counter.Builder.cs
@@ -132,7 +132,7 @@ public static partial class Counter
 
         public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCase, object? state = null)
         {
-            var underlyingCounter = (Func<TUnionCase, long>)unionCase.Type.Accept(this)!;
+            var underlyingCounter = (Func<TUnionCase, long>)unionCase.UnionCaseType.Accept(this)!;
             var marshaler = unionCase.Marshaler;
             return new Func<TUnion, long>(union => underlyingCounter(marshaler.Unmarshal(union)!));
         }

--- a/src/PolyType.Examples/Counter/Counter.cs
+++ b/src/PolyType.Examples/Counter/Counter.cs
@@ -23,8 +23,8 @@ public static partial class Counter
     /// <summary>
     /// Creates an object counting delegate using the specified shape provider.
     /// </summary>
-    public static Func<T?, long> Create<T>(ITypeShapeProvider shapeProvider)
-        => (Func<T?, long>)s_cache.GetOrAdd(typeof(T), shapeProvider)!;
+    public static Func<T?, long> Create<T>(ITypeShapeProvider typeShapeProvider)
+        => (Func<T?, long>)s_cache.GetOrAdd(typeof(T), typeShapeProvider)!;
 
 #if NET
     /// <summary>
@@ -41,7 +41,7 @@ public static partial class Counter
 
     private static class CounterCache<T, TProvider> where TProvider : IShapeable<T>
     {
-        public static Func<T?, long> Value => s_value ??= Create(TProvider.GetShape());
+        public static Func<T?, long> Value => s_value ??= Create(TProvider.GetTypeShape());
         private static Func<T?, long>? s_value;
     }
 #endif

--- a/src/PolyType.Examples/DependencyInjection/ServiceProviderContext.Builder.cs
+++ b/src/PolyType.Examples/DependencyInjection/ServiceProviderContext.Builder.cs
@@ -22,7 +22,7 @@ public sealed partial class ServiceProviderContext
                 if (descriptor.ImplementationType != typeof(T))
                 {
                     Debug.Assert(typeof(T).IsAssignableFrom(descriptor.ImplementationType));
-                    ITypeShape implShape = typeShape.Provider.Resolve(descriptor.ImplementationType);
+                    ITypeShape implShape = typeShape.Provider.GetTypeShape(descriptor.ImplementationType, throwIfMissing: true)!;
                     var otherFactory = (ServiceFactory)implShape.Invoke(this, state)!;
                     return otherFactory.Cast<T>(descriptor.Lifetime);
                 }

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
@@ -229,7 +229,7 @@ public static partial class JsonSerializerTS
 
         public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state)
         {
-            var caseConverter = (JsonConverter<TUnionCase>)unionCaseShape.Type.Accept(this)!;
+            var caseConverter = (JsonConverter<TUnionCase>)unionCaseShape.UnionCaseType.Accept(this)!;
             return new JsonUnionCaseConverter<TUnionCase, TUnion>(unionCaseShape.Name, unionCaseShape.Marshaler, caseConverter);
         }
 

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.cs
@@ -33,9 +33,9 @@ public static partial class JsonSerializerTS
     /// Builds an <see cref="JsonConverter{T}"/> instance from the specified shape provider.
     /// </summary>
     /// <typeparam name="T">The type for which to build the converter.</typeparam>
-    /// <param name="shapeProvider">The shape provider guiding converter construction.</param>
+    /// <param name="typeShapeProvider">The shape provider guiding converter construction.</param>
     /// <returns>An <see cref="JsonConverter{T}"/> instance.</returns>
-    public static JsonConverter<T> CreateConverter<T>(ITypeShapeProvider shapeProvider) => (JsonConverter<T>)s_converterCaches.GetOrAdd(typeof(T), shapeProvider)!;
+    public static JsonConverter<T> CreateConverter<T>(ITypeShapeProvider typeShapeProvider) => (JsonConverter<T>)s_converterCaches.GetOrAdd(typeof(T), typeShapeProvider)!;
 
     /// <summary>
     /// Builds a <see cref="JsonConverter"/> instance from the reflection-based shape provider.
@@ -251,7 +251,7 @@ public static partial class JsonSerializerTS
     /// <typeparam name="T">The type for which to build the converter.</typeparam>
     /// <returns>An <see cref="JsonConverter{T}"/> instance.</returns>
     public static JsonConverter<T> CreateConverter<T>() where T : IShapeable<T> =>
-        CreateConverter(T.GetShape());
+        CreateConverter(T.GetTypeShape());
 
     /// <summary>
     /// Serializes a value to a JSON string using its <see cref="IShapeable{T}"/> implementation.
@@ -297,7 +297,7 @@ public static partial class JsonSerializerTS
 
     private static class JsonSerializerCache<T, TProvider> where TProvider : IShapeable<T>
     {
-        public static JsonConverter<T> Value => s_value ??= CreateConverter(TProvider.GetShape());
+        public static JsonConverter<T> Value => s_value ??= CreateConverter(TProvider.GetTypeShape());
         private static JsonConverter<T>? s_value;
     }
 #endif

--- a/src/PolyType.Examples/ObjectMapper/Mapper.cs
+++ b/src/PolyType.Examples/ObjectMapper/Mapper.cs
@@ -50,17 +50,17 @@ public static partial class Mapper
     /// </summary>
     /// <typeparam name="TSource">The type to map from.</typeparam>
     /// <typeparam name="TTarget">The type to map to.</typeparam>
-    /// <param name="shapeProvider">The PolyType provider.</param>
+    /// <param name="typeShapeProvider">The PolyType provider.</param>
     /// <returns>A mapper delegate.</returns>
-    public static Mapper<TSource, TTarget> Create<TSource, TTarget>(ITypeShapeProvider shapeProvider)
+    public static Mapper<TSource, TTarget> Create<TSource, TTarget>(ITypeShapeProvider typeShapeProvider)
     {
-        TypeCache providerScopedTypeCache = s_cache.GetScopedCache(shapeProvider);
+        TypeCache providerScopedTypeCache = s_cache.GetScopedCache(typeShapeProvider);
         if (providerScopedTypeCache.TryGetValue(typeof(Mapper<TSource, TTarget>), out object? result))
         {
             return (Mapper<TSource, TTarget>)result!;
         }
 
-        ITypeShape mapperShape = new MapperShape<TSource, TTarget>(shapeProvider.Resolve<TSource>(), shapeProvider.Resolve<TTarget>());
+        ITypeShape mapperShape = new MapperShape<TSource, TTarget>(typeShapeProvider.GetTypeShape<TSource>(throwIfMissing: true)!, typeShapeProvider.GetTypeShape<TTarget>(throwIfMissing: true)!);
         return (Mapper<TSource, TTarget>)providerScopedTypeCache.GetOrAdd(mapperShape)!;
     }
 
@@ -82,7 +82,7 @@ public static partial class Mapper
         where TSource : IShapeable<TSource>
         where TTarget : IShapeable<TTarget>
     {
-        public static Mapper<TSource, TTarget> Value => s_value ??= Create(TSource.GetShape(), TTarget.GetShape());
+        public static Mapper<TSource, TTarget> Value => s_value ??= Create(TSource.GetTypeShape(), TTarget.GetTypeShape());
         private static Mapper<TSource, TTarget>? s_value;
     }
 #endif

--- a/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.Builder.cs
+++ b/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.Builder.cs
@@ -241,7 +241,7 @@ public static partial class PrettyPrinter
 
         public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state = null)
         {
-            var underlying = (PrettyPrinter<TUnionCase>)unionCaseShape.Type.Accept(this)!;
+            var underlying = (PrettyPrinter<TUnionCase>)unionCaseShape.UnionCaseType.Accept(this)!;
             var marshaler = unionCaseShape.Marshaler;
             return new PrettyPrinter<TUnion>((sb, indentation, value) => underlying(sb, indentation, marshaler.Unmarshal(value)));
         }

--- a/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.cs
+++ b/src/PolyType.Examples/PrettyPrinter/PrettyPrinter.cs
@@ -29,10 +29,10 @@ public static partial class PrettyPrinter
     /// Builds a <see cref="PrettyPrinter{T}"/> instance from the specified shape provider.
     /// </summary>
     /// <typeparam name="T">The type for which to build the printer.</typeparam>
-    /// <param name="shapeProvider">The shape provider guiding printer construction.</param>
+    /// <param name="typeShapeProvider">The shape provider guiding printer construction.</param>
     /// <returns>An <see cref="PrettyPrinter{T}"/> instance.</returns>
-    public static PrettyPrinter<T> Create<T>(ITypeShapeProvider shapeProvider)
-        => (PrettyPrinter<T>)s_cache.GetOrAdd(typeof(T), shapeProvider)!;
+    public static PrettyPrinter<T> Create<T>(ITypeShapeProvider typeShapeProvider)
+        => (PrettyPrinter<T>)s_cache.GetOrAdd(typeof(T), typeShapeProvider)!;
 
     /// <summary>
     /// Pretty prints the specified value to a string.
@@ -70,7 +70,7 @@ public static partial class PrettyPrinter
 
     private static class PrettyPrinterCache<T, TProvider> where TProvider : IShapeable<T>
     {
-        public static PrettyPrinter<T> Value => s_value ??= Create(TProvider.GetShape());
+        public static PrettyPrinter<T> Value => s_value ??= Create(TProvider.GetTypeShape());
         private static PrettyPrinter<T>? s_value;
     }
 #endif

--- a/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
+++ b/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
@@ -297,14 +297,14 @@ public partial class RandomGenerator
             List<RandomGenerator<TUnion>> unionCaseGenerators = [];
             foreach (var unionCase in unionShape.UnionCases)
             {
-                if (!IsConstructible(unionCase.Type))
+                if (!IsConstructible(unionCase.UnionCaseType))
                 {
                     continue;
                 }
 
                 // Can rely on covariance for this cast to succeed.
-                unionCaseGenerators.Add((RandomGenerator<TUnion>)unionCase.Type.Accept(this)!);
-                foundBaseType |= unionCase.Type.Type == typeof(TUnion);
+                unionCaseGenerators.Add((RandomGenerator<TUnion>)unionCase.UnionCaseType.Accept(this)!);
+                foundBaseType |= unionCase.UnionCaseType.Type == typeof(TUnion);
             }
 
             if (!foundBaseType && IsConstructible(unionShape.BaseType))

--- a/src/PolyType.Examples/RandomGenerator/RandomGenerator.cs
+++ b/src/PolyType.Examples/RandomGenerator/RandomGenerator.cs
@@ -139,7 +139,7 @@ public static partial class RandomGenerator
 
     private static class RandomGeneratorCache<T, TProvider> where TProvider : IShapeable<T>
     {
-        public static RandomGenerator<T> Value => s_value ??= Create(TProvider.GetShape());
+        public static RandomGenerator<T> Value => s_value ??= Create(TProvider.GetTypeShape());
         private static RandomGenerator<T>? s_value;
     }
 #endif

--- a/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.Builder.cs
+++ b/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.Builder.cs
@@ -113,7 +113,7 @@ public static partial class StructuralEqualityComparer
 
         public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state = null)
         {
-            var underlyingComparer = (EqualityComparer<TUnionCase>)unionCaseShape.Type.Accept(this)!;
+            var underlyingComparer = (EqualityComparer<TUnionCase>)unionCaseShape.UnionCaseType.Accept(this)!;
             return new UnionCaseEqualityComparer<TUnionCase, TUnion>(underlyingComparer, unionCaseShape.Marshaler);
         }
 

--- a/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.cs
+++ b/src/PolyType.Examples/StructuralEquality/StructuralEqualityComparer.cs
@@ -27,10 +27,10 @@ public static partial class StructuralEqualityComparer
     /// Builds a structural <see cref="IEqualityComparer{T}"/> instance from the specified shape provider.
     /// </summary>
     /// <typeparam name="T">The type for which to build the comparer.</typeparam>
-    /// <param name="shapeProvider">The shape provider guiding comparer construction.</param>
+    /// <param name="typeShapeProvider">The shape provider guiding comparer construction.</param>
     /// <returns>An <see cref="IEqualityComparer{T}"/> instance.</returns>
-    public static IEqualityComparer<T> Create<T>(ITypeShapeProvider shapeProvider) =>
-        (IEqualityComparer<T>)s_converterCaches.GetOrAdd(typeof(T), shapeProvider)!;
+    public static IEqualityComparer<T> Create<T>(ITypeShapeProvider typeShapeProvider) =>
+        (IEqualityComparer<T>)s_converterCaches.GetOrAdd(typeof(T), typeShapeProvider)!;
 
 #if NET
     /// <summary>
@@ -92,7 +92,7 @@ public static partial class StructuralEqualityComparer
 
     private static class EqualityComparerCache<T, TProvider> where TProvider : IShapeable<T>
     {
-        public static IEqualityComparer<T> Value => s_value ??= Create(TProvider.GetShape());
+        public static IEqualityComparer<T> Value => s_value ??= Create(TProvider.GetTypeShape());
         private static IEqualityComparer<T>? s_value;
     }
 #endif

--- a/src/PolyType.Examples/Validation/Validator.Builder.cs
+++ b/src/PolyType.Examples/Validation/Validator.Builder.cs
@@ -203,7 +203,7 @@ public static partial class Validator
 
         public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state = null)
         {
-            var underlying = (Validator<TUnionCase>?)unionCaseShape.Type.Accept(this);
+            var underlying = (Validator<TUnionCase>?)unionCaseShape.UnionCaseType.Accept(this);
             if (underlying is null)
             {
                 return null;

--- a/src/PolyType.Examples/Validation/Validator.cs
+++ b/src/PolyType.Examples/Validation/Validator.cs
@@ -33,8 +33,8 @@ public static partial class Validator
     /// <summary>
     /// Builds a validator delegate using a shape provider as input.
     /// </summary>
-    public static Validator<T> Create<T>(ITypeShapeProvider shapeProvider) =>
-        (Validator<T>?)s_cache.GetOrAdd(typeof(T), shapeProvider) ?? Builder.CreateNullValidator<T>();
+    public static Validator<T> Create<T>(ITypeShapeProvider typeShapeProvider) =>
+        (Validator<T>?)s_cache.GetOrAdd(typeof(T), typeShapeProvider) ?? Builder.CreateNullValidator<T>();
 
     /// <summary>
     /// Runs validation against the provided value.
@@ -85,7 +85,7 @@ public static partial class Validator
 
     private static class ValidatorCache<T, TProvider> where TProvider : IShapeable<T>
     {
-        public static Validator<T> Value => s_value ??= Create(TProvider.GetShape());
+        public static Validator<T> Value => s_value ??= Create(TProvider.GetTypeShape());
         private static Validator<T>? s_value;
     }
 #endif

--- a/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
+++ b/src/PolyType.Examples/XmlSerializer/XmlSerializer.Builder.cs
@@ -160,7 +160,7 @@ public static partial class XmlSerializer
         public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state)
         {
             // NB: don't use the cached converter for TUnionCase, as it might equal TUnion.
-            var caseConverter = (XmlConverter<TUnionCase>)unionCaseShape.Type.Invoke(this)!;
+            var caseConverter = (XmlConverter<TUnionCase>)unionCaseShape.UnionCaseType.Invoke(this)!;
             return new XmlUnionCaseConverter<TUnionCase, TUnion>(caseConverter, unionCaseShape.Marshaler);
         }
 

--- a/src/PolyType.Examples/XmlSerializer/XmlSerializer.cs
+++ b/src/PolyType.Examples/XmlSerializer/XmlSerializer.cs
@@ -43,10 +43,10 @@ public static partial class XmlSerializer
     /// Builds an <see cref="XmlConverter{T}"/> instance from the specified shape provider.
     /// </summary>
     /// <typeparam name="T">The type for which to build the converter.</typeparam>
-    /// <param name="shapeProvider">The shape provider guiding converter construction.</param>
+    /// <param name="typeShapeProvider">The shape provider guiding converter construction.</param>
     /// <returns>An <see cref="XmlConverter{T}"/> instance.</returns>
-    public static XmlConverter<T> CreateConverter<T>(ITypeShapeProvider shapeProvider) =>
-        (XmlConverter<T>)s_converterCaches.GetOrAdd(typeof(T), shapeProvider)!;
+    public static XmlConverter<T> CreateConverter<T>(ITypeShapeProvider typeShapeProvider) =>
+        (XmlConverter<T>)s_converterCaches.GetOrAdd(typeof(T), typeShapeProvider)!;
 
     /// <summary>
     /// Serializes a value to an XML string using the provided converter.
@@ -133,7 +133,7 @@ public static partial class XmlSerializer
 
     private static class XmlSerializerCache<T, TProvider> where TProvider : IShapeable<T>
     {
-        public static XmlConverter<T> Value => s_value ??= CreateConverter(TProvider.GetShape());
+        public static XmlConverter<T> Value => s_value ??= CreateConverter(TProvider.GetTypeShape());
         private static XmlConverter<T>? s_value;
     }
 #endif

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -1139,8 +1139,8 @@ public sealed partial class Parser : TypeDataModelGenerator
     private static TypeDeclarationModel CreateShapeProviderDeclaration(Compilation compilation)
     {
         string typeName = !string.IsNullOrWhiteSpace(compilation.AssemblyName)
-            ? "ShapeProvider_" + s_escapeAssemblyName.Replace(compilation.AssemblyName!, "_")
-            : "ShapeProvider_AnonAssembly";
+            ? "TypeShapeProvider_" + s_escapeAssemblyName.Replace(compilation.AssemblyName!, "_")
+            : "TypeShapeProvider_AnonAssembly";
 
         return new()
         {
@@ -1152,7 +1152,7 @@ public sealed partial class Parser : TypeDataModelGenerator
             },
             Name = typeName,
             Namespace = "PolyType.SourceGenerator",
-            SourceFilenamePrefix = "PolyType.SourceGenerator.ShapeProvider",
+            SourceFilenamePrefix = "PolyType.SourceGenerator.TypeShapeProvider",
             TypeDeclarationHeader = $"internal sealed partial class {typeName}",
             IsWitnessTypeDeclaration = false,
             ContainingTypes = [],

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Dictionary.cs
@@ -18,7 +18,7 @@ internal sealed partial class SourceFormatter
         }
 
         writer.WriteLine($$"""
-            private global::PolyType.Abstractions.ITypeShape<{{dictionaryShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
+            private global::PolyType.ITypeShape<{{dictionaryShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
             {
                 return new global::PolyType.SourceGenModel.SourceGenDictionaryTypeShape<{{dictionaryShapeModel.Type.FullyQualifiedName}}, {{dictionaryShapeModel.KeyType.FullyQualifiedName}}, {{dictionaryShapeModel.ValueType.FullyQualifiedName}}>
                 {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enum.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enum.cs
@@ -8,7 +8,7 @@ internal sealed partial class SourceFormatter
     private void FormatEnumTypeShapeFactory(SourceWriter writer, string methodName, EnumShapeModel enumShapeType)
     {
         writer.WriteLine($$"""
-            private global::PolyType.Abstractions.ITypeShape<{{enumShapeType.Type.FullyQualifiedName}}> {{methodName}}()
+            private global::PolyType.ITypeShape<{{enumShapeType.Type.FullyQualifiedName}}> {{methodName}}()
             {
                 return new global::PolyType.SourceGenModel.SourceGenEnumTypeShape<{{enumShapeType.Type.FullyQualifiedName}}, {{enumShapeType.UnderlyingType.FullyQualifiedName}}>
                 {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enumerable.cs
@@ -11,7 +11,7 @@ internal sealed partial class SourceFormatter
         string? eventFactoryMethodName = CreateEventsFactoryName(enumerableShapeModel);
 
         writer.WriteLine($$"""
-            private global::PolyType.Abstractions.ITypeShape<{{enumerableShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
+            private global::PolyType.ITypeShape<{{enumerableShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
             {
                 return new global::PolyType.SourceGenModel.SourceGenEnumerableTypeShape<{{enumerableShapeModel.Type.FullyQualifiedName}}, {{enumerableShapeModel.ElementType.FullyQualifiedName}}>
                 {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.FSharpUnion.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.FSharpUnion.cs
@@ -12,7 +12,7 @@ internal sealed partial class SourceFormatter
         string? eventFactoryMethodName = CreateEventsFactoryName(unionShapeModel);
 
         writer.WriteLine($$"""
-            private global::PolyType.Abstractions.ITypeShape<{{unionShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
+            private global::PolyType.ITypeShape<{{unionShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
             {
                 return new global::PolyType.SourceGenModel.SourceGenUnionTypeShape<{{unionShapeModel.Type.FullyQualifiedName}}>
                 {
@@ -60,7 +60,7 @@ internal sealed partial class SourceFormatter
             writer.WriteLine($$"""
                 new global::PolyType.SourceGenModel.SourceGenUnionCaseShape<{{unionCase.TypeModel.Type.FullyQualifiedName}}, {{unionShapeModel.Type.FullyQualifiedName}}>
                 {
-                    Type = {{unionCase.TypeModel.SourceIdentifier}},
+                    UnionCaseType = {{unionCase.TypeModel.SourceIdentifier}},
                     Marshaler = global::PolyType.SourceGenModel.SubtypeMarshaler<{{unionCase.TypeModel.Type.FullyQualifiedName}}, {{unionShapeModel.Type.FullyQualifiedName}}>.Instance,
                     Name = {{FormatStringLiteral(unionCase.Name)}},
                     Tag = {{unionCase.Tag}},

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Function.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Function.cs
@@ -14,7 +14,7 @@ internal sealed partial class SourceFormatter
         string? requiredParametersMaskFieldName = FormatRequiredParametersMaskFieldName(functionShapeModel);
 
         writer.WriteLine($$"""
-            private global::PolyType.Abstractions.ITypeShape<{{functionShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
+            private global::PolyType.ITypeShape<{{functionShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
             {
                 return new global::PolyType.SourceGenModel.SourceGenFunctionTypeShape<{{functionShapeModel.Type.FullyQualifiedName}}, {{functionArgumentStateFQN}}, {{functionShapeModel.ReturnType.FullyQualifiedName}}>
                 {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Object.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Object.cs
@@ -13,7 +13,7 @@ internal sealed partial class SourceFormatter
         string? eventFactoryMethodName = CreateEventsFactoryName(objectShapeModel);
 
         writer.WriteLine($$"""
-            private global::PolyType.Abstractions.ITypeShape<{{objectShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
+            private global::PolyType.ITypeShape<{{objectShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
             {
                 return new global::PolyType.SourceGenModel.SourceGenObjectTypeShape<{{objectShapeModel.Type.FullyQualifiedName}}>
                 {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Optional.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Optional.cs
@@ -13,7 +13,7 @@ internal sealed partial class SourceFormatter
         // Disable CS8622 to avoid a dependency on MaybeNullWhenAttribute in netfx
         writer.WriteLine("#pragma warning disable CS8622 // Nullability warning for out parameter mismatch", disableIndentation: true);
         writer.WriteLine($$"""
-            private global::PolyType.Abstractions.ITypeShape<{{optionalShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
+            private global::PolyType.ITypeShape<{{optionalShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
             {
                 return new global::PolyType.SourceGenModel.SourceGenOptionalTypeShape<{{optionalShapeModel.Type.FullyQualifiedName}}, {{optionalShapeModel.ElementType.FullyQualifiedName}}>
                 {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Surrogate.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Surrogate.cs
@@ -11,7 +11,7 @@ internal sealed partial class SourceFormatter
         string? eventFactoryMethodName = CreateEventsFactoryName(surrogateShapeModel);
 
         writer.WriteLine($$"""
-            private global::PolyType.Abstractions.ITypeShape<{{surrogateShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
+            private global::PolyType.ITypeShape<{{surrogateShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
             {
                 return new global::PolyType.SourceGenModel.SourceGenSurrogateTypeShape<{{surrogateShapeModel.Type.FullyQualifiedName}}, {{surrogateShapeModel.SurrogateType.FullyQualifiedName}}>
                 {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Type.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Type.cs
@@ -9,7 +9,7 @@ internal sealed partial class SourceFormatter
 {
     private SourceText FormatProvidedType(TypeShapeProviderModel provider, TypeShapeModel type)
     {
-        string generatedPropertyType = $"global::PolyType.Abstractions.ITypeShape<{type.Type.FullyQualifiedName}>";
+        string generatedPropertyType = $"global::PolyType.ITypeShape<{type.Type.FullyQualifiedName}>";
         string generatedFactoryMethodName = $"__Create_{type.SourceIdentifier}";
         string generatedFieldName = "__" + type.SourceIdentifier;
 

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.TypeShapeProvider.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.TypeShapeProvider.cs
@@ -7,7 +7,7 @@ namespace PolyType.SourceGenerator;
 
 internal sealed partial class SourceFormatter
 {
-    private static SourceText FormatShapeProviderMainFile(TypeShapeProviderModel provider)
+    private static SourceText FormatTypeShapeProviderMainFile(TypeShapeProviderModel provider)
     {
         var writer = new SourceWriter();
         StartFormatSourceFile(writer, provider.ProviderDeclaration);
@@ -53,7 +53,7 @@ internal sealed partial class SourceFormatter
     {
         writer.WriteLine("""
             /// <inheritdoc/>
-            public override global::PolyType.Abstractions.ITypeShape? GetShape(global::System.Type type)
+            public override global::PolyType.ITypeShape? GetTypeShape(global::System.Type type)
             {
             """);
 
@@ -121,8 +121,8 @@ internal sealed partial class SourceFormatter
         if (typeDeclaration.IsWitnessTypeDeclaration)
         {
             writer.WriteLine($$"""
-                /// <summary>Gets the source generated <see cref="global::PolyType.SourceGenModel.SourceGenTypeShapeProvider"/> corresponding to the current witness type.</summary>
-                public static global::PolyType.SourceGenModel.SourceGenTypeShapeProvider ShapeProvider =>
+                /// <summary>Gets the source generated <see cref="global::PolyType.SourceGenModel.SourceGenTypeShapeProvider"/> corresponding to the current assembly.</summary>
+                public static global::PolyType.SourceGenModel.SourceGenTypeShapeProvider GeneratedTypeShapeProvider =>
                     {{provider.ProviderDeclaration.Id.FullyQualifiedName}}.{{ProviderSingletonProperty}};
                 """);
 
@@ -139,7 +139,7 @@ internal sealed partial class SourceFormatter
                 }
 
                 writer.WriteLine($"""
-                    static global::PolyType.Abstractions.ITypeShape<{typeToImplement.FullyQualifiedName}> global::PolyType.IShapeable<{typeToImplement.FullyQualifiedName}>.GetShape() =>
+                    static global::PolyType.ITypeShape<{typeToImplement.FullyQualifiedName}> global::PolyType.IShapeable<{typeToImplement.FullyQualifiedName}>.GetTypeShape() =>
                         {provider.ProviderDeclaration.Id.FullyQualifiedName}.{ProviderSingletonProperty}.{GetShapeModel(typeToImplement).SourceIdentifier};
                     """);
             }
@@ -152,9 +152,10 @@ internal sealed partial class SourceFormatter
             }
 
             writer.WriteLine($$"""
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
                 private sealed class {{LocalTypeShapeProviderName}} : global::PolyType.ITypeShapeProvider
                 {
-                    global::PolyType.Abstractions.ITypeShape? global::PolyType.ITypeShapeProvider.GetShape(global::System.Type type)
+                    global::PolyType.ITypeShape? global::PolyType.ITypeShapeProvider.GetTypeShape(global::System.Type type)
                     {
                 """);
 

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Union.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Union.cs
@@ -14,7 +14,7 @@ internal sealed partial class SourceFormatter
         string? eventFactoryMethodName = CreateEventsFactoryName(unionShapeModel);
 
         writer.WriteLine($$"""
-            private global::PolyType.Abstractions.ITypeShape<{{unionShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
+            private global::PolyType.ITypeShape<{{unionShapeModel.Type.FullyQualifiedName}}> {{methodName}}()
             {
                 return new global::PolyType.SourceGenModel.SourceGenUnionTypeShape<{{unionShapeModel.Type.FullyQualifiedName}}>
                 {
@@ -67,7 +67,7 @@ internal sealed partial class SourceFormatter
             writer.WriteLine($$"""
                 new global::PolyType.SourceGenModel.SourceGenUnionCaseShape<{{unionCase.Type.FullyQualifiedName}}, {{unionShapeModel.Type.FullyQualifiedName}}>
                 {
-                    Type = {{unionCaseType.SourceIdentifier}},
+                    UnionCaseType = {{unionCaseType.SourceIdentifier}},
                     Marshaler = global::PolyType.SourceGenModel.SubtypeMarshaler<{{unionCase.Type.FullyQualifiedName}}, {{unionShapeModel.Type.FullyQualifiedName}}>.Instance,
                     Name = {{FormatStringLiteral(unionCase.Name)}},
                     Tag = {{unionCase.Tag}},

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
@@ -16,7 +16,7 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
     private const string AllBindingFlagsConstMember = "__BindingFlags_All";
     private const string InitializeMethodName = "__Init_Singleton";
     private const string ProviderSingletonProperty = "Default";
-    private const string GetShapeMethodName = "GetShape";
+    private const string GetShapeMethodName = "GetTypeShape";
 
     public static void GenerateSourceFiles(SourceProductionContext context, TypeShapeProviderModel provider)
     {
@@ -33,7 +33,7 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
         }
 
         context.CancellationToken.ThrowIfCancellationRequested();
-        context.AddSource($"{provider.ProviderDeclaration.SourceFilenamePrefix}.g.cs", FormatShapeProviderMainFile(provider));
+        context.AddSource($"{provider.ProviderDeclaration.SourceFilenamePrefix}.g.cs", FormatTypeShapeProviderMainFile(provider));
 
         foreach (TypeShapeModel type in provider.ProvidedTypes.Values)
         {
@@ -81,21 +81,18 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
 #if DEBUG
         writer.WriteLine("""
             #nullable enable
+            #pragma warning disable CS0612, CS0618 // Use of obsolete APIs is natural when we're emitting delegates for obsolete properties.
+            #pragma warning disable CS0436 // Use of local types when imported types by the same name exist.
 
             """);
 #else
         writer.WriteLine("""
             #nullable enable annotations
             #nullable disable warnings
+            #pragma warning disable
 
             """);
 #endif
-
-        writer.WriteLine("""
-            #pragma warning disable CS0612, CS0618 // Use of obsolete APIs is natural when we're emitting delegates for obsolete properties.
-            #pragma warning disable CS0436 // Use of local types when imported types by the same name exist.
-
-            """);
 
         if (typeDeclaration.Namespace is string @namespace)
         {

--- a/src/PolyType.TestCases/TestCaseOfT.cs
+++ b/src/PolyType.TestCases/TestCaseOfT.cs
@@ -11,7 +11,7 @@ namespace PolyType.Tests;
 /// <param name="Value">The value being tested.</param>
 public sealed record TestCase<T, TProvider>(T? Value) : TestCase<T>
 #if NET
-    (Value, TProvider.GetShape()) where TProvider : IShapeable<T>;
+    (Value, TProvider.GetTypeShape()) where TProvider : IShapeable<T>;
 #else
     (Value, TypeShapeResolver.ResolveDynamic<T, TProvider>(throwIfMissing: true)!);
 #endif
@@ -39,8 +39,8 @@ public record TestCase<T> : ITestCase
     /// Initializes a new instance of the <see cref="TestCase{T}"/> class.
     /// </summary>
     /// <param name="value">The value being tested.</param>
-    /// <param name="shapeProvider">The default type shape provider of the value, typically source generated.</param>
-    public TestCase(T? value, ITypeShapeProvider shapeProvider) : this(value, shapeProvider.Resolve<T>())
+    /// <param name="typeShapeProvider">The default type shape provider of the value, typically source generated.</param>
+    public TestCase(T? value, ITypeShapeProvider typeShapeProvider) : this(value, typeShapeProvider.GetTypeShape<T>(throwIfMissing: true)!)
     {
     }
 

--- a/src/PolyType/Abstractions/IUnionCaseShape.cs
+++ b/src/PolyType/Abstractions/IUnionCaseShape.cs
@@ -41,7 +41,7 @@ public interface IUnionCaseShape
     /// <summary>
     /// Gets the underlying type shape of the union case.
     /// </summary>
-    ITypeShape Type { get; }
+    ITypeShape UnionCaseType { get; }
 
     /// <summary>
     /// Accepts an <see cref="TypeShapeVisitor"/> for strongly-typed traversal.
@@ -63,7 +63,7 @@ public interface IUnionCaseShape<TUnionCase, TUnion> : IUnionCaseShape
     /// <summary>
     /// Gets the underlying type shape of the union case.
     /// </summary>
-    new ITypeShape<TUnionCase> Type { get; }
+    new ITypeShape<TUnionCase> UnionCaseType { get; }
 
     /// <summary>
     /// Gets a bidirectional mapper between <typeparamref name="TUnionCase"/> and <typeparamref name="TUnion"/>.

--- a/src/PolyType/Abstractions/TypeShapeExtensions.cs
+++ b/src/PolyType/Abstractions/TypeShapeExtensions.cs
@@ -1,11 +1,9 @@
-﻿using System.ComponentModel;
-
-namespace PolyType.Abstractions;
+﻿namespace PolyType.Abstractions;
 
 /// <summary>
 /// Extension methods for the various type shape interfaces.
 /// </summary>
-public static class ShapeExtensions
+public static class TypeShapeExtensions
 {
     /// <summary>
     /// Retrieves the default constructor for the given type shape, if available.
@@ -13,18 +11,16 @@ public static class ShapeExtensions
     /// <typeparam name="T">The type to be constructed.</typeparam>
     /// <param name="shape">The type's object shape.</param>
     /// <returns>A delegate for the default constructor; or <see langword="null" /> if none is available.</returns>
-    public static Func<T>? GetDefaultConstructor<T>(this IObjectTypeShape<T> shape) => (Func<T>?)shape.Constructor?.Accept(DefaultConstructorVisitor.Instance);
+    public static Func<T>? GetDefaultConstructor<T>(this IObjectTypeShape<T> shape) =>
+        (Func<T>?)shape.Constructor?.Accept(DefaultConstructorVisitor.Instance);
 
     /// <inheritdoc cref="GetDefaultConstructor{T}(IObjectTypeShape{T})"/>
-    public static Func<object>? GetDefaultConstructor(this IObjectTypeShape shape) => (Func<object>?)shape.Constructor?.Accept(DefaultConstructorVisitor.Instance);
+    public static Func<object>? GetDefaultConstructor(this IObjectTypeShape shape) =>
+        (Func<object>?)shape.Constructor?.Accept(DefaultConstructorVisitor.Instance);
 
     private sealed class DefaultConstructorVisitor : TypeShapeVisitor
     {
         internal static readonly DefaultConstructorVisitor Instance = new();
-
-        private DefaultConstructorVisitor()
-        {
-        }
 
         public override object? VisitConstructor<TDeclaringType, TArgumentState>(IConstructorShape<TDeclaringType, TArgumentState> constructorShape, object? state = null)
             => constructorShape.Parameters is [] ? constructorShape.GetDefaultConstructor() : null;

--- a/src/PolyType/Abstractions/TypeShapeProviderAttribute.cs
+++ b/src/PolyType/Abstractions/TypeShapeProviderAttribute.cs
@@ -16,21 +16,21 @@ public sealed class TypeShapeProviderAttribute : Attribute
     /// <summary>
     /// Initializes a new instance of the <see cref="TypeShapeProviderAttribute"/> class.
     /// </summary>
-    /// <param name="shapeProvider">The linked type shape provider implementation.</param>
+    /// <param name="typeShapeProvider">The linked type shape provider implementation.</param>
     /// <remarks>
-    /// The parameter <paramref name="shapeProvider"/> should expose a public
+    /// The parameter <paramref name="typeShapeProvider"/> should expose a public
     /// parameterless constructor and implement <see cref="ITypeShapeProvider"/>.
     /// </remarks>
-    public TypeShapeProviderAttribute([DynamicallyAccessedMembers(TypeShapeProviderRequirements)] Type shapeProvider)
+    public TypeShapeProviderAttribute([DynamicallyAccessedMembers(TypeShapeProviderRequirements)] Type typeShapeProvider)
     {
-        ShapeProvider = shapeProvider;
+        TypeShapeProvider = typeShapeProvider;
     }
 
     /// <summary>
     /// The linked type implementing <see cref="ITypeShapeProvider"/>.
     /// </summary>
     [DynamicallyAccessedMembers(TypeShapeProviderRequirements)]
-    public Type ShapeProvider { get; }
+    public Type TypeShapeProvider { get; }
 
     private const DynamicallyAccessedMemberTypes TypeShapeProviderRequirements =
         DynamicallyAccessedMemberTypes.PublicParameterlessConstructor |

--- a/src/PolyType/IShapeableOfT.cs
+++ b/src/PolyType/IShapeableOfT.cs
@@ -13,6 +13,6 @@ public interface IShapeable<T>
     /// Gets the PolyType instance corresponding to <typeparamref name="T"/>.
     /// </summary>
     /// <returns>The shape for <typeparamref name="T"/>.</returns>
-    static abstract ITypeShape<T> GetShape();
+    static abstract ITypeShape<T> GetTypeShape();
 }
 #endif

--- a/src/PolyType/ITypeShape.cs
+++ b/src/PolyType/ITypeShape.cs
@@ -1,6 +1,7 @@
-﻿using System.Reflection;
+﻿using PolyType.Abstractions;
+using System.Reflection;
 
-namespace PolyType.Abstractions;
+namespace PolyType;
 
 /// <summary>
 /// Provides a strongly typed shape model for a given .NET type.
@@ -41,7 +42,7 @@ public interface ITypeShape
     IReadOnlyList<IEventShape> Events { get; }
 
     /// <summary>
-    /// Accepts an <see cref="TypeShapeVisitor"/> for strongly-typed traversal.
+    /// Accepts a <see cref="TypeShapeVisitor"/> for type graph traversal.
     /// </summary>
     /// <param name="visitor">The visitor to accept.</param>
     /// <param name="state">The state parameter to pass to the underlying visitor.</param>

--- a/src/PolyType/ITypeShapeProvider.cs
+++ b/src/PolyType/ITypeShapeProvider.cs
@@ -15,5 +15,5 @@ public interface ITypeShapeProvider
     /// A <see cref="ITypeShape"/> instance corresponding to the current type,
     /// or <see langword="null" /> if a shape is not available.
     /// </returns>
-    ITypeShape? GetShape(Type type);
+    ITypeShape? GetTypeShape(Type type);
 }

--- a/src/PolyType/ReflectionProvider/FSharpOptionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/FSharpOptionTypeShape.cs
@@ -14,7 +14,7 @@ internal sealed class FSharpOptionTypeShape<TOptional, TElement>(FSharpUnionInfo
     public override TypeShapeKind Kind => TypeShapeKind.Optional;
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitOptional(this, state);
 
-    public ITypeShape<TElement> ElementType => Provider.GetShape<TElement>();
+    public ITypeShape<TElement> ElementType => Provider.GetTypeShape<TElement>();
     ITypeShape IOptionalTypeShape.ElementType => ElementType;
 
     public Func<TOptional> GetNoneConstructor() => _noneConstructor ?? CommonHelpers.ExchangeIfNull(ref _noneConstructor, unionInfo.UnionCases[0].Constructor.CreateDelegate<Func<TOptional>>());

--- a/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
@@ -56,13 +56,13 @@ internal sealed class FSharpUnionCaseShape<TUnionCase, TUnion>(FSharpUnionCaseIn
     : IUnionCaseShape<TUnionCase, TUnion>
     where TUnionCase : TUnion
 {
-    public ITypeShape<TUnionCase> Type { get; } = new FSharpUnionCaseTypeShape<TUnionCase>(unionCaseInfo, provider, options);
+    public ITypeShape<TUnionCase> UnionCaseType { get; } = new FSharpUnionCaseTypeShape<TUnionCase>(unionCaseInfo, provider, options);
     public IMarshaler<TUnionCase, TUnion> Marshaler => SubtypeMarshaler<TUnionCase, TUnion>.Instance;
     public string Name => unionCaseInfo.Name;
     public int Tag => unionCaseInfo.Tag;
     public bool IsTagSpecified => false; // F# tags are inferred from the union case ordering
     public int Index => unionCaseInfo.Tag;
-    ITypeShape IUnionCaseShape.Type => Type;
+    ITypeShape IUnionCaseShape.UnionCaseType => UnionCaseType;
     public object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitUnionCase(this, state);
 }
 

--- a/src/PolyType/ReflectionProvider/ReflectionDelegateTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionDelegateTypeShape.cs
@@ -20,7 +20,7 @@ internal sealed class ReflectionDelegateTypeShape<TDelegate, TArgumentState, TRe
     public bool IsAsync => methodShapeInfo.IsAsync;
     public IReadOnlyList<IParameterShape> Parameters => _parameters ?? CommonHelpers.ExchangeIfNull(ref _parameters, GetParameters().AsReadOnlyList());
     public override TypeShapeKind Kind => TypeShapeKind.Function;
-    public ITypeShape<TResult> ReturnType => Provider.GetShape<TResult>();
+    public ITypeShape<TResult> ReturnType => Provider.GetTypeShape<TResult>();
     ITypeShape IFunctionTypeShape.ReturnType => ReturnType;
 
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitFunction(this, state);

--- a/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionDictionaryTypeShape.cs
@@ -35,8 +35,8 @@ internal abstract class ReflectionDictionaryTypeShape<TDictionary, TKey, TValue>
         ? mutableCtor.AvailableInsertionModes
         : DictionaryInsertionMode.None;
 
-    public ITypeShape<TKey> KeyType => Provider.GetShape<TKey>();
-    public ITypeShape<TValue> ValueType => Provider.GetShape<TValue>();
+    public ITypeShape<TKey> KeyType => Provider.GetTypeShape<TKey>();
+    public ITypeShape<TValue> ValueType => Provider.GetTypeShape<TValue>();
     ITypeShape IDictionaryTypeShape.KeyType => KeyType;
     ITypeShape IDictionaryTypeShape.ValueType => ValueType;
 

--- a/src/PolyType/ReflectionProvider/ReflectionEnumTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumTypeShape.cs
@@ -16,7 +16,7 @@ internal sealed class ReflectionEnumTypeShape<TEnum, TUnderlying>(ReflectionType
 
     public override TypeShapeKind Kind => TypeShapeKind.Enum;
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitEnum(this, state);
-    public ITypeShape<TUnderlying> UnderlyingType => Provider.GetShape<TUnderlying>();
+    public ITypeShape<TUnderlying> UnderlyingType => Provider.GetTypeShape<TUnderlying>();
     ITypeShape IEnumTypeShape.UnderlyingType => UnderlyingType;
     public IReadOnlyDictionary<string, TUnderlying> Members => _members ?? InitializeMembers();
 

--- a/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
@@ -34,7 +34,7 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
 
     public sealed override TypeShapeKind Kind => TypeShapeKind.Enumerable;
     public sealed override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitEnumerable(this, state);
-    public ITypeShape<TElement> ElementType => Provider.GetShape<TElement>();
+    public ITypeShape<TElement> ElementType => Provider.GetTypeShape<TElement>();
     ITypeShape IEnumerableTypeShape.ElementType => ElementType;
 
     public virtual EnumerableAppender<TEnumerable, TElement> GetAppender()

--- a/src/PolyType/ReflectionProvider/ReflectionEventShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEventShape.cs
@@ -23,8 +23,8 @@ internal sealed class ReflectionEventShape<TDeclaringType, TEventHandler> : IEve
     public string Name { get; }
     public bool IsStatic => _eventInfo.AddMethod!.IsStatic;
     public bool IsPublic => _eventInfo.AddMethod!.IsPublic;
-    public ITypeShape<TDeclaringType> DeclaringType => _provider.GetShape<TDeclaringType>();
-    public IFunctionTypeShape HandlerType => _handlerType ?? CommonHelpers.ExchangeIfNull(ref _handlerType, (IFunctionTypeShape)_provider.GetShape<TEventHandler>());
+    public ITypeShape<TDeclaringType> DeclaringType => _provider.GetTypeShape<TDeclaringType>();
+    public IFunctionTypeShape HandlerType => _handlerType ?? CommonHelpers.ExchangeIfNull(ref _handlerType, (IFunctionTypeShape)_provider.GetTypeShape<TEventHandler>());
     public ICustomAttributeProvider? AttributeProvider => _eventInfo;
     public object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitEvent(this, state);
     ITypeShape IEventShape.DeclaringType => DeclaringType;

--- a/src/PolyType/ReflectionProvider/ReflectionMethodShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionMethodShape.cs
@@ -21,8 +21,8 @@ internal sealed class ReflectionMethodShape<TDeclaringType, TArgumentState, TRes
         _methodShapeInfo = methodShapeInfo;
     }
 
-    public ITypeShape<TDeclaringType> DeclaringType => _provider.GetShape<TDeclaringType>();
-    public ITypeShape<TResult> ReturnType => _provider.GetShape<TResult>();
+    public ITypeShape<TDeclaringType> DeclaringType => _provider.GetTypeShape<TDeclaringType>();
+    public ITypeShape<TResult> ReturnType => _provider.GetTypeShape<TResult>();
     public string Name => _methodShapeInfo.Name;
     public bool IsPublic => _methodShapeInfo.IsPublic;
     public bool IsStatic => _methodShapeInfo.Method!.IsStatic;

--- a/src/PolyType/ReflectionProvider/ReflectionNullableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionNullableTypeShape.cs
@@ -27,6 +27,6 @@ internal sealed class ReflectionNullableTypeShape<T>(ReflectionTypeShapeProvider
             return true;
         };
 
-    public ITypeShape<T> ElementType => Provider.GetShape<T>();
+    public ITypeShape<T> ElementType => Provider.GetTypeShape<T>();
     ITypeShape IOptionalTypeShape.ElementType => ElementType;
 }

--- a/src/PolyType/ReflectionProvider/ReflectionParameterShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionParameterShape.cs
@@ -27,7 +27,7 @@ internal sealed class ReflectionParameterShape<TArgumentState, TParameter> : IPa
         _provider = provider;
     }
 
-    public ITypeShape<TParameter> ParameterType => _provider.GetShape<TParameter>();
+    public ITypeShape<TParameter> ParameterType => _provider.GetTypeShape<TParameter>();
 
     public int Position { get; }
     public string Name => _parameterInfo.Name;

--- a/src/PolyType/ReflectionProvider/ReflectionPropertyShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionPropertyShape.cs
@@ -53,7 +53,7 @@ internal sealed class ReflectionPropertyShape<TDeclaringType, TPropertyType> : I
     public string Name { get; }
     public ICustomAttributeProvider AttributeProvider { get; }
     public IObjectTypeShape<TDeclaringType> DeclaringType { get; }
-    public ITypeShape<TPropertyType> PropertyType => _provider.GetShape<TPropertyType>();
+    public ITypeShape<TPropertyType> PropertyType => _provider.GetTypeShape<TPropertyType>();
 
     public bool IsField { get; }
     public bool IsGetterPublic { get; }

--- a/src/PolyType/ReflectionProvider/ReflectionSurrogateTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionSurrogateTypeShape.cs
@@ -14,6 +14,6 @@ internal sealed class ReflectionSurrogateTypeShape<T, TSurrogate>(
     public override TypeShapeKind Kind => TypeShapeKind.Surrogate;
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitSurrogate(this, state);
     public IMarshaler<T, TSurrogate> Marshaler => marshaler;
-    public ITypeShape<TSurrogate> SurrogateType => Provider.GetShape<TSurrogate>();
+    public ITypeShape<TSurrogate> SurrogateType => Provider.GetTypeShape<TSurrogate>();
     ITypeShape ISurrogateTypeShape.SurrogateType => SurrogateType;
 }

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShape.cs
@@ -36,7 +36,7 @@ internal abstract class ReflectionTypeShape<T>(ReflectionTypeShapeProvider provi
             ? associatedType.MakeGenericType(Type.GenericTypeArguments)
             : associatedType;
 
-        return provider.GetShape(closedType);
+        return provider.GetTypeShape(closedType);
     }
 
     private IEnumerable<IMethodShape> GetMethods()

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -79,7 +79,7 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
     /// <returns>
     /// A <see cref="ITypeShape{T}"/> instance corresponding to the current type.
     /// </returns>
-    public ITypeShape<T> GetShape<T>() => (ITypeShape<T>)GetShape(typeof(T));
+    public ITypeShape<T> GetTypeShape<T>() => (ITypeShape<T>)GetTypeShape(typeof(T));
 
     /// <summary>
     /// Gets a <see cref="ITypeShape"/> instance corresponding to the supplied type.
@@ -90,7 +90,7 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
     /// </returns>
     /// <exception cref="ArgumentNullException">The <paramref name="type"/> argument is null.</exception>
     /// <exception cref="ArgumentException">The <paramref name="type"/> cannot be a generic argument.</exception>
-    public ITypeShape GetShape(Type type)
+    public ITypeShape GetTypeShape(Type type)
     {
         Throw.IfNull(type);
         return _cache.GetOrAdd(type, _typeShapeFactory);

--- a/src/PolyType/ReflectionProvider/ReflectionUnionCaseShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionUnionCaseShape.cs
@@ -6,7 +6,7 @@ namespace PolyType.ReflectionProvider;
 internal sealed class ReflectionUnionCaseShape<TUnionCase, TUnion>(IUnionTypeShape unionType, DerivedTypeInfo derivedTypeInfo, ReflectionTypeShapeProvider provider) : IUnionCaseShape<TUnionCase, TUnion>
     where TUnionCase : TUnion
 {
-    public ITypeShape<TUnionCase> Type => _type ?? CommonHelpers.ExchangeIfNull(ref _type, typeof(TUnionCase) == typeof(TUnion) ? (ITypeShape<TUnionCase>)unionType.BaseType : provider.GetShape<TUnionCase>());
+    public ITypeShape<TUnionCase> UnionCaseType => _type ?? CommonHelpers.ExchangeIfNull(ref _type, typeof(TUnionCase) == typeof(TUnion) ? (ITypeShape<TUnionCase>)unionType.BaseType : provider.GetTypeShape<TUnionCase>());
     private ITypeShape<TUnionCase>? _type;
 
     public IMarshaler<TUnionCase, TUnion> Marshaler => SubtypeMarshaler<TUnionCase, TUnion>.Instance;
@@ -16,7 +16,7 @@ internal sealed class ReflectionUnionCaseShape<TUnionCase, TUnion>(IUnionTypeSha
     public bool IsTagSpecified => derivedTypeInfo.IsTagSpecified;
     public int Index => derivedTypeInfo.Index;
 
-    ITypeShape IUnionCaseShape.Type => Type;
+    ITypeShape IUnionCaseShape.UnionCaseType => UnionCaseType;
 
     public object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitUnionCase(this, state);
 }

--- a/src/PolyType/SourceGenModel/SourceGenTypeShapeProvider.cs
+++ b/src/PolyType/SourceGenModel/SourceGenTypeShapeProvider.cs
@@ -14,14 +14,5 @@ public abstract class SourceGenTypeShapeProvider : ITypeShapeProvider
     /// <returns>
     /// A <see cref="ITypeShape"/> instance corresponding to the current type.
     /// </returns>
-    public abstract ITypeShape? GetShape(Type type);
-
-    /// <summary>
-    /// Gets a <see cref="ITypeShape{T}"/> instance corresponding to the supplied type.
-    /// </summary>
-    /// <typeparam name="T">The type for which a shape is requested.</typeparam>
-    /// <returns>
-    /// A <see cref="ITypeShape{T}"/> instance corresponding to the current type.
-    /// </returns>
-    public ITypeShape<T>? GetShape<T>() => (ITypeShape<T>?)GetShape(typeof(T));
+    public abstract ITypeShape? GetTypeShape(Type type);
 }

--- a/src/PolyType/SourceGenModel/SourceGenUnionCaseShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenUnionCaseShape.cs
@@ -10,7 +10,7 @@ namespace PolyType.SourceGenModel;
 public sealed class SourceGenUnionCaseShape<TUnionCase, TUnion> : IUnionCaseShape<TUnionCase, TUnion>
 {
     /// <inheritdoc/>
-    public required ITypeShape<TUnionCase> Type { get; init; }
+    public required ITypeShape<TUnionCase> UnionCaseType { get; init; }
 
     /// <inheritdoc/>
     public required IMarshaler<TUnionCase, TUnion> Marshaler { get; init; }
@@ -27,6 +27,6 @@ public sealed class SourceGenUnionCaseShape<TUnionCase, TUnion> : IUnionCaseShap
     /// <inheritdoc/>
     public required int Index { get; init; }
 
-    ITypeShape IUnionCaseShape.Type => Type;
+    ITypeShape IUnionCaseShape.UnionCaseType => UnionCaseType;
     object? IUnionCaseShape.Accept(TypeShapeVisitor visitor, object? state) => visitor.VisitUnionCase(this, state);
 }

--- a/src/PolyType/TypeShapeProviderExtensions.cs
+++ b/src/PolyType/TypeShapeProviderExtensions.cs
@@ -1,0 +1,47 @@
+﻿namespace PolyType;
+
+/// <summary>
+/// Extension methods for the <see cref="ITypeShapeProvider"/> interface.
+/// </summary>
+public static class TypeShapeProviderExtensions
+{
+    /// <summary>
+    /// Gets a <see cref="ITypeShape"/> instance corresponding to the specified type.
+    /// </summary>
+    /// <param name="typeShapeProvider">The shape provider from which to extract the <see cref="ITypeShape"/>.</param>
+    /// <param name="type">The type whose shape we need to resolve.</param>
+    /// <param name="throwIfMissing">If <see langword="true"/>, throws an exception if no shape is found.</param>
+    /// <returns>An <see cref="ITypeShape"/> instance describing <paramref name="type"/>.</returns>
+    /// <exception cref="NotSupportedException"><paramref name="typeShapeProvider"/> does not support <paramref name="type"/>.</exception>
+    public static ITypeShape? GetTypeShape(this ITypeShapeProvider typeShapeProvider, Type type, bool throwIfMissing)
+    {
+        ITypeShape? typeShape = typeShapeProvider.GetTypeShape(type);
+        if (typeShape is null && throwIfMissing)
+        {
+            ThrowTypeShapeNotFound();
+            void ThrowTypeShapeNotFound() => throw new NotSupportedException($"The type shape provider '{typeShapeProvider.GetType()}' does not support type '{type}'.");
+        }
+
+        return typeShape;
+    }
+
+    /// <summary>
+    /// Gets a <see cref="ITypeShape{T}"/> instance corresponding to the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type whose shape we need to resolve.</typeparam>
+    /// <param name="typeShapeProvider">The shape provider from which to extract the <see cref="ITypeShape"/>.</param>
+    /// <param name="throwIfMissing">If <see langword="true"/>, throws an exception if no shape is found.</param>
+    /// <returns>An <see cref="ITypeShape{T}"/> instance describing <typeparamref name="T"/>.</returns>
+    /// <exception cref="NotSupportedException"><paramref name="typeShapeProvider"/> does not support <typeparamref name="T"/>.</exception>
+    public static ITypeShape<T>? GetTypeShape<T>(this ITypeShapeProvider typeShapeProvider, bool throwIfMissing = false)
+    {
+        ITypeShape<T>? typeShape = (ITypeShape<T>?)typeShapeProvider.GetTypeShape(typeof(T));
+        if (typeShape is null && throwIfMissing)
+        {
+            ThrowTypeShapeNotFound();
+            void ThrowTypeShapeNotFound() => throw new NotSupportedException($"The type shape provider '{typeShapeProvider.GetType()}' does not support type '{typeof(T)}'.");
+        }
+
+        return typeShape;
+    }
+}

--- a/src/PolyType/Utilities/AggregatingTypeShapeProvider.cs
+++ b/src/PolyType/Utilities/AggregatingTypeShapeProvider.cs
@@ -49,11 +49,11 @@ public sealed class AggregatingTypeShapeProvider : ITypeShapeProvider
     public IReadOnlyList<ITypeShapeProvider> Providers => _providers;
 
     /// <inheritdoc/>
-    public ITypeShape? GetShape(Type type)
+    public ITypeShape? GetTypeShape(Type type)
     {
         for (int i = 0; i < _providers.Count; i++)
         {
-            if (_providers[i].GetShape(type) is ITypeShape shape)
+            if (_providers[i].GetTypeShape(type) is ITypeShape shape)
             {
                 return shape;
             }

--- a/src/PolyType/Utilities/Caching/MultiProviderTypeCache.cs
+++ b/src/PolyType/Utilities/Caching/MultiProviderTypeCache.cs
@@ -45,14 +45,14 @@ public sealed class MultiProviderTypeCache
     public bool CacheExceptions { get; init; }
 
     /// <summary>
-    /// Gets or creates a cache scoped to the specified <paramref name="shapeProvider"/>.
+    /// Gets or creates a cache scoped to the specified <paramref name="typeShapeProvider"/>.
     /// </summary>
-    /// <param name="shapeProvider">The shape provider key.</param>
-    /// <returns>A <see cref="TypeCache"/> scoped to <paramref name="shapeProvider"/>.</returns>
-    public TypeCache GetScopedCache(ITypeShapeProvider shapeProvider)
+    /// <param name="typeShapeProvider">The shape provider key.</param>
+    /// <returns>A <see cref="TypeCache"/> scoped to <paramref name="typeShapeProvider"/>.</returns>
+    public TypeCache GetScopedCache(ITypeShapeProvider typeShapeProvider)
     {
-        Throw.IfNull(shapeProvider);
-        return _providerCaches.GetValue(shapeProvider, _createProviderCache);
+        Throw.IfNull(typeShapeProvider);
+        return _providerCaches.GetValue(typeShapeProvider, _createProviderCache);
     }
 
     /// <summary>

--- a/src/PolyType/Utilities/Caching/TypeCache.cs
+++ b/src/PolyType/Utilities/Caching/TypeCache.cs
@@ -153,7 +153,7 @@ public sealed class TypeCache : IReadOnlyDictionary<Type, object?>
             static void Throw() => throw new InvalidOperationException("The current cache does not specify a Provider property.");
         }
 
-        return AddValue(Provider.Resolve(type));
+        return AddValue(Provider.GetTypeShape(type, throwIfMissing: true)!);
     }
 
     /// <summary>

--- a/tests/PolyType.Benchmarks/CounterBenchmark.cs
+++ b/tests/PolyType.Benchmarks/CounterBenchmark.cs
@@ -16,8 +16,8 @@ public partial class CounterBenchmark
         Dict = new() { ["key1"] = 42, ["key2"] = -1 },
     };
 
-    private readonly Func<MyPoco, long> _reflectionEmitCounter = Counter.Create(EmitProvider.GetShape<MyPoco>());
-    private readonly Func<MyPoco, long> _reflectionCounter = Counter.Create(NoEmitProvider.GetShape<MyPoco>());
+    private readonly Func<MyPoco, long> _reflectionEmitCounter = Counter.Create(EmitProvider.GetTypeShape<MyPoco>());
+    private readonly Func<MyPoco, long> _reflectionCounter = Counter.Create(NoEmitProvider.GetTypeShape<MyPoco>());
 
     [Benchmark(Baseline = true)]
     public long Baseline()

--- a/tests/PolyType.Benchmarks/MethodInvokeBenchmarks.cs
+++ b/tests/PolyType.Benchmarks/MethodInvokeBenchmarks.cs
@@ -35,8 +35,8 @@ public partial class MethodInvokeBenchmarks
         _reflectionWrapper = CreateReflectionWrapper();
 
         // Initialize IMethodShape wrappers
-        _methodShapeEmitWrapper = CreateMethodShapeWrapper(EmitProvider.GetShape<TestClass>());
-        _methodShapeNoEmitWrapper = CreateMethodShapeWrapper(NoEmitProvider.GetShape<TestClass>());
+        _methodShapeEmitWrapper = CreateMethodShapeWrapper(EmitProvider.GetTypeShape<TestClass>());
+        _methodShapeNoEmitWrapper = CreateMethodShapeWrapper(NoEmitProvider.GetTypeShape<TestClass>());
         _methodShapeSourceGenWrapper = CreateMethodShapeWrapper(TypeShapeResolver.Resolve<TestClass>());
     }
 

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationHelpers.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationHelpers.cs
@@ -99,7 +99,7 @@ public static class CompilationHelpers
             MetadataReference.CreateFromFile(typeof(System.Collections.Immutable.ImmutableArray).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(System.Threading.Tasks.ValueTask).Assembly.Location),
 #endif
-            MetadataReference.CreateFromFile(typeof(PolyType.Abstractions.ITypeShape).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(PolyType.ITypeShape).Assembly.Location),
             .. additionalReferences,
         ];
 

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
@@ -29,7 +29,7 @@ public static partial class CompilationTests
                 public Dictionary<string, int>? Dict { get; set; }
 
             #if NET8_0_OR_GREATER
-                public static PolyType.Abstractions.ITypeShape<MyPoco> Test()
+                public static PolyType.ITypeShape<MyPoco> Test()
                     => PolyType.Abstractions.TypeShapeResolver.Resolve<MyPoco>();
             #endif
             }
@@ -545,8 +545,8 @@ public static partial class CompilationTests
             {
                 public static void TestMethod()
                 {
-                    PolyType.Abstractions.ITypeShape<string> stringShape = PolyType.Abstractions.TypeShapeResolver.Resolve<string, MyWitness>();
-                    PolyType.Abstractions.ITypeShape<int> intShape = PolyType.Abstractions.TypeShapeResolver.Resolve<int, MyWitness>();
+                    PolyType.ITypeShape<string> stringShape = PolyType.Abstractions.TypeShapeResolver.Resolve<string, MyWitness>();
+                    PolyType.ITypeShape<int> intShape = PolyType.Abstractions.TypeShapeResolver.Resolve<int, MyWitness>();
                 }
             }
             #endif
@@ -681,10 +681,11 @@ public static partial class CompilationTests
             using PolyType.Abstractions;
 
             ITypeShape<MyPoco> shape;
-            #if NET8_0_OR_GREATER
+            #if NET
             shape = TypeShapeResolver.Resolve<MyPoco, Witness>();
             #endif
-            shape = TypeShapeResolver.Resolve<MyPoco>(Witness.ShapeProvider);
+            shape = TypeShapeResolver.ResolveDynamic<MyPoco, Witness>(throwIfMissing: true)!;
+            shape = Witness.GeneratedTypeShapeProvider.GetTypeShape<MyPoco>(throwIfMissing: true)!;
 
             record MyPoco(string[] Values);
 
@@ -758,7 +759,7 @@ public static partial class CompilationTests
             partial class Default { }
 
             [GenerateShape]
-            partial class GetShape { }
+            partial class GetTypeShape { }
 
             [GenerateShape]
             partial class @class { }

--- a/tests/PolyType.Tests.NativeAOT/ResolveDynamicTests.cs
+++ b/tests/PolyType.Tests.NativeAOT/ResolveDynamicTests.cs
@@ -30,9 +30,9 @@ public partial class ResolveDynamicTests
         // used by netstandard2.0 compilations.
         private sealed class Provider : ITypeShapeProvider
         {
-            public ITypeShape? GetShape(Type type) =>
+            public ITypeShape? GetTypeShape(Type type) =>
                 type == typeof(NetStandardPoco1) ?
-                PolyType.SourceGenerator.ShapeProvider_PolyType_Tests_NativeAOT.Default.NetStandardPoco1 :
+                PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests_NativeAOT.Default.NetStandardPoco1 :
                 null;
         }
     }
@@ -46,9 +46,9 @@ public partial class ResolveDynamicTests
         // used by netstandard2.0 compilations.
         private sealed class Provider : ITypeShapeProvider
         {
-            public ITypeShape? GetShape(Type type) =>
+            public ITypeShape? GetTypeShape(Type type) =>
                 type == typeof(NetStandardPoco2) ?
-                PolyType.SourceGenerator.ShapeProvider_PolyType_Tests_NativeAOT.Default.NetStandardPoco2 :
+                PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests_NativeAOT.Default.NetStandardPoco2 :
                 null;
         }
     }

--- a/tests/PolyType.Tests/AssociatedTypesTests.cs
+++ b/tests/PolyType.Tests/AssociatedTypesTests.cs
@@ -23,7 +23,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void CanConstructAssociatedType()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericDataType<int, string>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericDataType<int, string>));
         Assert.NotNull(typeShape);
         Func<object>? factory = GetAssociatedTypeFactory(typeShape, typeof(GenericDataTypeConverter<,>));
         Assert.NotNull(factory);
@@ -35,7 +35,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void CanConstructAssociatedType2()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericDataType<int, string>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericDataType<int, string>));
         Assert.NotNull(typeShape);
         Func<object>? factory = GetAssociatedTypeFactory(typeShape, typeof(GenericDataTypeCloner<,>));
         Assert.NotNull(factory);
@@ -47,7 +47,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void CanConstructAssociatedType_WithClosedGeneric()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericDataType<int, string>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericDataType<int, string>));
         Assert.NotNull(typeShape);
         Func<object>? factory = GetAssociatedTypeFactory(typeShape, typeof(GenericDataTypeConverter<int, string>));
         Assert.NotNull(factory);
@@ -59,7 +59,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void CanConstructAssociatedType_ByExtension()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericDataType<int, string>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericDataType<int, string>));
         Assert.NotNull(typeShape);
         IObjectTypeShape? associatedShape = (IObjectTypeShape?)typeShape.GetAssociatedTypeShape(typeof(GenericDataTypeVerifier<,>));
         Assert.NotNull(associatedShape);
@@ -73,7 +73,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void CanConstructAssociatedType_NonGeneric()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(NonGenericDataType));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(NonGenericDataType));
         Assert.NotNull(typeShape);
         Func<object>? factory = GetAssociatedTypeFactory(typeShape, typeof(NonGenericDataTypeConverter));
         Assert.NotNull(factory);
@@ -83,7 +83,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void CanConstructAssociatedType_GenericToNonGeneric()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericDataType<int, string>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericDataType<int, string>));
         Assert.NotNull(typeShape);
         Func<object>? factory = GetAssociatedTypeFactory(typeShape, typeof(NonGenericDataTypeConverter));
         Assert.NotNull(factory);
@@ -93,7 +93,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void CanConstructAssociatedType_TypeArgsSplitAcrossTypes()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericDataType<int, string>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericDataType<int, string>));
         Assert.NotNull(typeShape);
         Func<object>? factory = GetAssociatedTypeFactory(typeShape, typeof(GenericWrapper<>.GenericNested<>));
         Assert.NotNull(factory);
@@ -103,7 +103,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void AssociatedTypeAttribute_MissingConstructor()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericDataType<int, string>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericDataType<int, string>));
         Assert.NotNull(typeShape);
         IObjectTypeShape<GenericDataTypePropertiesOnly<int, string>>? associatedShape = (IObjectTypeShape<GenericDataTypePropertiesOnly<int, string>>?)typeShape.GetAssociatedTypeShape(typeof(GenericDataTypePropertiesOnly<,>));
         Assert.NotNull(associatedShape);
@@ -114,7 +114,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void AssociatedTypeAttribute_MissingEverything()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericDataType<int, string>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericDataType<int, string>));
         Assert.NotNull(typeShape);
         IObjectTypeShape<GenericDataTypeNoneAtAll<int, string>>? associatedShape = (IObjectTypeShape<GenericDataTypeNoneAtAll<int, string>>?)typeShape.GetAssociatedTypeShape(typeof(GenericDataTypeNoneAtAll<,>));
         Assert.NotNull(associatedShape);
@@ -125,7 +125,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void PartialAssociationAndFullReference()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericDataType<int, string>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericDataType<int, string>));
         Assert.NotNull(typeShape);
         IObjectTypeShape<GenericDataTypeFullAndPartialPaths<int, string>>? associatedShape = (IObjectTypeShape<GenericDataTypeFullAndPartialPaths<int, string>>?)typeShape.GetAssociatedTypeShape(typeof(GenericDataTypeFullAndPartialPaths<,>));
         Assert.NotNull(associatedShape);
@@ -136,7 +136,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void AssociatedTypeAttribute_ConstructorParameter()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(CustomTypeWithCustomConverter));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(CustomTypeWithCustomConverter));
         Assert.NotNull(typeShape);
         IObjectTypeShape<CustomTypeConverter>? associatedShape = (IObjectTypeShape<CustomTypeConverter>?)typeShape.GetAssociatedTypeShape(typeof(CustomTypeConverter));
         Assert.NotNull(associatedShape);
@@ -149,7 +149,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void AssociatedTypeAttribute_NamedParameter()
     {
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(CustomTypeWithCustomConverter));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(CustomTypeWithCustomConverter));
         Assert.NotNull(typeShape);
         IObjectTypeShape? associatedShape = (IObjectTypeShape<CustomTypeConverter1>?)typeShape.GetAssociatedTypeShape(typeof(CustomTypeConverter1));
         Assert.NotNull(associatedShape);
@@ -176,11 +176,11 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     public void AssociatedTypeAttribute_OnProperty()
     {
         // Assert that the associated type is available on its own.
-        IObjectTypeShape? associatedShape = (IObjectTypeShape<GenericConverter<SpecialKey2>>?)providerUnderTest.Provider.GetShape(typeof(GenericConverter<SpecialKey2>));
+        IObjectTypeShape? associatedShape = (IObjectTypeShape<GenericConverter<SpecialKey2>>?)providerUnderTest.Provider.GetTypeShape(typeof(GenericConverter<SpecialKey2>));
         Assert.NotNull(associatedShape);
 
         // Assert that it is available as an associated type of the original.
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericWrapper<SpecialKey2>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericWrapper<SpecialKey2>));
         Assert.NotNull(typeShape);
         associatedShape = (IObjectTypeShape<GenericConverter<SpecialKey2>>?)typeShape.GetAssociatedTypeShape(typeof(GenericConverter<>));
         Assert.NotNull(associatedShape);
@@ -196,11 +196,11 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     public void AssociatedTypeAttribute_OnField()
     {
         // Assert that the associated type is available on its own.
-        IObjectTypeShape? associatedShape = (IObjectTypeShape<GenericConverter<SpecialKey3>>?)providerUnderTest.Provider.GetShape(typeof(GenericConverter<SpecialKey3>));
+        IObjectTypeShape? associatedShape = (IObjectTypeShape<GenericConverter<SpecialKey3>>?)providerUnderTest.Provider.GetTypeShape(typeof(GenericConverter<SpecialKey3>));
         Assert.NotNull(associatedShape);
 
         // Assert that it is available as an associated type of the original.
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericWrapper<SpecialKey3>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericWrapper<SpecialKey3>));
         Assert.NotNull(typeShape);
         associatedShape = (IObjectTypeShape<GenericConverter<SpecialKey3>>?)typeShape.GetAssociatedTypeShape(typeof(GenericConverter<>));
         Assert.NotNull(associatedShape);
@@ -211,11 +211,11 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     {
         // Get it through the associated type shape API, which accepts an unbound generic type.
         // We do this by first starting with a known shape, then jumping to the associated type.
-        ITypeShape? ordinaryShape = providerUnderTest.Provider.GetShape(typeof(GenericDataType<int, string>));
+        ITypeShape? ordinaryShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericDataType<int, string>));
         Assert.NotNull(ordinaryShape);
 
         // Fetch as an independent shape.
-        IObjectTypeShape? associatedShape = (IObjectTypeShape<ExtraShape<int, string>>?)providerUnderTest.Provider.GetShape(typeof(ExtraShape<int, string>));
+        IObjectTypeShape? associatedShape = (IObjectTypeShape<ExtraShape<int, string>>?)providerUnderTest.Provider.GetTypeShape(typeof(ExtraShape<int, string>));
         Assert.NotNull(associatedShape);
 
         // Fetch as an associated shape by its unbound generic.
@@ -235,11 +235,11 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     {
         // Get it through the associated type shape API, which accepts an unbound generic type.
         // We do this by first starting with a known shape, then jumping to the associated type.
-        ITypeShape? ordinaryShape = providerUnderTest.Provider.GetShape(typeof(GenericDataType<int, string>));
+        ITypeShape? ordinaryShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericDataType<int, string>));
         Assert.NotNull(ordinaryShape);
 
         // Fetch as an independent shape.
-        IObjectTypeShape? associatedShape = (IObjectTypeShape<ExtraShape2<int, string>>?)providerUnderTest.Provider.GetShape(typeof(ExtraShape2<int, string>));
+        IObjectTypeShape? associatedShape = (IObjectTypeShape<ExtraShape2<int, string>>?)providerUnderTest.Provider.GetTypeShape(typeof(ExtraShape2<int, string>));
         Assert.NotNull(associatedShape);
 
         // Fetch as an associated shape by its unbound generic.
@@ -258,8 +258,8 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void Enumerables_HaveAssociatedTypes()
     {
-        Assert.NotNull(providerUnderTest.Provider.GetShape(typeof(GenericWrapper<SpecialKey>)));
-        ITypeShape? shape = providerUnderTest.Provider.GetShape(typeof(IEnumerable<SpecialKey>));
+        Assert.NotNull(providerUnderTest.Provider.GetTypeShape(typeof(GenericWrapper<SpecialKey>)));
+        ITypeShape? shape = providerUnderTest.Provider.GetTypeShape(typeof(IEnumerable<SpecialKey>));
         Assert.NotNull(shape);
         ITypeShape? associatedShape = shape.GetAssociatedTypeShape(typeof(GenericWrapper<>));
         Assert.NotNull(associatedShape);
@@ -269,8 +269,8 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     [Fact]
     public void Dictionaries_HaveAssociatedTypes()
     {
-        Assert.NotNull(providerUnderTest.Provider.GetShape(typeof(GenericWrapper<SpecialKey>.GenericNested<string>)));
-        ITypeShape? shape = providerUnderTest.Provider.GetShape(typeof(Dictionary<SpecialKey, string>));
+        Assert.NotNull(providerUnderTest.Provider.GetTypeShape(typeof(GenericWrapper<SpecialKey>.GenericNested<string>)));
+        ITypeShape? shape = providerUnderTest.Provider.GetTypeShape(typeof(Dictionary<SpecialKey, string>));
         Assert.NotNull(shape);
         ITypeShape? associatedShape = shape.GetAssociatedTypeShape(typeof(GenericWrapper<>.GenericNested<>));
         Assert.NotNull(associatedShape);
@@ -281,7 +281,7 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
     public void GenericClassWithMarshallerAndAssociatedTypes_ReturnsExpectedShape()
     {
         // Regression test for https://github.com/eiriktsarpalis/PolyType/issues/239
-        ITypeShape? typeShape = providerUnderTest.Provider.GetShape(typeof(GenericClassWithMarshallerAndAssociatedTypes<(Guid, bool)>));
+        ITypeShape? typeShape = providerUnderTest.Provider.GetTypeShape(typeof(GenericClassWithMarshallerAndAssociatedTypes<(Guid, bool)>));
         Assert.IsType<ISurrogateTypeShape>(typeShape, exactMatch: false);
         ITypeShape? associatedShape = typeShape.GetAssociatedTypeShape(typeof(List<>));
         Assert.IsType<ITypeShape<List<(Guid, bool)>>>(associatedShape, exactMatch: false);
@@ -411,5 +411,5 @@ public abstract partial class AssociatedTypesTests(ProviderUnderTest providerUnd
 
     public sealed class Reflection() : AssociatedTypesTests(ReflectionProviderUnderTest.NoEmit, partialShapesSupported: false);
     public sealed class ReflectionEmit() : AssociatedTypesTests(ReflectionProviderUnderTest.Emit, partialShapesSupported: false);
-    public sealed class SourceGen() : AssociatedTypesTests(new SourceGenProviderUnderTest(Witness.ShapeProvider), partialShapesSupported: true);
+    public sealed class SourceGen() : AssociatedTypesTests(new SourceGenProviderUnderTest(Witness.GeneratedTypeShapeProvider), partialShapesSupported: true);
 }

--- a/tests/PolyType.Tests/CacheTests.cs
+++ b/tests/PolyType.Tests/CacheTests.cs
@@ -48,7 +48,7 @@ public static class CacheTests
     [Fact]
     public static void TypeGenerationContext_TryGetValue()
     {
-        ITypeShape<int> key = Witness.ShapeProvider.Resolve<int>();
+        ITypeShape<int> key = Witness.GeneratedTypeShapeProvider.GetTypeShape<int>(throwIfMissing: true)!;
         TypeGenerationContext context = new();
 
         Assert.DoesNotContain(typeof(int), context);
@@ -71,7 +71,7 @@ public static class CacheTests
     [Fact]
     public static void TypeGenerationContext_TryGetValue_DelayedValueFactory()
     {
-        ITypeShape<int> key = Witness.ShapeProvider.Resolve<int>();
+        ITypeShape<int> key = Witness.GeneratedTypeShapeProvider.GetTypeShape<int>(throwIfMissing: true)!;
         TestDelayedValueFactory factory = new();
         TypeGenerationContext context = new() { DelayedValueFactory = factory };
 
@@ -130,9 +130,9 @@ public static class CacheTests
     [Fact]
     public static void TypeCache_DefaultValue()
     {
-        TypeCache cache = new(provider: Witness.ShapeProvider);
+        TypeCache cache = new(provider: Witness.GeneratedTypeShapeProvider);
 
-        Assert.Same(Witness.ShapeProvider, cache.Provider);
+        Assert.Same(Witness.GeneratedTypeShapeProvider, cache.Provider);
         Assert.Null(cache.ValueBuilderFactory);
         Assert.Null(cache.DelayedValueFactory);
         Assert.False(cache.CacheExceptions);
@@ -142,7 +142,7 @@ public static class CacheTests
     [Fact]
     public static void TypeCache_AddValues()
     {
-        TypeCache cache = new(provider: Witness.ShapeProvider);
+        TypeCache cache = new(provider: Witness.GeneratedTypeShapeProvider);
         TypeGenerationContext generationContext = cache.CreateGenerationContext();
         Assert.Empty(generationContext);
         Assert.Same(cache, generationContext.ParentCache);
@@ -187,7 +187,7 @@ public static class CacheTests
     [Fact]
     public static void TypeCache_DelayedValueFactory()
     {
-        TypeCache cache = new(Witness.ShapeProvider) { DelayedValueFactory = new TestDelayedValueFactory() };
+        TypeCache cache = new(Witness.GeneratedTypeShapeProvider) { DelayedValueFactory = new TestDelayedValueFactory() };
         TypeGenerationContext generationContext = cache.CreateGenerationContext();
         Assert.Same(cache.DelayedValueFactory, generationContext.DelayedValueFactory);
 
@@ -195,7 +195,7 @@ public static class CacheTests
         Assert.Empty(cache);
 
         // Register an incomplete value in the cache.
-        ITypeShape<int> key = Witness.ShapeProvider.Resolve<int>();
+        ITypeShape<int> key = Witness.GeneratedTypeShapeProvider.GetTypeShape<int>(throwIfMissing: true)!;
         Assert.False(generationContext.TryGetValue(key, out object? result));
         Assert.Null(result);
         Assert.Throws<InvalidOperationException>(() => generationContext.TryCommitResults());
@@ -246,9 +246,9 @@ public static class CacheTests
     [Fact]
     public static void TypeGenerationContext_InvalidMethodParameters_ThrowsArgumentException()
     {
-        TypeCache cache = new(Witness.ShapeProvider) { ValueBuilderFactory = _ => new IdBuilderFactory() };
+        TypeCache cache = new(Witness.GeneratedTypeShapeProvider) { ValueBuilderFactory = _ => new IdBuilderFactory() };
         TypeGenerationContext generationContext = cache.CreateGenerationContext();
-        ITypeShape<int> shapeFromOtherProvider = ReflectionTypeShapeProvider.Default.Resolve<int>();
+        ITypeShape<int> shapeFromOtherProvider = ReflectionTypeShapeProvider.Default.GetTypeShape<int>(throwIfMissing: true)!;
         Assert.NotNull(generationContext.ValueBuilder);
 
         Assert.Throws<ArgumentNullException>(() => generationContext.TryGetValue<int>(null!, out _));
@@ -263,9 +263,9 @@ public static class CacheTests
     [Fact]
     public static void TypeGenerationContext_NoValueBuilder_GetOrAddThrowsInvalidOperationException()
     {
-        TypeCache cache = new(Witness.ShapeProvider);
+        TypeCache cache = new(Witness.GeneratedTypeShapeProvider);
         TypeGenerationContext generationContext = cache.CreateGenerationContext();
-        ITypeShape<int> key = Witness.ShapeProvider.Resolve<int>();
+        ITypeShape<int> key = Witness.GeneratedTypeShapeProvider.GetTypeShape<int>(throwIfMissing: true)!;
 
         Assert.Throws<InvalidOperationException>(() => generationContext.GetOrAdd(key));
     }
@@ -280,13 +280,13 @@ public static class CacheTests
     [InlineData(true)]
     public static void TypeCache_CacheExceptions(bool cacheExceptions)
     {
-        TypeCache cache = new(Witness.ShapeProvider) 
+        TypeCache cache = new(Witness.GeneratedTypeShapeProvider) 
         { 
             CacheExceptions = cacheExceptions,
             ValueBuilderFactory = _ => new ThrowingBuilder() 
         };
 
-        ITypeShape<int> key = Witness.ShapeProvider.Resolve<int>();
+        ITypeShape<int> key = Witness.GeneratedTypeShapeProvider.GetTypeShape<int>(throwIfMissing: true)!;
 
         var ex1 = Assert.Throws<NotFiniteNumberException>(() => cache.GetOrAdd(key));
         var ex2 = Assert.Throws<NotFiniteNumberException>(() => cache.GetOrAdd(key));
@@ -311,9 +311,9 @@ public static class CacheTests
     {
         MultiProviderTypeCache cache = new();
 
-        Assert.Same(cache.GetScopedCache(Witness.ShapeProvider), cache.GetScopedCache(Witness.ShapeProvider));
+        Assert.Same(cache.GetScopedCache(Witness.GeneratedTypeShapeProvider), cache.GetScopedCache(Witness.GeneratedTypeShapeProvider));
         Assert.Same(cache.GetScopedCache(ReflectionTypeShapeProvider.Default), cache.GetScopedCache(ReflectionTypeShapeProvider.Default));
-        Assert.NotSame(cache.GetScopedCache(Witness.ShapeProvider), cache.GetScopedCache(ReflectionTypeShapeProvider.Default));
+        Assert.NotSame(cache.GetScopedCache(Witness.GeneratedTypeShapeProvider), cache.GetScopedCache(ReflectionTypeShapeProvider.Default));
     }
 
     [Fact]
@@ -326,8 +326,8 @@ public static class CacheTests
             ValueBuilderFactory = _ => new IdBuilderFactory(),
         };
 
-        TypeCache sourceGenCache = cache.GetScopedCache(Witness.ShapeProvider);
-        Assert.Same(Witness.ShapeProvider, sourceGenCache.Provider);
+        TypeCache sourceGenCache = cache.GetScopedCache(Witness.GeneratedTypeShapeProvider);
+        Assert.Same(Witness.GeneratedTypeShapeProvider, sourceGenCache.Provider);
         Assert.Equal(cache.CacheExceptions, sourceGenCache.CacheExceptions);
         Assert.Same(cache.DelayedValueFactory, sourceGenCache.DelayedValueFactory);
         Assert.Same(cache.ValueBuilderFactory, sourceGenCache.ValueBuilderFactory);

--- a/tests/PolyType.Tests/CborCustomConverterTests.cs
+++ b/tests/PolyType.Tests/CborCustomConverterTests.cs
@@ -81,9 +81,9 @@ public abstract partial class CborCustomConverterTests(ProviderUnderTest provide
     }
 
     private CborConverter<T> GetConverterUnderTest<T>() =>
-        CborSerializer.CreateConverter((ITypeShape<T>?)providerUnderTest.Provider.GetShape(typeof(T)) ?? throw new InvalidOperationException("Shape missing."));
+        CborSerializer.CreateConverter((ITypeShape<T>?)providerUnderTest.Provider.GetTypeShape(typeof(T)) ?? throw new InvalidOperationException("Shape missing."));
 
     public sealed class Reflection() : CborCustomConverterTests(ReflectionProviderUnderTest.NoEmit);
     public sealed class ReflectionEmit() : CborCustomConverterTests(ReflectionProviderUnderTest.Emit);
-    public sealed class SourceGen() : CborCustomConverterTests(new SourceGenProviderUnderTest(Witness.ShapeProvider));
+    public sealed class SourceGen() : CborCustomConverterTests(new SourceGenProviderUnderTest(Witness.GeneratedTypeShapeProvider));
 }

--- a/tests/PolyType.Tests/CborTests.cs
+++ b/tests/PolyType.Tests/CborTests.cs
@@ -108,7 +108,7 @@ public abstract partial class CborTests(ProviderUnderTest providerUnderTest)
     [Fact]
     public void ThrowsOnMissingRequiredProperties()
     {
-        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.Resolve<SimpleRecord>());
+        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.GetTypeShape<SimpleRecord>(throwIfMissing: true)!);
         var ex = Assert.Throws<KeyNotFoundException>(() => converter.DecodeFromHex("A16376616C182A"));
         Assert.Contains("'value'", ex.Message);
     }
@@ -116,7 +116,7 @@ public abstract partial class CborTests(ProviderUnderTest providerUnderTest)
     [Fact]
     public void ThrowsOnDuplicateProperties_Mutable()
     {
-        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.Resolve<SimplePoco>());
+        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.GetTypeShape<SimplePoco>(throwIfMissing: true)!);
         var ex = Assert.Throws<InvalidOperationException>(() => converter.DecodeFromHex("A26556616C7565182A6556616C7565182B"));
         Assert.Contains("Duplicate", ex.Message);
     }
@@ -124,7 +124,7 @@ public abstract partial class CborTests(ProviderUnderTest providerUnderTest)
     [Fact]
     public void ThrowsOnDuplicateProperties_Parameterized()
     {
-        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.Resolve<SimpleRecord>());
+        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.GetTypeShape<SimpleRecord>(throwIfMissing: true)!);
         var ex = Assert.Throws<InvalidOperationException>(() => converter.DecodeFromHex("A26576616C7565182A6576616C7565182B"));
         Assert.Contains("Duplicate", ex.Message);
     }
@@ -132,7 +132,7 @@ public abstract partial class CborTests(ProviderUnderTest providerUnderTest)
     [Fact]
     public void DoesNotThrowOnDuplicateUnboundProperties()
     {
-        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.Resolve<SimplePoco>());
+        var converter = CborSerializer.CreateConverter(providerUnderTest.Provider.GetTypeShape<SimplePoco>(throwIfMissing: true)!);
         var result = converter.DecodeFromHex("A26576616C7565182A6576616C7565182B");
         Assert.Equal(0, result?.Value);
     }

--- a/tests/PolyType.Tests/CollectionShapeTests.cs
+++ b/tests/PolyType.Tests/CollectionShapeTests.cs
@@ -5,7 +5,7 @@ public abstract partial class CollectionShapeTests(ProviderUnderTest providerUnd
     [Fact]
     public void MutableListWithInternalConstructorCannotBeConstructed()
     {
-        var shape = (IEnumerableTypeShape<PublicListOfIntWithInternalConstructor, int>?)providerUnderTest.Provider.GetShape(typeof(PublicListOfIntWithInternalConstructor));
+        var shape = (IEnumerableTypeShape<PublicListOfIntWithInternalConstructor, int>?)providerUnderTest.Provider.GetTypeShape(typeof(PublicListOfIntWithInternalConstructor));
         Assert.NotNull(shape);
         Assert.Equal(CollectionConstructionStrategy.None, shape.ConstructionStrategy);
     }
@@ -13,7 +13,7 @@ public abstract partial class CollectionShapeTests(ProviderUnderTest providerUnd
     [Fact]
     public void InternalMutableListWithPublicConstructorCanBeConstructed()
     {
-        var shape = (IEnumerableTypeShape<InternalListOfIntWithPublicConstructor, int>?)providerUnderTest.Provider.GetShape(typeof(InternalListOfIntWithPublicConstructor));
+        var shape = (IEnumerableTypeShape<InternalListOfIntWithPublicConstructor, int>?)providerUnderTest.Provider.GetTypeShape(typeof(InternalListOfIntWithPublicConstructor));
         Assert.NotNull(shape);
         Assert.Equal(CollectionConstructionStrategy.Mutable, shape.ConstructionStrategy);
         Assert.NotNull(shape.GetDefaultConstructor()());
@@ -22,7 +22,7 @@ public abstract partial class CollectionShapeTests(ProviderUnderTest providerUnd
     [Fact]
     public void MutableDictionaryWithInternalConstructorCannotBeConstructed()
     {
-        var shape = (IDictionaryTypeShape<PublicDictionaryOfIntWithInternalConstructor, int, bool>?)providerUnderTest.Provider.GetShape(typeof(PublicDictionaryOfIntWithInternalConstructor));
+        var shape = (IDictionaryTypeShape<PublicDictionaryOfIntWithInternalConstructor, int, bool>?)providerUnderTest.Provider.GetTypeShape(typeof(PublicDictionaryOfIntWithInternalConstructor));
         Assert.NotNull(shape);
         Assert.Equal(CollectionConstructionStrategy.None, shape.ConstructionStrategy);
     }
@@ -30,7 +30,7 @@ public abstract partial class CollectionShapeTests(ProviderUnderTest providerUnd
     [Fact]
     public void InternalMutableDictionaryWithPublicConstructorCanBeConstructed()
     {
-        var shape = (IDictionaryTypeShape<InternalDictionaryOfIntWithPublicConstructor, int, bool>?)providerUnderTest.Provider.GetShape(typeof(InternalDictionaryOfIntWithPublicConstructor));
+        var shape = (IDictionaryTypeShape<InternalDictionaryOfIntWithPublicConstructor, int, bool>?)providerUnderTest.Provider.GetTypeShape(typeof(InternalDictionaryOfIntWithPublicConstructor));
         Assert.NotNull(shape);
         Assert.Equal(CollectionConstructionStrategy.Mutable, shape.ConstructionStrategy);
         Assert.NotNull(shape.GetDefaultConstructor()());
@@ -73,5 +73,5 @@ public abstract partial class CollectionShapeTests(ProviderUnderTest providerUnd
 
     public sealed class Reflection() : CollectionShapeTests(ReflectionProviderUnderTest.NoEmit);
     public sealed class ReflectionEmit() : CollectionShapeTests(ReflectionProviderUnderTest.Emit);
-    public sealed class SourceGen() : CollectionShapeTests(new SourceGenProviderUnderTest(Witness.ShapeProvider));
+    public sealed class SourceGen() : CollectionShapeTests(new SourceGenProviderUnderTest(Witness.GeneratedTypeShapeProvider));
 }

--- a/tests/PolyType.Tests/CollectionsWithCapacityTests.cs
+++ b/tests/PolyType.Tests/CollectionsWithCapacityTests.cs
@@ -5,7 +5,7 @@ public abstract partial class CollectionsWithCapacityTests(ProviderUnderTest pro
     [Fact]
     public void List_OfInt()
     {
-        IEnumerableTypeShape<List<int>, int> shape = (IEnumerableTypeShape<List<int>, int>)providerUnderTest.Provider.Resolve<List<int>>();
+        IEnumerableTypeShape<List<int>, int> shape = (IEnumerableTypeShape<List<int>, int>)providerUnderTest.Provider.GetTypeShape<List<int>>(throwIfMissing: true)!;
         List<int> list = shape.GetDefaultConstructor()(new() { Capacity = 11 });
         Assert.Equal(11, list.Capacity);
     }
@@ -13,7 +13,7 @@ public abstract partial class CollectionsWithCapacityTests(ProviderUnderTest pro
     [Fact]
     public void List_OfString()
     {
-        IEnumerableTypeShape<List<string>, string> shape = (IEnumerableTypeShape<List<string>, string>)providerUnderTest.Provider.Resolve<List<string>>();
+        IEnumerableTypeShape<List<string>, string> shape = (IEnumerableTypeShape<List<string>, string>)providerUnderTest.Provider.GetTypeShape<List<string>>(throwIfMissing: true)!;
         List<string> list = shape.GetDefaultConstructor()(new() { Capacity = 11 });
         Assert.Equal(11, list.Capacity);
     }
@@ -21,7 +21,7 @@ public abstract partial class CollectionsWithCapacityTests(ProviderUnderTest pro
     [Fact]
     public void Dictionary()
     {
-        IDictionaryTypeShape<Dictionary<int, bool>, int, bool> shape = (IDictionaryTypeShape<Dictionary<int, bool>, int, bool>)providerUnderTest.Provider.Resolve<Dictionary<int, bool>>();
+        IDictionaryTypeShape<Dictionary<int, bool>, int, bool> shape = (IDictionaryTypeShape<Dictionary<int, bool>, int, bool>)providerUnderTest.Provider.GetTypeShape<Dictionary<int, bool>>(throwIfMissing: true)!;
         Dictionary<int, bool> dict = shape.GetDefaultConstructor()(new() { Capacity = 11 });
 #if NET9_0_OR_GREATER
         Assert.Equal(11, dict.Capacity);
@@ -33,7 +33,7 @@ public abstract partial class CollectionsWithCapacityTests(ProviderUnderTest pro
     [Fact]
     public void HashSet()
     {
-        IEnumerableTypeShape<HashSet<int>, int> shape = (IEnumerableTypeShape<HashSet<int>, int>)providerUnderTest.Provider.Resolve<HashSet<int>>();
+        IEnumerableTypeShape<HashSet<int>, int> shape = (IEnumerableTypeShape<HashSet<int>, int>)providerUnderTest.Provider.GetTypeShape<HashSet<int>>(throwIfMissing: true)!;
         HashSet<int> set = shape.GetDefaultConstructor()(new() { Capacity = 11 });
 #if NET9_0_OR_GREATER
         Assert.Equal(11, set.Capacity);
@@ -50,5 +50,5 @@ public abstract partial class CollectionsWithCapacityTests(ProviderUnderTest pro
 
     public sealed class Reflection() : CollectionsWithCapacityTests(ReflectionProviderUnderTest.NoEmit);
     public sealed class ReflectionEmit() : CollectionsWithCapacityTests(ReflectionProviderUnderTest.Emit);
-    public sealed class SourceGen() : CollectionsWithCapacityTests(new SourceGenProviderUnderTest(Witness.ShapeProvider));
+    public sealed class SourceGen() : CollectionsWithCapacityTests(new SourceGenProviderUnderTest(Witness.GeneratedTypeShapeProvider));
 }

--- a/tests/PolyType.Tests/CollectionsWithComparersTests.cs
+++ b/tests/PolyType.Tests/CollectionsWithComparersTests.cs
@@ -230,7 +230,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
     private IDictionaryTypeShape<T, K, V> GetDictionaryShape<T, K, V>()
         where K : notnull
     {
-        var shape = (IDictionaryTypeShape<T, K, V>?)providerUnderTest.Provider.GetShape(typeof(T));
+        var shape = (IDictionaryTypeShape<T, K, V>?)providerUnderTest.Provider.GetTypeShape(typeof(T));
         Assert.NotNull(shape);
         return shape;
     }
@@ -320,7 +320,7 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
 
     private IEnumerableTypeShape<T, K> GetEnumerableShape<T, K>()
     {
-        var shape = (IEnumerableTypeShape<T, K>?)providerUnderTest.Provider.GetShape(typeof(T));
+        var shape = (IEnumerableTypeShape<T, K>?)providerUnderTest.Provider.GetTypeShape(typeof(T));
         Assert.NotNull(shape);
         return shape;
     }
@@ -609,5 +609,5 @@ public abstract partial class CollectionsWithComparersTests(ProviderUnderTest pr
 
     public sealed class Reflection() : CollectionsWithComparersTests(ReflectionProviderUnderTest.NoEmit);
     public sealed class ReflectionEmit() : CollectionsWithComparersTests(ReflectionProviderUnderTest.Emit);
-    public sealed class SourceGen() : CollectionsWithComparersTests(new SourceGenProviderUnderTest(Witness.ShapeProvider));
+    public sealed class SourceGen() : CollectionsWithComparersTests(new SourceGenProviderUnderTest(Witness.GeneratedTypeShapeProvider));
 }

--- a/tests/PolyType.Tests/DependencyInjectionTests.cs
+++ b/tests/PolyType.Tests/DependencyInjectionTests.cs
@@ -11,7 +11,7 @@ public partial class DependencyInjectionTests
         serviceCollection.Add<IFoo, FooImpl>();
         serviceCollection.Add<IBar, BarImpl>(ServiceLifetime.Scoped);
 
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
         using ServiceProvider provider = context.CreateScope();
 
         TestService testService = provider.GetRequiredService<TestService>();
@@ -35,7 +35,7 @@ public partial class DependencyInjectionTests
         serviceCollection.Add<IFoo, FooImpl>();
         serviceCollection.Add<IBar, BarImpl>(ServiceLifetime.Transient);
 
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
         using ServiceProvider provider = context.CreateScope();
 
         TestService testService = provider.GetRequiredService<TestService>();
@@ -59,7 +59,7 @@ public partial class DependencyInjectionTests
         serviceCollection.Add<IFoo, FooImpl>(ServiceLifetime.Scoped);
         serviceCollection.Add<IBar, BarImpl>(ServiceLifetime.Singleton);
 
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
         using ServiceProvider provider = context.CreateScope();
         TestService testService = provider.GetRequiredService<TestService>();
         Assert.IsType<FooImpl>(testService.Foo);
@@ -85,7 +85,7 @@ public partial class DependencyInjectionTests
         serviceCollection.Add<IBaz>(serviceProvider => new BazImpl(), ServiceLifetime.Transient);
         serviceCollection.Add<int>(42);
 
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
         using ServiceProvider provider = context.CreateScope();
         TestService testService = provider.GetRequiredService<TestService>();
         Assert.IsType<FooImpl>(testService.Foo);
@@ -108,7 +108,7 @@ public partial class DependencyInjectionTests
         serviceCollection.Add<IFoo, FooImpl>(ServiceLifetime.Scoped);
         serviceCollection.Add<IBaz>(serviceProvider => new BazImpl(), ServiceLifetime.Transient);
 
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
         using ServiceProvider provider = context.CreateScope();
 
         InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<TestService>());
@@ -119,7 +119,7 @@ public partial class DependencyInjectionTests
     public void ServiceProvider_InstantiatesEmptyCollections()
     {
         ServiceCollection serviceCollection = new();
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
         using ServiceProvider provider = context.CreateScope();
 
         var service = provider.GetRequiredService<TestServiceWithCollections>();
@@ -134,7 +134,7 @@ public partial class DependencyInjectionTests
         serviceCollection.Add<IFoo, FooImpl>(ServiceLifetime.Scoped);
         serviceCollection.Add<IBar>(serviceProvider => new BarImpl { Value = serviceProvider.GetRequiredService<IFoo>().Value }, ServiceLifetime.Singleton);
 
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
 
         using ServiceProvider provider = context.CreateScope();
         TestService testService = provider.GetRequiredService<TestService>();
@@ -154,7 +154,7 @@ public partial class DependencyInjectionTests
         serviceCollection.Add(42);
         serviceCollection.Add<BinTree>();
 
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
         using ServiceProvider provider = context.CreateScope();
 
         InvalidOperationException ex;
@@ -169,7 +169,7 @@ public partial class DependencyInjectionTests
         ServiceCollection serviceCollection = new();
         serviceCollection.Add<IFoo>(_ => new FooImpl { Value = 42 });
 
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
         using ServiceProvider provider = context.CreateScope();
         var value = provider.GetRequiredService<ClassWithSurrogate>();
         Assert.Equal(42, value.Value);
@@ -181,7 +181,7 @@ public partial class DependencyInjectionTests
         ServiceCollection serviceCollection = new();
         serviceCollection.Add(42);
 
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
         using ServiceProvider provider = context.CreateScope();
         var value = provider.GetRequiredService<NullableValue>();
         Assert.Equal(42, value.Value);
@@ -193,7 +193,7 @@ public partial class DependencyInjectionTests
         ServiceCollection serviceCollection = new();
         serviceCollection.Add<IFoo, FooImpl>();
 
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
         using ServiceProvider provider = context.CreateScope();
 
         InvalidOperationException ex;
@@ -212,7 +212,7 @@ public partial class DependencyInjectionTests
         serviceCollection.Add<IFoo, DisposableFoo>();
         serviceCollection.Add<IBar, BarImpl>();
 
-        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.ShapeProvider_PolyType_Tests.Default);
+        using ServiceProviderContext context = serviceCollection.Build(PolyType.SourceGenerator.TypeShapeProvider_PolyType_Tests.Default);
         using (ServiceProvider provider = context.CreateScope())
         {
             TestService testService = provider.GetRequiredService<TestService>();

--- a/tests/PolyType.Tests/EnumMemberShapeTests.cs
+++ b/tests/PolyType.Tests/EnumMemberShapeTests.cs
@@ -5,7 +5,7 @@ public abstract partial class EnumMemberShapeTests(ProviderUnderTest providerUnd
     [Fact]
     public void EnumMemberShapeTest()
     {
-        var enumShape = (IEnumTypeShape<TestEnum, byte>)providerUnderTest.Provider.Resolve<TestEnum>();
+        var enumShape = (IEnumTypeShape<TestEnum, byte>)providerUnderTest.Provider.GetTypeShape<TestEnum>(throwIfMissing: true)!;
         Assert.Equal(3, enumShape.Members.Count);
         Assert.Equal(0, enumShape.Members["FirstValue"]);
         Assert.Equal(5, enumShape.Members["Second"]);
@@ -26,5 +26,5 @@ public abstract partial class EnumMemberShapeTests(ProviderUnderTest providerUnd
 
     public sealed class Reflection() : EnumMemberShapeTests(ReflectionProviderUnderTest.NoEmit);
     public sealed class ReflectionEmit() : EnumMemberShapeTests(ReflectionProviderUnderTest.Emit);
-    public sealed class SourceGen() : EnumMemberShapeTests(new SourceGenProviderUnderTest(Witness.ShapeProvider));
+    public sealed class SourceGen() : EnumMemberShapeTests(new SourceGenProviderUnderTest(Witness.GeneratedTypeShapeProvider));
 }

--- a/tests/PolyType.Tests/IsRequiredTests.cs
+++ b/tests/PolyType.Tests/IsRequiredTests.cs
@@ -8,7 +8,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     [Fact]
     public void UnattributedProperties()
     {
-        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetShape(typeof(HasRequiredProperty));
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasRequiredProperty));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         Assert.True(shape.Constructor.Parameters.Single(p => p.Name == nameof(HasRequiredProperty.RequiredProperty)).IsRequired);
@@ -26,7 +26,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     [Fact]
     public void AttributedProperties_NoChanges()
     {
-        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetShape(typeof(HasRequiredPropertyWithNonOverriddingAttributes));
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasRequiredPropertyWithNonOverriddingAttributes));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         Assert.True(shape.Constructor.Parameters.Single(p => p.Name == nameof(HasRequiredPropertyWithNonOverriddingAttributes.RequiredProperty)).IsRequired);
@@ -46,7 +46,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     [Fact]
     public void AttributedProperties_WithChanges()
     {
-        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetShape(typeof(HasRequiredPropertyWithOverriddingAttributes));
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasRequiredPropertyWithOverriddingAttributes));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         Assert.False(shape.Constructor.Parameters.Single(p => p.Name == nameof(HasRequiredPropertyWithOverriddingAttributes.RequiredProperty)).IsRequired);
@@ -66,7 +66,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     [Fact]
     public void PropertyRequiredByAttribute()
     {
-        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetShape(typeof(HasPropertyRequiredByAttribute));
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasPropertyRequiredByAttribute));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         Assert.True(shape.Constructor.Parameters.Single(p => p.Name == nameof(HasPropertyRequiredByAttribute.RequiredProperty)).IsRequired);
@@ -82,7 +82,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     [Fact]
     public void PropertyRequiredButNotByAttribute()
     {
-        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetShape(typeof(HasPropertyRequiredButNotByAttribute));
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasPropertyRequiredButNotByAttribute));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         Assert.False(shape.Constructor.Parameters.Single(p => p.Name == nameof(HasPropertyRequiredButNotByAttribute.RequiredProperty)).IsRequired);
@@ -98,7 +98,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     [Fact]
     public void NonDefaultCtor()
     {
-        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetShape(typeof(HasNonDefaultConstructor));
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasNonDefaultConstructor));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         Assert.True(shape.Constructor.Parameters.Single(p => p.Name == nameof(HasNonDefaultConstructor.MyProperty)).IsRequired);
@@ -118,7 +118,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     [Fact]
     public void NonDefaultCtor_NonRequiredProperty_WithOverride()
     {
-        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetShape(typeof(HasNonDefaultConstructorAndParameterOverride));
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasNonDefaultConstructorAndParameterOverride));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         Assert.False(shape.Constructor.Parameters.Single(p => p.Name == nameof(HasNonDefaultConstructorAndParameterOverride.MyProperty)).IsRequired);
@@ -138,7 +138,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     [Fact]
     public void NonDefaultCtor_NonRequiredProperty_WithShapeNoOverride()
     {
-        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetShape(typeof(HasNonDefaultConstructorAndParameterNonOverride));
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasNonDefaultConstructorAndParameterNonOverride));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         Assert.True(shape.Constructor.Parameters.Single(p => p.Name == nameof(HasNonDefaultConstructorAndParameterNonOverride.MyProperty)).IsRequired);
@@ -158,7 +158,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     [Fact]
     public void RequiredPropertyAndCtorWithDefaultValue()
     {
-        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetShape(typeof(HasNonDefaultConstructorWithDefaultAndRequiredProperty));
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasNonDefaultConstructorWithDefaultAndRequiredProperty));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         var parameter = shape.Constructor.Parameters.Single(p => p.Name == nameof(HasNonDefaultConstructorWithDefaultAndRequiredProperty.MyProperty) && p.Kind == ParameterKind.MethodParameter);
@@ -181,7 +181,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     [Fact]
     public void NonDefaultConstructorAndUnrelatedRequiredProperty()
     {
-        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetShape(typeof(HasNonDefaultConstructorAndUnrelatedRequiredProperty));
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasNonDefaultConstructorAndUnrelatedRequiredProperty));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         Assert.True(shape.Constructor.Parameters.Single(p => p.Name == nameof(HasNonDefaultConstructorAndUnrelatedRequiredProperty.RequiredProperty)).IsRequired);
@@ -200,7 +200,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     [Fact]
     public void NonDefaultConstructorAndUnrelatedRequiredOverriddenProperty()
     {
-        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetShape(typeof(HasNonDefaultConstructorAndUnrelatedRequiredOverriddenProperty));
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasNonDefaultConstructorAndUnrelatedRequiredOverriddenProperty));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         Assert.False(shape.Constructor.Parameters.Single(p => p.Name == nameof(HasNonDefaultConstructorAndUnrelatedRequiredOverriddenProperty.RequiredProperty)).IsRequired);
@@ -222,5 +222,5 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
 
     public sealed class Reflection() : IsRequiredTests(ReflectionProviderUnderTest.NoEmit);
     public sealed class ReflectionEmit() : IsRequiredTests(ReflectionProviderUnderTest.Emit);
-    public sealed class SourceGen() : IsRequiredTests(new SourceGenProviderUnderTest(Witness.ShapeProvider));
+    public sealed class SourceGen() : IsRequiredTests(new SourceGenProviderUnderTest(Witness.GeneratedTypeShapeProvider));
 }

--- a/tests/PolyType.Tests/JsonSchemaTests.cs
+++ b/tests/PolyType.Tests/JsonSchemaTests.cs
@@ -140,7 +140,7 @@ public abstract class JsonSchemaTests(ProviderUnderTest providerUnderTest)
     [Fact]
     public void TestMethodShapeSchema()
     {
-        ITypeShape serviceShape = providerUnderTest.Provider.Resolve<RpcService>();
+        ITypeShape serviceShape = providerUnderTest.Provider.GetTypeShape<RpcService>(throwIfMissing: true)!;
         IMethodShape getEventsAsync = serviceShape.Methods.Single(m => m.Name == nameof(RpcService.GetEventsAsync));
         IMethodShape resetAsync = serviceShape.Methods.Single(m => m.Name == nameof(RpcService.ResetAsync));
 

--- a/tests/PolyType.Tests/JsonTests.cs
+++ b/tests/PolyType.Tests/JsonTests.cs
@@ -402,7 +402,7 @@ public abstract partial class JsonTests(ProviderUnderTest providerUnderTest)
     [Fact]
     public async Task JsonFunc_InvokedAsExpected()
     {
-        var serviceShape = providerUnderTest.Provider.Resolve<RpcService>();
+        var serviceShape = providerUnderTest.Provider.GetTypeShape<RpcService>(throwIfMissing: true)!;
         var instance = new RpcService();
 
         var getEventsFunc = JsonSerializerTS.CreateJsonFunc(serviceShape.Methods.First(m => m.Name == nameof(RpcService.GetEventsAsync)), instance);
@@ -445,7 +445,7 @@ public abstract partial class JsonTests(ProviderUnderTest providerUnderTest)
             return;
         }
 
-        var serviceShape = providerUnderTest.Provider.Resolve<RpcService>();
+        var serviceShape = providerUnderTest.Provider.GetTypeShape<RpcService>(throwIfMissing: true)!;
         var instance = new RpcService();
 
         JsonEvent onMethodCalledEvent = JsonSerializerTS.CreateJsonEvent(serviceShape.Events.First(m => m.Name == nameof(RpcService.OnMethodCalled)), instance);

--- a/tests/PolyType.Tests/ProviderUnderTest.cs
+++ b/tests/PolyType.Tests/ProviderUnderTest.cs
@@ -42,7 +42,7 @@ public enum ProviderKind
 
 public sealed class SourceGenProviderUnderTest(SourceGenTypeShapeProvider sourceGenProvider) : ProviderUnderTest
 {
-    public static SourceGenProviderUnderTest Default { get; } = new(Witness.ShapeProvider);
+    public static SourceGenProviderUnderTest Default { get; } = new(Witness.GeneratedTypeShapeProvider);
 
     public override ProviderKind Kind => ProviderKind.SourceGen;
     public override bool ResolvesNullableAnnotations => true;
@@ -60,5 +60,5 @@ public sealed class ReflectionProviderUnderTest(ReflectionTypeShapeProviderOptio
     public override ITypeShapeProvider Provider { get; } = ReflectionTypeShapeProvider.Create(options);
     public override ProviderKind Kind => options.UseReflectionEmit ? ProviderKind.ReflectionEmit : ProviderKind.ReflectionNoEmit;
     public override bool ResolvesNullableAnnotations => ReflectionHelpers.IsNullabilityInfoContextSupported;
-    public override ITypeShape ResolveShape(ITestCase testCase) => Provider.Resolve(testCase.Type);
+    public override ITypeShape ResolveShape(ITestCase testCase) => Provider.GetTypeShape(testCase.Type, throwIfMissing: true)!;
 }

--- a/tests/PolyType.Tests/Utilities/AggregatingTypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/Utilities/AggregatingTypeShapeProviderTests.cs
@@ -22,14 +22,14 @@ public class AggregatingTypeShapeProviderTests
     public void EmptyList()
     {
         AggregatingTypeShapeProvider aggregate = new();
-        Assert.Null(aggregate.GetShape(typeof(int)));
+        Assert.Null(aggregate.GetTypeShape(typeof(int)));
     }
 
     [Fact]
     public void One_NullShape()
     {
         AggregatingTypeShapeProvider aggregate = new(new MockTypeShapeProvider());
-        Assert.Null(aggregate.GetShape(typeof(int)));
+        Assert.Null(aggregate.GetTypeShape(typeof(int)));
     }
 
 
@@ -44,7 +44,7 @@ public class AggregatingTypeShapeProviderTests
             },
         };
         AggregatingTypeShapeProvider aggregate = new(first);
-        Assert.Same(first.Shapes[typeof(int)], aggregate.GetShape(typeof(int)));
+        Assert.Same(first.Shapes[typeof(int)], aggregate.GetTypeShape(typeof(int)));
     }
 
     [Fact]
@@ -65,9 +65,9 @@ public class AggregatingTypeShapeProviderTests
             },
         };
         AggregatingTypeShapeProvider aggregate = new(first, second);
-        Assert.Same(first.Shapes[typeof(int)], aggregate.GetShape(typeof(int)));
-        Assert.Same(second.Shapes[typeof(string)], aggregate.GetShape(typeof(string)));
-        Assert.Null(aggregate.GetShape(typeof(bool)));
+        Assert.Same(first.Shapes[typeof(int)], aggregate.GetTypeShape(typeof(int)));
+        Assert.Same(second.Shapes[typeof(string)], aggregate.GetTypeShape(typeof(string)));
+        Assert.Null(aggregate.GetTypeShape(typeof(bool)));
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class AggregatingTypeShapeProviderTests
         };
 
         // Verify that the new provider is not used.
-        Assert.Null(aggregate.GetShape(typeof(int)));
+        Assert.Null(aggregate.GetTypeShape(typeof(int)));
     }
 
     [Fact]
@@ -115,11 +115,11 @@ public class AggregatingTypeShapeProviderTests
             },
         };
         AggregatingTypeShapeProvider aggregate = new(first);
-        Assert.Same(first.Shapes[typeof(int)], aggregate.GetShape(typeof(int)));
+        Assert.Same(first.Shapes[typeof(int)], aggregate.GetTypeShape(typeof(int)));
 
         // Remove the shape, and verify that the aggregator no longer returns it.
         first.Shapes.Remove(typeof(int));
-        Assert.Null(aggregate.GetShape(typeof(int)));
+        Assert.Null(aggregate.GetTypeShape(typeof(int)));
     }
 
     /// <summary>
@@ -147,20 +147,20 @@ public class AggregatingTypeShapeProviderTests
             },
         };
         AggregatingTypeShapeProvider aggregate = new(first, second);
-        Assert.NotNull(aggregate.GetShape(typeof(string)));
+        Assert.NotNull(aggregate.GetTypeShape(typeof(string)));
 
         // Add a new string shape to the first provider.
         first.Shapes[typeof(string)] = new MockTypeShape<string>();
 
         // The aggregator should return the new shape.
-        Assert.Same(first.Shapes[typeof(string)], aggregate.GetShape(typeof(string)));
+        Assert.Same(first.Shapes[typeof(string)], aggregate.GetTypeShape(typeof(string)));
     }
 
     private class MockTypeShapeProvider : ITypeShapeProvider
     {
         internal Dictionary<Type, ITypeShape> Shapes { get; } = new();
 
-        public ITypeShape? GetShape(Type type) => Shapes.TryGetValue(type, out ITypeShape? shape) ? shape : null;
+        public ITypeShape? GetTypeShape(Type type) => Shapes.TryGetValue(type, out ITypeShape? shape) ? shape : null;
     }
 
     [ExcludeFromCodeCoverage]


### PR DESCRIPTION
Makes the following breaking changes to the PolyType APIs:

* Moves the `ITypeShape` and `ITypeShape<T>` types to the root `PolyType` namespace.
* Renames `ITypeShapeProvider.GetShape` and `IShapeable<T>.GetShape` methods to `GetTypeShape`.
* Moves all `TypeShapeResolver.Resolve` overloads accepting `ITypeShapeProvider` to a new `TypeShapeProviderExtensions` class and renames them to `GetTypeShape`.
* Renames `IUnionCaseShape.Type` to `IUnionCaseShape.UnionCaseType`.
* Renames all `shapeProvider` parameters to `typeShapeProvider`.

Fix #254. Closes #206.