### PR TITLE
Unify visible member resolution algorithm and disallow conflicting member names.

### DIFF
--- a/src/PolyType.Roslyn/Model/EventDataModel.cs
+++ b/src/PolyType.Roslyn/Model/EventDataModel.cs
@@ -16,10 +16,15 @@ public readonly struct EventDataModel
     /// The event symbol that this model represents.
     /// </summary>
     public required IEventSymbol Event { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the member is ambiguous due to diamond inheritance.
+    /// </summary>
+    public bool IsAmbiguous { get; init; }
 }
 
 /// <summary>
-/// A method data model wrapping an <see cref="IEventSymbol"/>.
+/// An event data model wrapping an <see cref="IEventSymbol"/>.
 /// </summary>
 public readonly struct ResolvedEventSymbol
 {
@@ -32,4 +37,9 @@ public readonly struct ResolvedEventSymbol
     /// Gets a custom name to be applied to the method, if specified.
     /// </summary>
     public string? CustomName { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the member is ambiguous due to diamond inheritance.
+    /// </summary>
+    public bool IsAmbiguous { get; init; }
 }

--- a/src/PolyType.Roslyn/Model/MethodDataModel.cs
+++ b/src/PolyType.Roslyn/Model/MethodDataModel.cs
@@ -36,7 +36,7 @@ public readonly struct MethodDataModel
     /// <summary>
     /// Whether the method is ambiguous due to diamond inheritance.
     /// </summary>
-    public required bool IsDiamondAmbiguous { get; init; }
+    public required bool IsAmbiguous { get; init; }
 }
 
 /// <summary>
@@ -93,5 +93,5 @@ public readonly struct ResolvedMethodSymbol
     /// <summary>
     /// Gets a value indicating whether the method is ambiguous due to diamond inheritance.
     /// </summary>
-    public bool IsDiamondAmbiguous { get; init; }
+    public bool IsAmbiguous { get; init; }
 }

--- a/src/PolyType.Roslyn/Model/PropertyDataModel.cs
+++ b/src/PolyType.Roslyn/Model/PropertyDataModel.cs
@@ -51,6 +51,16 @@ public readonly struct PropertyDataModel
     public string Name => PropertySymbol.Name;
 
     /// <summary>
+    /// A logical name overwriting the underlying name.
+    /// </summary>
+    public string? LogicalName { get; init; }
+
+    /// <summary>
+    /// The declared order of the property or field.
+    /// </summary>
+    public int Order { get; init; }
+
+    /// <summary>
     /// The type exposed by this property.
     /// </summary>
     public ITypeSymbol PropertyType => PropertySymbol switch
@@ -105,6 +115,11 @@ public readonly struct PropertyDataModel
     public bool? IsRequiredByPolicy { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether the member is ambiguous due to diamond inheritance.
+    /// </summary>
+    public bool IsAmbiguous { get; init; }
+
+    /// <summary>
     /// Whether the property is init-only.
     /// </summary>
     public bool IsInitOnly => PropertySymbol switch
@@ -112,4 +127,40 @@ public readonly struct PropertyDataModel
         IPropertySymbol p => p.SetMethod is { IsInitOnly: true },
         _ => false,
     };
