### PR TITLE
Revise ResolveDynamic signature and implementation.

### DIFF
--- a/src/PolyType.Examples/CborSerializer/CborSerializer.cs
+++ b/src/PolyType.Examples/CborSerializer/CborSerializer.cs
@@ -54,13 +54,12 @@ public static partial class CborSerializer
     /// <typeparam name="T">The type for which to build the converter.</typeparam>
     /// <returns>An <see cref="CborConverter{T}"/> instance.</returns>
     /// <exception cref="NotSupportedException">No source generated implementation for <typeparamref name="T"/> was found.</exception>
-    public static CborConverter<T> CreateConverterUsingSourceGen<
-#if NET
-        [DynamicallyAccessedMembers(TypeShapeResolver.ResolveDynamicLinkerRequirements)]
+#if NET8_0
+    [RequiresDynamicCode("Dynamic resolution of IShapeable<T> interface may require dynamic code generation in .NET 8 Native AOT. It is recommended to switch to statically resolved IShapeable<T> APIs or upgrade your app to .NET 9 or later.")]
 #endif
-        T>() =>
+    public static CborConverter<T> CreateConverterUsingSourceGen<T>() =>
 
-        CreateConverter(TypeShapeResolver.ResolveDynamic<T>(throwIfMissing: true)!)!;
+        CreateConverter(TypeShapeResolver.ResolveDynamicOrThrow<T>());
 
     /// <summary>
     /// Serializes a value to a CBOR encoding using the provided converter.

--- a/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.cs
+++ b/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.cs
@@ -47,11 +47,10 @@ public static partial class ConfigurationBinderTS
     /// <typeparam name="T">The type for which to build the binder.</typeparam>
     /// <returns>A configuration binder delegate.</returns>
     /// <exception cref="NotSupportedException">No source generated implementation for <typeparamref name="T"/> was found.</exception>
-    public static Func<IConfiguration, T?> CreateUsingSourceGen<
-#if NET
-        [DynamicallyAccessedMembers(TypeShapeResolver.ResolveDynamicLinkerRequirements)]
+#if NET8_0
+    [RequiresDynamicCode("Dynamic resolution of IShapeable<T> interface may require dynamic code generation in .NET 8 Native AOT. It is recommended to switch to statically resolved IShapeable<T> APIs or upgrade your app to .NET 9 or later.")]
 #endif
-        T>() => Create<T>(TypeShapeResolver.ResolveDynamic<T>(throwIfMissing: true)!);
+    public static Func<IConfiguration, T?> CreateUsingSourceGen<T>() => Create(TypeShapeResolver.ResolveDynamicOrThrow<T>());
 
 #if NET
     /// <summary>

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.cs
@@ -52,13 +52,11 @@ public static partial class JsonSerializerTS
     /// <typeparam name="T">The type for which to build the converter.</typeparam>
     /// <returns>An <see cref="JsonConverter{T}"/> instance.</returns>
     /// <exception cref="NotSupportedException">No source generated implementation for <typeparamref name="T"/> was found.</exception>
-    public static JsonConverter<T> CreateConverterUsingSourceGen<
-#if NET
-        [DynamicallyAccessedMembers(TypeShapeResolver.ResolveDynamicLinkerRequirements)]
+#if NET8_0
+    [RequiresDynamicCode("Dynamic resolution of IShapeable<T> interface may require dynamic code generation in .NET 8 Native AOT. It is recommended to switch to statically resolved IShapeable<T> APIs or upgrade your app to .NET 9 or later.")]
 #endif
-        T>() =>
-
-        CreateConverter(TypeShapeResolver.ResolveDynamic<T>(throwIfMissing: true)!)!;
+    public static JsonConverter<T> CreateConverterUsingSourceGen<T>() =>
+        CreateConverter(TypeShapeResolver.ResolveDynamicOrThrow<T>());
 
     /// <summary>
     /// Creates a JSON marshaling delegate that wraps the specified method shape.

