### PR TITLE
Tolerate objects containing properties with duplicate property names in constructor resolution.

### DIFF
--- a/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
@@ -109,16 +109,20 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
             // 2. Maximize the number of parameters that match read-only properties/fields.
             // 3. Minimize the total number of constructor parameters.
 
-            Dictionary<(Type, string), bool> readableMembers = allMembers
-                .Where(member => member.MemberInfo is PropertyInfo { CanRead: true } or FieldInfo)
-                .ToDictionary(
-                    keySelector: member => (member.MemberInfo.GetMemberType(), member.MemberInfo.Name),
-                    elementSelector: member => member.MemberInfo switch
+            Dictionary<(Type, string), bool> readableMembers = new(ReflectionTypeShapeProvider.CtorParameterEqualityComparer);
+            foreach (var member in allMembers)
+            {
+                if (member.MemberInfo is PropertyInfo { CanRead: true } or FieldInfo)
+                {
+                    var key = (member.MemberInfo.GetMemberType(), member.MemberInfo.Name);
+                    readableMembers.TryGetValue(key, out bool isReadOnly);
+                    readableMembers[key] = isReadOnly && member.MemberInfo switch
                     {
                         PropertyInfo prop => !prop.CanWrite,
                         var field => ((FieldInfo)field).IsInitOnly,
-                    },
-                    comparer: ReflectionTypeShapeProvider.CtorParameterEqualityComparer);
+                    };
+                }
+            }
 
             (constructorInfo, parameters) = ctorCandidates
                 .OrderByDescending(ctor =>
@@ -368,7 +372,7 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
                 }
 
                 logicalName = dataMemberAttr.Name;
-                if (dataMemberAttr.Order != 0)
+                if (dataMemberAttr.Order != -1)
                 {
                     order = dataMemberAttr.Order;
                     isOrderSpecified = true;

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.DataContract.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.DataContract.cs
@@ -139,4 +139,35 @@ public static partial class CompilationTests
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
         Assert.Empty(result.Diagnostics);
     }
+
+    [Fact]
+    public static void DataContract_ConflictingMembers()
+    {
+        // Regression test for https://github.com/eiriktsarpalis/PolyType/issues/286
+
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+            using System.IO;
+            using System.Runtime.Serialization;
+
+            [DataContract]
+            [GenerateShape]
+            public partial class StreamContainingClass
+            {
+                [DataMember]
+                private Stream innerStream;
+
+                public StreamContainingClass(Stream innerStream)
+                {
+                    this.innerStream = innerStream;
+                }
+
+                [PropertyShape(Name = "innerStream")]
+                public Stream InnerStream => this.innerStream;
+            }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
+        Assert.Empty(result.Diagnostics);
+    }
 }


### PR DESCRIPTION
Fix https://github.com/eiriktsarpalis/PolyType/issues/286