+}
+
+/// <summary>
+/// A property data model wrapping an <see cref="IEventSymbol"/>.
+/// </summary>
+public readonly struct ResolvedPropertySymbol
+{
+    /// <summary>
+    /// Gets the resolved property or field symbol.
+    /// </summary>
+    public required ISymbol Symbol { get; init; }
+
+    /// <summary>
+    /// Gets a custom name to be applied to the member, if specified.
+    /// </summary>
+    public string? CustomName { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the getter should be included in the shape.
+    /// </summary>
+    public bool IncludeGetter { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the setter should be included in the shape.
+    /// </summary>
+    public bool IncludeSetter { get; init; }
+
+    /// <summary>
+    /// The declared order of the property or field.
+    /// </summary>
+    public int Order { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the member is ambiguous due to diamond inheritance.
+    /// </summary>
+    public bool IsAmbiguous { get; init; }
 }

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Dictionary.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Dictionary.cs
@@ -98,11 +98,10 @@ public partial class TypeDataModelGenerator
         {
             availableInsertionModes = DictionaryInsertionMode.None;
             bool foundContainsKey = false;
-            var instanceMethods = type.GetAllMembers()
-                .OfType<IMethodSymbol>()
-                .Where(method => method.IsStatic is false && IsAccessibleSymbol(method));
+            var instanceMethods = type.ResolveVisibleMembers<IMethodSymbol>()
+                .Where(method => method.Symbol.IsStatic is false && IsAccessibleSymbol(method.Symbol));
 
-            foreach (var method in instanceMethods)
+            foreach ((var method, _) in instanceMethods)
             {
                 if (method.Parameters is [var p1, var p2] &&
                     SymbolEqualityComparer.Default.Equals(p1.Type, keyType) &&

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enumerable.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enumerable.cs
@@ -159,11 +159,10 @@ public partial class TypeDataModelGenerator
         IMethodSymbol? ResolveAddMethod(ITypeSymbol type, ITypeSymbol elementType, out EnumerableInsertionMode insertionMode)
         {
             insertionMode = EnumerableInsertionMode.None;
-            IMethodSymbol? result = type.GetAllMembers()
-                .OfType<IMethodSymbol>()
+            (IMethodSymbol? result, _) = type.ResolveVisibleMembers<IMethodSymbol>()
                 .FirstOrDefault(method =>
-                    method is { DeclaredAccessibility: Accessibility.Public, IsStatic: false, Name: "Add" or "Enqueue" or "Push", Parameters: [{ Type: ITypeSymbol parameterType }] } &&
-                    SymbolEqualityComparer.Default.Equals(method.Parameters[0].Type, elementType));
+                    method.Symbol is { DeclaredAccessibility: Accessibility.Public, IsStatic: false, Name: "Add" or "Enqueue" or "Push", Parameters: [{ Type: ITypeSymbol parameterType }] } &&
+                    SymbolEqualityComparer.Default.Equals(method.Symbol.Parameters[0].Type, elementType));
 
             if (result is not null)
             {

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Tuple.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Tuple.cs
@@ -41,7 +41,7 @@ public partial class TypeDataModelGenerator
                     return true;
                 }
 
-                PropertyDataModel propertyModel = MapField(element);
+                PropertyDataModel propertyModel = MapField(element, customName: null, order: 0, includeGetter: true, includeSetter: true, isAmbiguous: false);
                 elements.Add(propertyModel);
             }
 
@@ -71,7 +71,7 @@ public partial class TypeDataModelGenerator
                     return true;
                 }
 
-                PropertyDataModel propertyModel = MapProperty(elementProp, includeGetter: true, includeSetter: false);
+                PropertyDataModel propertyModel = MapProperty(elementProp, customName: null, order: 0, includeGetter: true, includeSetter: false, isAmbiguous: false);
                 elements.Add(propertyModel);
             }
 

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.cs
@@ -480,7 +480,7 @@ public partial class TypeDataModelGenerator
             ReturnedValueType = returnType,
             ReturnTypeKind = returnTypeKind,
             Parameters = parameters.ToImmutable(),
-            IsDiamondAmbiguous = resolvedMethod.IsDiamondAmbiguous,
+            IsAmbiguous = resolvedMethod.IsAmbiguous,
         };
 
         return TypeDataModelGenerationStatus.Success;
@@ -575,6 +575,7 @@ public partial class TypeDataModelGenerator
         {
             Name = resolvedEvent.CustomName ?? resolvedEvent.Event.Name,
             Event = resolvedEvent.Event,
+            IsAmbiguous = resolvedEvent.IsAmbiguous,
         };
 
         return status;

--- a/src/PolyType.SourceGenerator/Model/EventShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/EventShapeModel.cs
@@ -8,6 +8,7 @@ public sealed record EventShapeModel
     public required TypeId DeclaringType { get; init; }
     public required bool IsAccessible { get; init; }
     public required bool CanUseUnsafeAccessors { get; init; }
+    public required bool RequiresDisambiguation { get; init; }
     public required bool IsPublic { get; init; }
     public required bool IsStatic { get; init; }
 }

--- a/src/PolyType.SourceGenerator/Model/MethodShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/MethodShapeModel.cs
@@ -15,7 +15,7 @@ public sealed record MethodShapeModel
     public required bool CanUseUnsafeAccessors { get; init; }
     public required bool IsStatic { get; init; }
     public required bool ReturnsByRef { get; init; }
-    public required bool InstanceMethodRequiresCast { get; init; }
+    public required bool RequiresDisambiguation { get; init; }
     public required MethodReturnTypeKind ReturnTypeKind { get; init; }
     public required ImmutableEquatableArray<ParameterShapeModel> Parameters { get; init; }
     public required ArgumentStateType ArgumentStateType { get; init; }

--- a/src/PolyType.SourceGenerator/Model/PropertyShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/PropertyShapeModel.cs
@@ -37,4 +37,6 @@ public sealed record PropertyShapeModel
     public required bool CanUseUnsafeAccessors { get; init; }
 
     public required int Order { get; init; }
+
+    public required bool RequiresDisambiguation { get; init; }
 }