--- a/src/PolyType.TestCases/TestCaseOfT.cs
+++ b/src/PolyType.TestCases/TestCaseOfT.cs
@@ -13,7 +13,7 @@ public sealed record TestCase<T, TProvider>(T? Value) : TestCase<T>
 #if NET
     (Value, TProvider.GetTypeShape()) where TProvider : IShapeable<T>;
 #else
-    (Value, TypeShapeResolver.ResolveDynamic<T, TProvider>(throwIfMissing: true)!);
+    (Value, TypeShapeResolver.ResolveDynamicOrThrow<T, TProvider>());
 #endif
 
 /// <summary>

--- a/src/PolyType/PolyType.csproj
+++ b/src/PolyType/PolyType.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Shared/Helpers/ReflectionHelpers.cs
+++ b/src/Shared/Helpers/ReflectionHelpers.cs
@@ -615,6 +615,7 @@ internal static class ReflectionHelpers
             genericArguments[7].IsTupleType();
     }
 
+    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
     [RequiresDynamicCode(RequiresDynamicCodeMessage)]
     public static Type CreateValueTupleType(Type[] elementTypes)
     {

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
@@ -684,7 +684,7 @@ public static partial class CompilationTests
             #if NET
             shape = TypeShapeResolver.Resolve<MyPoco, Witness>();
             #endif
-            shape = TypeShapeResolver.ResolveDynamic<MyPoco, Witness>(throwIfMissing: true)!;
+            shape = TypeShapeResolver.ResolveDynamicOrThrow<MyPoco, Witness>();
             shape = Witness.GeneratedTypeShapeProvider.GetTypeShapeOrThrow<MyPoco>();
 
             record MyPoco(string[] Values);

--- a/tests/PolyType.SourceGenerator.UnitTests/Verifiers/ReferencesHelper.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/Verifiers/ReferencesHelper.cs
@@ -6,8 +6,10 @@ namespace PolyType.SourceGenerator.UnitTests;
 
 internal class ReferencesHelper
 {
-#if NET
-	internal static ReferenceAssemblies References = ReferenceAssemblies.Net.Net80;
+#if NET9_0
+	internal static ReferenceAssemblies References = ReferenceAssemblies.Net.Net90;
+#elif NET8_0
+    internal static ReferenceAssemblies References = ReferenceAssemblies.Net.Net80;
 #else
     internal static ReferenceAssemblies References = ReferenceAssemblies.NetStandard.NetStandard20
         .WithPackages(ImmutableArray.Create([

--- a/tests/PolyType.Tests.NativeAOT/ResolveDynamicTests.cs
+++ b/tests/PolyType.Tests.NativeAOT/ResolveDynamicTests.cs
@@ -9,6 +9,10 @@ public partial class ResolveDynamicTests
     {
         await Assert.That(TypeShapeResolver.ResolveDynamic<Poco1>()).IsNotNull();
         await Assert.That(TypeShapeResolver.ResolveDynamic<Poco2, Witness>()).IsNotNull();
+
+        await Assert.That(TypeShapeResolver.ResolveDynamic<Struct1>()).IsNotNull();
+        await Assert.That(TypeShapeResolver.ResolveDynamic<Struct2, Witness>()).IsNotNull();
+
         await Assert.That(TypeShapeResolver.ResolveDynamic<NetStandardPoco1>()).IsNotNull();
         await Assert.That(TypeShapeResolver.ResolveDynamic<NetStandardPoco2, Witness>()).IsNotNull();
     }
@@ -18,7 +22,13 @@ public partial class ResolveDynamicTests
 
     public record Poco2;
 
+    [GenerateShape]
+    public partial record Struct1;
+
+    public partial record Struct2;
+
     [GenerateShapeFor<Poco2>]
+    [GenerateShapeFor<Struct2>]
     [GenerateShapeFor<NetStandardPoco1>]
     [GenerateShapeFor<NetStandardPoco2>]
     public partial class Witness;

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -1574,8 +1574,8 @@ public sealed partial class TypeShapeProviderTests_SourceGen() : TypeShapeProvid
         Assert.Null(TypeShapeResolver.ResolveDynamic<object>());
         Assert.Null(TypeShapeResolver.ResolveDynamic<int, object>());
 
-        Assert.Throws<NotSupportedException>(() => TypeShapeResolver.ResolveDynamic<object>(throwIfMissing: true));
-        Assert.Throws<NotSupportedException>(() => TypeShapeResolver.ResolveDynamic<int, object>(throwIfMissing: true));
+        Assert.Throws<NotSupportedException>(() => TypeShapeResolver.ResolveDynamicOrThrow<object>());
+        Assert.Throws<NotSupportedException>(() => TypeShapeResolver.ResolveDynamicOrThrow<int, object>());
     }
 
     [Fact]

--- a/tests/PolyType.Tests/TypeShapeResolverTests.cs
+++ b/tests/PolyType.Tests/TypeShapeResolverTests.cs
@@ -1,0 +1,57 @@
+namespace PolyType.Tests;
+
+public static partial class TypeShapeResolverTests
+{
+    [Fact]
+    public static void ResolveDynamic_ShapeableType_ReturnsExpectedSingleton()
+    {
+        ITypeShape<ResolverShapeable>? s1 = TypeShapeResolver.ResolveDynamic<ResolverShapeable>();
+        ITypeShape<ResolverShapeable>? s2 = TypeShapeResolver.ResolveDynamic<ResolverShapeable>();
+        Assert.NotNull(s1);
+        Assert.Same(s1, s2);
+    }
+
+    [Fact]
+    public static void ResolveDynamic_WithProvider_ReturnsExpectedSingleton()
+    {
+        ITypeShape<ResolverShapeable>? s1 = TypeShapeResolver.ResolveDynamic<ResolverShapeable, ResolverShapeProvider>();
+        ITypeShape<ResolverShapeable>? s2 = TypeShapeResolver.ResolveDynamic<ResolverShapeable, ResolverShapeProvider>();
+        Assert.NotNull(s1);
+        Assert.Same(s1, s2);
+    }
+
+    [Fact]
+    public static void ResolveDynamicOrThrow_ReturnsSameInstance()
+    {
+        ITypeShape<ResolverShapeable> s1 = TypeShapeResolver.ResolveDynamicOrThrow<ResolverShapeable>();
+        ITypeShape<ResolverShapeable> s2 = TypeShapeResolver.ResolveDynamicOrThrow<ResolverShapeable>();
+        Assert.Same(s1, s2);
+    }
+
+    [Fact]
+    public static void ResolveDynamicOrThrow_WithProvider_ReturnsSameInstance()
+    {
+        ITypeShape<ResolverShapeable> s1 = TypeShapeResolver.ResolveDynamicOrThrow<ResolverShapeable, ResolverShapeProvider>();
+        ITypeShape<ResolverShapeable> s2 = TypeShapeResolver.ResolveDynamicOrThrow<ResolverShapeable, ResolverShapeProvider>();
+        Assert.Same(s1, s2);
+    }
+
+    [Fact]
+    public static void ResolveDynamic_ReturnsNullForNonShapeable()
+    {
+        Assert.Null(TypeShapeResolver.ResolveDynamic<Unannotated>());
+        Assert.Null(TypeShapeResolver.ResolveDynamic<Unannotated, ResolverShapeProvider>()); // provider does not expose Unannotated
+        Assert.Throws<NotSupportedException>(() => TypeShapeResolver.ResolveDynamicOrThrow<Unannotated>());
+        Assert.Throws<NotSupportedException>(() => TypeShapeResolver.ResolveDynamicOrThrow<Unannotated, ResolverShapeProvider>());
+    }
+
+    // Shapeable type under test.
+    [GenerateShape]
+    public partial record ResolverShapeable(int X, string Y);
+
+    // Separate provider type generating a shape for ResolverShapeable (used with Resolve<T, TProvider>()).
+    [GenerateShapeFor(typeof(ResolverShapeable))]
+    public partial class ResolverShapeProvider;
+
+    private sealed class Unannotated;
+}


### PR DESCRIPTION
Update the `ResolveDynamic` implementation following guidance from the .NET runtime team. Updates the signature to match the `OrThrow` nomenclature already applied to `TypeShapeProviderExtensions`.