### PR TITLE
Tweak data contract resolution semantics.

### DIFF
--- a/docs/shape-providers.md
+++ b/docs/shape-providers.md
@@ -320,9 +320,11 @@ class PocoWithConstructors
 
 PolyType includes limited support for types using [data contract annotations](https://learn.microsoft.com/dotnet/framework/wcf/feature-details/using-data-contracts).
 
-Types annotated with `DataContractAttribute` will only include member shapes annotated with `DataMemberAttribute`, resolving property shape metadata from the relevant attribute properties where applicable. DataContract types annotated with `KnownTypeAttribute` will be mapped to union shapes following the same rules as `DerivedTypeShapeAttribute`.
+Types annotated with `DataContractAttribute` will only include member shapes annotated with `DataMemberAttribute`, resolving shape information from the attribute where applicable.
+Members annotated with `PropertyShapeAttribute` will also be included, with `PropertyShapeAttribute` taking precedence over `DataMemberAttribute` in case of conflicts.
+Data contract types annotated with `KnownTypeAttribute` will be mapped to union shapes following the same rules as `DerivedTypeShapeAttribute`.
 
-Types not annotated with `DataContractAttribute` will include all public readable properties, ignoring any `DataMemberAttribute` or `KnownTypeAttribute` annotations. Members annotated with `IgnoreDataMemberAttribute` but not with `PropertyShapeAttribute` will be ignored.
+Types not annotated with `DataContractAttribute` ignore `DataMemberAttribute` and `KnownTypeAttribute` annotations, but will honor `IgnoreDataMemberAttribute` annotations if present.
 
 The `EnumMemberAttribute` is supported for enum types, with `EnumMemberShapeAttribute` annotations taking precedence.
 

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -1007,6 +1007,24 @@ public sealed partial class Parser
         propertyName = propertySymbol.Name;
         order = 0;
 
+        if (propertySymbol.GetAttribute(_knownSymbols.PropertyShapeAttribute) is AttributeData propertyAttr)
+        {
+            foreach (KeyValuePair<string, TypedConstant> namedArgument in propertyAttr.NamedArguments)
+            {
+                switch (namedArgument.Key)
+                {
+                    case "Name":
+                        propertyName = (string?)namedArgument.Value.Value ?? propertyName;
+                        break;
+                    case "Order":
+                        order = (int)namedArgument.Value.Value!;
+                        break;
+                }
+            }
+
+            return;
+        }
+
         if (propertySymbol.ContainingType.HasAttribute(_knownSymbols.DataContractAttribute))
         {
             if (propertySymbol.GetAttribute(_knownSymbols.DataMemberAttribute) is AttributeData dataMemberAttr)
@@ -1022,24 +1040,6 @@ public sealed partial class Parser
                             order = (int)namedArgument.Value.Value!;
                             break;
                     }
-                }
-            }
-
-            return;
-        }
-
-        if (propertySymbol.GetAttribute(_knownSymbols.PropertyShapeAttribute) is AttributeData propertyAttr)
-        {
-            foreach (KeyValuePair<string, TypedConstant> namedArgument in propertyAttr.NamedArguments)
-            {
-                switch (namedArgument.Key)
-                {
-                    case "Name":
-                        propertyName = (string?)namedArgument.Value.Value ?? propertyName;
-                        break;
-                    case "Order":
-                        order = (int)namedArgument.Value.Value!;
-                        break;
                 }
             }
         }

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -210,21 +210,6 @@ public sealed partial class Parser : TypeDataModelGenerator
 
     protected override bool IncludeProperty(IPropertySymbol property, out bool includeGetter, out bool includeSetter)
     {
-        if (property.ContainingType.HasAttribute(_knownSymbols.DataContractAttribute))
-        {
-            // If the type is annotated with [DataContract], only include properties with [DataMember].
-            if (!property.HasAttribute(_knownSymbols.DataMemberAttribute))
-            {
-                includeGetter = includeSetter = false;
-                return false;
-            }
-
-            property = property.GetBaseProperty();
-            includeGetter = property.GetMethod is not null;
-            includeSetter = property.SetMethod is not null;
-            return true;
-        }
-
         if (property.GetAttribute(_knownSymbols.PropertyShapeAttribute) is AttributeData propertyAttribute)
         {
             // Ignore properties with the [PropertyShape] attribute set to Ignore = true.
@@ -240,6 +225,21 @@ public sealed partial class Parser : TypeDataModelGenerator
 
             includeGetter = includeSetter = false;
             return false;
+        }
+
+        if (property.ContainingType.HasAttribute(_knownSymbols.DataContractAttribute))
+        {
+            // If the type is annotated with [DataContract], only include properties with [DataMember].
+            if (!property.HasAttribute(_knownSymbols.DataMemberAttribute))
+            {
+                includeGetter = includeSetter = false;
+                return false;
+            }
+
+            property = property.GetBaseProperty();
+            includeGetter = property.GetMethod is not null;
+            includeSetter = property.SetMethod is not null;
+            return true;
         }
 
         if (property.HasAttribute(_knownSymbols.IgnoreDataMemberAttribute))

--- a/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
@@ -338,28 +338,7 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
             int order = 0;
             bool? isRequiredByAttribute = null;
 
-            if (hasDataContractAttribute)
-            {
-                if (attributeProvider.GetCustomAttribute<DataMemberAttribute>() is not { } dataMemberAttr)
-                {
-                    // Always skip members not explicitly annotated with DataMemberAttribute.
-                    return;
-                }
-
-                logicalName = dataMemberAttr.Name;
-                if (dataMemberAttr.Order != 0)
-                {
-                    order = dataMemberAttr.Order;
-                    isOrderSpecified = true;
-                }
-
-                includeNonPublic = true;
-                if (dataMemberAttr.IsRequired)
-                {
-                    isRequiredByAttribute = true;
-                }
-            }
-            else if (attributeProvider.GetCustomAttribute<PropertyShapeAttribute>(inherit: true) is { } propertyShapeAttr)
+            if (attributeProvider.GetCustomAttribute<PropertyShapeAttribute>(inherit: true) is { } propertyShapeAttr)
             {
                 // If the attribute is present, use the value of the Ignore property to determine its inclusion.
                 if (propertyShapeAttr.Ignore)
@@ -378,6 +357,27 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
                 if (propertyShapeAttr.IsRequiredSpecified)
                 {
                     isRequiredByAttribute = propertyShapeAttr.IsRequired;
+                }
+            }
+            else if (hasDataContractAttribute)
+            {
+                if (attributeProvider.GetCustomAttribute<DataMemberAttribute>() is not { } dataMemberAttr)
+                {
+                    // Always skip members not explicitly annotated with DataMemberAttribute.
+                    return;
+                }
+
+                logicalName = dataMemberAttr.Name;
+                if (dataMemberAttr.Order != 0)
+                {
+                    order = dataMemberAttr.Order;
+                    isOrderSpecified = true;
+                }
+
+                includeNonPublic = true;
+                if (dataMemberAttr.IsRequired)
+                {
+                    isRequiredByAttribute = true;
                 }
             }
             else if (attributeProvider.GetCustomAttribute<IgnoreDataMemberAttribute>() is not null)

--- a/tests/PolyType.Tests/DataContractShapeTests.cs
+++ b/tests/PolyType.Tests/DataContractShapeTests.cs
@@ -10,13 +10,15 @@ public abstract partial class DataContractShapeTests(ProviderUnderTest providerU
         var shape = Assert.IsType<IObjectTypeShape>(providerUnderTest.Provider.GetTypeShape(typeof(ContractType)), exactMatch: false);
         Assert.NotNull(shape);
 
-        // Only members explicitly marked with [DataMember] should be included.
-        Assert.Equal(3, shape.Properties.Count);
+        // Only members explicitly marked with [DataMember] or [PropertyShape] should be included.
+        Assert.Equal(5, shape.Properties.Count);
 
         // Orders should follow DataMember.Order
         Assert.Equal("id", shape.Properties[0].Name);
         Assert.Equal("Renamed", shape.Properties[1].Name);
         Assert.Equal("AlsoIncluded", shape.Properties[2].Name);
+        Assert.Equal("ExplicitShape", shape.Properties[3].Name);
+        Assert.Equal("CustomName1", shape.Properties[4].Name);
 
         // Required flag propagated from DataMember(IsRequired=true)
         Assert.True(shape.Constructor!.Parameters.Single(p => p.Name == "id").IsRequired);
@@ -40,14 +42,16 @@ public abstract partial class DataContractShapeTests(ProviderUnderTest providerU
         var shape = Assert.IsType<IObjectTypeShape>(providerUnderTest.Provider.GetTypeShape(typeof(DerivedNonContractType)), exactMatch: false);
         Assert.NotNull(shape);
 
-        // Only members explicitly marked with [DataMember] should be included.
-        Assert.Equal(4, shape.Properties.Count);
+        // Only members explicitly marked with [DataMember] or [PropertyShape] should be included.
+        Assert.Equal(6, shape.Properties.Count);
 
         // Orders should follow DataMember.Order
         Assert.Equal("NewValue", shape.Properties[0].Name);
         Assert.Equal("id", shape.Properties[1].Name);
         Assert.Equal("Renamed", shape.Properties[2].Name);
         Assert.Equal("AlsoIncluded", shape.Properties[3].Name);
+        Assert.Equal("ExplicitShape", shape.Properties[4].Name);
+        Assert.Equal("CustomName1", shape.Properties[5].Name);
 
         // Required flag propagated from DataMember(IsRequired=true)
         Assert.True(shape.Constructor!.Parameters.Single(p => p.Name == "id").IsRequired);
@@ -114,6 +118,10 @@ public abstract partial class DataContractShapeTests(ProviderUnderTest providerU
 
         [PropertyShape(Name = "ExplicitShape", Order = 3)]
         public int ViaPropertyShape { get; set; }
+
+        [PropertyShape(Name = "CustomName1", Order = 100)]
+        [DataMember(Name = "CustomName2", Order = -100)]
+        public int PropertyWithConflictingAnnotation { get; set; }
     }
 
     [GenerateShape]


### PR DESCRIPTION
This tweaks the resolution algorithm such that types annotated with `DataContractAttribute` will be including *both* members annotated with `PropertyShapeAttribute` and members annotated with `DataMemberAttribute` are included. In case of a conflict, `PropertyShapeAttribute` wins and `DataMemberAttribute` arguments are discarded.

Fix #276.