--- a/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
@@ -150,4 +150,16 @@ public sealed partial class Parser
         category: "PolyType.SourceGenerator",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
+
+    internal static DiagnosticDescriptor DuplicateMemberName { get; } = new DiagnosticDescriptor(
+        id: "PT0022",
+        title: "Duplicate member name.",
+        messageFormat: 
+            "Conflicting members named '{0}' were found on type '{1}'. " +
+            "This member will not be included in the generated shape. " +
+            "Consider renaming one of them or disambiguating via the {2} attribute.",
+
+        category: "PolyType.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
 }

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -208,71 +208,59 @@ public sealed partial class Parser : TypeDataModelGenerator
     // Include delegate parameter types into generated shapes.
     protected override bool IncludeDelegateParameters => true;
 
-    protected override bool IncludeProperty(IPropertySymbol property, out bool includeGetter, out bool includeSetter)
+    protected override bool IncludeProperty(IPropertySymbol property, out string? customName, out int order, out bool includeGetter, out bool includeSetter)
     {
-        if (property.GetAttribute(_knownSymbols.PropertyShapeAttribute) is AttributeData propertyAttribute)
+        if (ParsePropertyShapeAttribute(property, out customName, out order, out bool ignore))
         {
-            // Ignore properties with the [PropertyShape] attribute set to Ignore = true.
-            bool includeProperty = !propertyAttribute.TryGetNamedArgument("Ignore", out bool ignoreValue) || !ignoreValue;
-            if (includeProperty)
-            {
-                // Use the signature of the base property to determine shape.
-                property = property.GetBaseProperty();
-                includeGetter = property.GetMethod is not null;
-                includeSetter = property.SetMethod is not null;
-                return true;
-            }
-
-            includeGetter = includeSetter = false;
-            return false;
-        }
-
-        if (property.ContainingType.HasAttribute(_knownSymbols.DataContractAttribute))
-        {
-            // If the type is annotated with [DataContract], only include properties with [DataMember].
-            if (!property.HasAttribute(_knownSymbols.DataMemberAttribute))
+            if (ignore)
             {
                 includeGetter = includeSetter = false;
                 return false;
             }
 
+            // Use the signature of the base property to determine shape.
             property = property.GetBaseProperty();
             includeGetter = property.GetMethod is not null;
             includeSetter = property.SetMethod is not null;
             return true;
         }
 
-        if (property.HasAttribute(_knownSymbols.IgnoreDataMemberAttribute))
-        {
-            // Ignore properties with [IgnoreDataMember] attribute.
-            includeGetter = includeSetter = false;
-            return false;
-        }
-
-        return base.IncludeProperty(property, out includeGetter, out includeSetter);
+        return base.IncludeProperty(property, out customName, out order, out includeGetter, out includeSetter);
     }
 
-    protected override bool IncludeField(IFieldSymbol field)
+    protected override bool IncludeField(IFieldSymbol field, out string? customName, out int order, out bool includeGetter, out bool includeSetter)
     {
-        if (field.ContainingType.HasAttribute(_knownSymbols.DataContractAttribute))
+        if (ParsePropertyShapeAttribute(field, out customName, out order, out bool ignore))
         {
-            // If the type is annotated with [DataContract], only include fields with [DataMember].
-            return field.HasAttribute(_knownSymbols.DataMemberAttribute);
+            if (ignore)
+            {
+                includeGetter = includeSetter = false;
+                return false;
+            }
+
+            includeGetter = true;
+            includeSetter = !field.IsReadOnly;
+            return true;
         }
 
-        if (field.GetAttribute(_knownSymbols.PropertyShapeAttribute) is AttributeData fieldAttribute)
-        {
-            // Ignore fields with the [PropertyShape] attribute set to Ignore = true.
-            return !fieldAttribute.TryGetNamedArgument("Ignore", out bool ignoreValue) || !ignoreValue;
-        }
+        return base.IncludeField(field, out customName, out order, out includeGetter, out includeSetter);
+    }
 
-        if (field.HasAttribute(_knownSymbols.IgnoreDataMemberAttribute))
-        {
-            // Ignore fields with [IgnoreDataMember] attribute.
-            return false;
-        }
+    protected override IEnumerable<ResolvedPropertySymbol> ResolveProperties(ITypeSymbol type)
+    {
+        HashSet<string>? propertyNames = null;
 
-        return base.IncludeField(field);
+        foreach (var resolvedProperty in base.ResolveProperties(type))
+        {
+            string name = resolvedProperty.CustomName ?? resolvedProperty.Symbol.Name;
+            if (!(propertyNames ??= new()).Add(name))
+            {
+                ReportDiagnostic(DuplicateMemberName, resolvedProperty.Symbol.Locations.FirstOrDefault(), name, type.ToDisplayString(), "PropertyShape");
+                continue;
+            }
+
+            yield return resolvedProperty;
+        }
     }
 
     protected override bool? IsRequiredByPolicy(IPropertySymbol member)
@@ -387,11 +375,26 @@ public sealed partial class Parser : TypeDataModelGenerator
 
     protected override IEnumerable<ResolvedMethodSymbol> ResolveMethods(ITypeSymbol type, BindingFlags bindingFlags)
     {
-        foreach ((IMethodSymbol method, bool isAmbiguous) in type.GetAllMethods())
+        if (type is not INamedTypeSymbol namedType)
+        {
+            yield break;
+        }
+
+        HashSet<string>? methodNames = null;
+        foreach ((IMethodSymbol method, bool isAmbiguous) in type.ResolveVisibleMembers<IMethodSymbol>())
         {
             if (IncludeMethod(method, out string? customName))
             {
-                yield return new() { CustomName = customName, MethodSymbol = method, IsDiamondAmbiguous = isAmbiguous };
+                // To account for overloads, method identifiers include the method name and parameter types but not the return type.
+                string name = customName ?? method.Name;
+                string identifier = $"{customName ?? method.Name}({string.Join(", ", method.Parameters.Select(p => p.Type.GetFullyQualifiedName()))})";
+                if (!(methodNames ??= new()).Add(identifier))
+                {
+                    ReportDiagnostic(DuplicateMemberName, method.Locations.FirstOrDefault(), name, type.ToDisplayString(), "MethodShape");
+                    continue;
+                }
+
+                yield return new() { CustomName = customName, MethodSymbol = method, IsAmbiguous = isAmbiguous };
             }
         }
 
@@ -465,11 +468,19 @@ public sealed partial class Parser : TypeDataModelGenerator
             yield break;
         }
 
-        foreach (IEventSymbol eventSymbol in namedType.GetAllEvents())
+        HashSet<string>? eventNames = null;
+        foreach ((IEventSymbol eventSymbol, bool isAmbiguous) in namedType.ResolveVisibleMembers<IEventSymbol>())
         {
             if (IncludeEvent(eventSymbol, out string? customName))
             {
-                yield return new() { CustomName = customName, Event = eventSymbol };
+                string name = customName ?? eventSymbol.Name;
+                if (!(eventNames ??= new()).Add(name))
+                {
+                    ReportDiagnostic(DuplicateMemberName, eventSymbol.Locations.FirstOrDefault(), name, type.ToDisplayString(), "EventShape");
+                    continue;
+                }
+
+                yield return new() { CustomName = customName, Event = eventSymbol, IsAmbiguous = isAmbiguous };
             }
         }
 

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Events.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Events.cs
@@ -66,9 +66,14 @@ internal sealed partial class SourceFormatter
             {
                 { IsStatic: true, IsAccessible: true } => $"{eventModel.DeclaringType.FullyQualifiedName}.{eventModel.UnderlyingMemberName} {op} {handlerExpr}",
                 { IsStatic: true, IsAccessible: false } => $"{GetEventAccessorName(declaringType, eventModel, isAdd)}({handlerExpr})",
-                { IsStatic: false, IsAccessible: true } => $"{objExpr}{suppressSuffix}.{eventModel.UnderlyingMemberName} {op} {handlerExpr}",
+                { IsStatic: false, IsAccessible: true } => $"{ApplyDisambiguation(eventModel, objExpr)}{suppressSuffix}.{eventModel.UnderlyingMemberName} {op} {handlerExpr}",
                 { IsStatic: false, IsAccessible: false } => $"{GetEventAccessorName(declaringType, eventModel, isAdd)}({refPrefix}{objExpr}, {handlerExpr})",
             };
+
+            static string ApplyDisambiguation(EventShapeModel eventModel, string objExpr)
+            {
+                return eventModel.RequiresDisambiguation ? $"(({eventModel.DeclaringType.FullyQualifiedName}?){objExpr})" : $"{objExpr}";
+            }
         }
     }
 

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Methods.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Methods.cs
@@ -158,7 +158,7 @@ internal sealed partial class SourceFormatter
             };
 
             string refPrefix = method.DeclaringType.IsValueType ? "ref " : "";
-            string targetExpr = method.InstanceMethodRequiresCast ? $"(({method.DeclaringType.FullyQualifiedName}){targetVar}!)" : $"{targetVar}!";
+            string targetExpr = method.RequiresDisambiguation ? $"(({method.DeclaringType.FullyQualifiedName}){targetVar}!)" : $"{targetVar}!";
             string invokeExpr = method switch
             {
                 { IsStatic: true, IsAccessible: true } => $"{declaringType.Type.FullyQualifiedName}.{method.UnderlyingMethodName}({parametersExpression})",

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Properties.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Properties.cs
@@ -85,6 +85,11 @@ internal sealed partial class SourceFormatter
                     }
                 }
 
+                if (property.RequiresDisambiguation)
+                {
+                    objParam = $"(({property.DeclaringType.FullyQualifiedName}){objParam})";
+                }
+
                 return $"{objParam}.{RoslynHelpers.EscapeKeywordIdentifier(property.UnderlyingMemberName)}";
             }
 
@@ -105,6 +110,11 @@ internal sealed partial class SourceFormatter
                         string propertySetterAccessorName = GetPropertySetterAccessorName(declaringType, property.UnderlyingMemberName);
                         return $"{propertySetterAccessorName}({refPrefix}{objParam}, {valueParam})";
                     }
+                }
+
+                if (property.RequiresDisambiguation)
+                {
+                    objParam = $"(({property.DeclaringType.FullyQualifiedName}){objParam})";
                 }
 
                 return $"{objParam}.{RoslynHelpers.EscapeKeywordIdentifier(property.UnderlyingMemberName)} = {valueParam}";

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -1595,8 +1595,8 @@ public partial record RecordWith42ConstructorParametersAndRequiredProperties(
     string x29, int x30, bool x31, TimeSpan x32, DateTime x33, int x34, string x35,
     string x36, int x37, bool x38, TimeSpan x39, DateTime x40, int x41, string x42)
 {
-    public required int requiredField;
     public required string RequiredProperty { get; set; }
+    public required int requiredField;
 }
 
 [GenerateShape]
@@ -1608,8 +1608,8 @@ public partial record StructRecordWith42ConstructorParametersAndRequiredProperti
     string x29, int x30, bool x31, TimeSpan x32, DateTime x33, int x34, string x35,
     string x36, int x37, bool x38, TimeSpan x39, DateTime x40, int x41, string x42)
 {
-    public required int requiredField;
     public required string RequiredProperty { get; set; }
+    public required int requiredField;
 }
 
 [GenerateShape]
@@ -1878,10 +1878,10 @@ public partial class WeatherForecastDTO
     public DateTimeOffset Date { get; set; }
     public int TemperatureCelsius { get; set; }
     public string? Summary { get; set; }
-    public string? SummaryField;
     public List<DateTimeOffset>? DatesAvailable { get; set; }
     public Dictionary<string, HighLowTempsDTO>? TemperatureRanges { get; set; }
     public string[]? SummaryWords { get; set; }
+    public string? SummaryField;
 }
 
 public class HighLowTempsDTO
@@ -2195,17 +2195,20 @@ public partial class ClassWithIncludedPrivateMembers
     [JsonInclude, PropertyShape]
     private int PrivateProperty { get; set; }
     [JsonInclude, PropertyShape]
-    private int PrivateField;
-    [JsonInclude, PropertyShape]
     public int PrivateGetter { private get; set; }
     [JsonInclude, PropertyShape]
     public int PrivateSetter { get; private set; }
 
     public required int RequiredProperty { get; set; }
-    public required int RequiredField;
 
     [JsonInclude, JsonPropertyOrder(1), PropertyShape(Order = 1)]
     private int? OptionalProperty { get; init; }
+
+    [JsonInclude, PropertyShape]
+    private int PrivateField;
+
+    public required int RequiredField;
+
     [JsonInclude, JsonPropertyOrder(1), PropertyShape(Order = 1)]
     private int? OptionalField;
 }
@@ -2235,17 +2238,20 @@ public partial struct StructWithIncludedPrivateMembers
     [JsonInclude, PropertyShape]
     private int PrivateProperty { get; set; }
     [JsonInclude, PropertyShape]
-    private int PrivateField;
-    [JsonInclude, PropertyShape]
     public int PrivateGetter { private get; set; }
     [JsonInclude, PropertyShape]
     public int PrivateSetter { get; private set; }
 
     public required int RequiredProperty { get; set; }
-    public required int RequiredField;
 
     [JsonInclude, JsonPropertyOrder(1), PropertyShape(Order = 1)]
     private int? OptionalProperty { get; init; }
+
+    [JsonInclude, PropertyShape]
+    private int PrivateField;
+
+    public required int RequiredField;
+
     [JsonInclude, JsonPropertyOrder(1), PropertyShape(Order = 1)]
     private int? OptionalField;
 }
@@ -3107,6 +3113,7 @@ public interface IBase1WithMethod
 
 public interface IBase2WithMethod
 {
+    [MethodShape(Name = "AddFromBase2")]
     int Add(int x, int y);
 }
 

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.DataContract.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.DataContract.cs
@@ -139,35 +139,4 @@ public static partial class CompilationTests
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
         Assert.Empty(result.Diagnostics);
     }
-
-    [Fact]
-    public static void DataContract_ConflictingMembers()
-    {
-        // Regression test for https://github.com/eiriktsarpalis/PolyType/issues/286
-
-        Compilation compilation = CompilationHelpers.CreateCompilation("""
-            using PolyType;
-            using System.IO;
-            using System.Runtime.Serialization;
-
-            [DataContract]
-            [GenerateShape]
-            public partial class StreamContainingClass
-            {
-                [DataMember]
-                private Stream innerStream;
-
-                public StreamContainingClass(Stream innerStream)
-                {
-                    this.innerStream = innerStream;
-                }
-
-                [PropertyShape(Name = "innerStream")]
-                public Stream InnerStream => this.innerStream;
-            }
-            """);
-
-        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
-        Assert.Empty(result.Diagnostics);
-    }
 }

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.MethodShapes.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.MethodShapes.cs
@@ -420,6 +420,7 @@ public static partial class CompilationTests
 
         public interface IBase2
         {
+            [MethodShape(Name = "DoSomething2")]
             void DoSomething();
         }
 

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.cs
@@ -1511,4 +1511,56 @@ public static partial class CompilationTests
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
         Assert.Empty(result.Diagnostics);
     }
+
+    [Fact]
+    public static void DuplicatePropertyShapeName_DiamondConflict_AttributeDisambiguation_NoWarning()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            interface IPropA { int X { get; set; } }
+            interface IPropB { [PropertyShape(Name = "XB")] int X { get; set; } }
+
+            [GenerateShape]
+            partial interface IPropC : IPropA, IPropB { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void DuplicateMethodShapeName_DiamondConflict_AttributeDisambiguation_NoWarning()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            interface IPropA { int M(); }
+            interface IPropB { [MethodShape(Name = "MB")] int M(); }
+
+            [GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
+            partial interface IPropC : IPropA, IPropB { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void DuplicateEventShapeName_DiamondConflict_AttributeDisambiguation_NoWarning()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+            using System;
+
+            interface IPropA { event Action? E; }
+            interface IPropB { [EventShape(Name = "EB")] event Action? E; }
+
+            [GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]
+            partial interface IPropC : IPropA, IPropB { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
 }

--- a/tests/PolyType.Tests/PolyType.Tests.csproj
+++ b/tests/PolyType.Tests/PolyType.Tests.csproj
@@ -10,6 +10,7 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
     <DefineConstants Condition="'$(OS)' != 'Windows_NT' and '$(TargetFramework)' == 'net472'">MONO</DefineConstants>
+    <NoWarn>$(NoWarn);PT0022</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Makes the following changes

1. Uses a common visible member resolution algorithm used for properties, methods, and events. 
2. Explicitly disallow properties, methods, and events that have conflicting member names. In the reflection provider this results in an exception, whereas in the source gen provider it results in a warning and skipped duplicate members.

Fix #289. Fix #290.

FYI @AArnott this is a breaking change.