### PR TITLE
Tweak multi-provider cache APIs.

### DIFF
--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.cs
@@ -66,7 +66,7 @@ public static partial class JsonSerializerTS
     /// <returns>A JSON marshaling delegate.</returns>
     public static JsonFunc CreateJsonFunc(IMethodShape methodShape, object? target = null)
     {
-        TypeCache scopedCache = s_converterCaches.GetScopedCache(methodShape.DeclaringType.Provider);
+        TypeCache scopedCache = s_converterCaches.GetScopedCache(methodShape.DeclaringType);
         TypeGenerationContext ctx = scopedCache.CreateGenerationContext();
         return (JsonFunc)methodShape.Accept((Builder)ctx.ValueBuilder!, state: target)!;
     }
@@ -80,7 +80,7 @@ public static partial class JsonSerializerTS
     public static JsonEvent CreateJsonEvent(IEventShape eventShape, object? target = null)
     {
         (bool RequireAsync, object? Target) state = (RequireAsync: false, Target: target);
-        TypeCache scopedCache = s_converterCaches.GetScopedCache(eventShape.DeclaringType.Provider);
+        TypeCache scopedCache = s_converterCaches.GetScopedCache(eventShape.DeclaringType);
         TypeGenerationContext ctx = scopedCache.CreateGenerationContext();
         return (JsonEvent)eventShape.Accept((Builder)ctx.ValueBuilder!, state)!;
     }
@@ -94,7 +94,7 @@ public static partial class JsonSerializerTS
     public static AsyncJsonEvent CreateAsyncJsonEvent(IEventShape eventShape, object? target = null)
     {
         (bool RequireAsync, object? Target) state = (RequireAsync: true, Target: target);
-        TypeCache scopedCache = s_converterCaches.GetScopedCache(eventShape.DeclaringType.Provider);
+        TypeCache scopedCache = s_converterCaches.GetScopedCache(eventShape.DeclaringType);
         TypeGenerationContext ctx = scopedCache.CreateGenerationContext();
         return (AsyncJsonEvent)eventShape.Accept((Builder)ctx.ValueBuilder!, state)!;
     }

--- a/src/PolyType.Examples/ObjectMapper/Mapper.cs
+++ b/src/PolyType.Examples/ObjectMapper/Mapper.cs
@@ -35,7 +35,7 @@ public static partial class Mapper
     /// <returns>A mapper delegate.</returns>
     public static Mapper<TSource, TTarget> Create<TSource, TTarget>(ITypeShape<TSource> sourceShape, ITypeShape<TTarget> targetShape)
     {
-        TypeCache providerScopedTypeCache = s_cache.GetScopedCache(sourceShape.Provider);
+        TypeCache providerScopedTypeCache = s_cache.GetScopedCache(sourceShape);
         if (providerScopedTypeCache.TryGetValue(typeof(Mapper<TSource, TTarget>), out object? result))
         {
             return (Mapper<TSource, TTarget>)result!;
@@ -54,7 +54,8 @@ public static partial class Mapper
     /// <returns>A mapper delegate.</returns>
     public static Mapper<TSource, TTarget> Create<TSource, TTarget>(ITypeShapeProvider typeShapeProvider)
     {
-        TypeCache providerScopedTypeCache = s_cache.GetScopedCache(typeShapeProvider);
+        ITypeShape shape = typeShapeProvider.GetTypeShapeOrThrow<TSource>();
+        TypeCache providerScopedTypeCache = s_cache.GetScopedCache(shape);
         if (providerScopedTypeCache.TryGetValue(typeof(Mapper<TSource, TTarget>), out object? result))
         {
             return (Mapper<TSource, TTarget>)result!;

--- a/src/PolyType/Utilities/Caching/MultiProviderTypeCache.cs
+++ b/src/PolyType/Utilities/Caching/MultiProviderTypeCache.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 namespace PolyType.Utilities;
 
 /// <summary>
-/// Stores weakly referenced <see cref="TypeCache"/> instances keyed on <see cref="ITypeShapeProvider"/>.
+/// Stores weakly referenced <see cref="TypeCache"/> instances keyed to a particular <see cref="ITypeShapeProvider"/> instance.
 /// </summary>
 public sealed class MultiProviderTypeCache
 {
@@ -45,25 +45,25 @@ public sealed class MultiProviderTypeCache
     public bool CacheExceptions { get; init; }
 
     /// <summary>
-    /// Gets or creates a cache scoped to the specified <paramref name="typeShapeProvider"/>.
+    /// Gets or creates a cache scoped to the specified <paramref name="typeShape"/> and its <see cref="ITypeShapeProvider"/>.
     /// </summary>
-    /// <param name="typeShapeProvider">The shape provider key.</param>
-    /// <returns>A <see cref="TypeCache"/> scoped to <paramref name="typeShapeProvider"/>.</returns>
-    public TypeCache GetScopedCache(ITypeShapeProvider typeShapeProvider)
+    /// <param name="typeShape">The shape provider key.</param>
+    /// <returns>A <see cref="TypeCache"/> scoped to <paramref name="typeShape"/>.</returns>
+    public TypeCache GetScopedCache(ITypeShape typeShape)
     {
-        Throw.IfNull(typeShapeProvider);
-        return _providerCaches.GetValue(typeShapeProvider, _createProviderCache);
+        Throw.IfNull(typeShape);
+        return _providerCaches.GetValue(typeShape.Provider, _createProviderCache);
     }
 
     /// <summary>
-    /// Gets or adds a value keyed on the type represented by <paramref name="typeShape"/>.
+    /// Gets or adds a value keyed on the type represented by <paramref name="typeShape"/> and its <see cref="ITypeShapeProvider"/>.
     /// </summary>
     /// <param name="typeShape">The type shape representing the key type.</param>
     /// <returns>The final computed value.</returns>
     public object? GetOrAdd(ITypeShape typeShape)
     {
         Throw.IfNull(typeShape);
-        TypeCache cache = GetScopedCache(typeShape.Provider);
+        TypeCache cache = GetScopedCache(typeShape);
         return cache.GetOrAdd(typeShape);
     }
 
@@ -75,7 +75,8 @@ public sealed class MultiProviderTypeCache
     /// <returns>The final computed value.</returns>
     public object? GetOrAdd(Type type, ITypeShapeProvider provider)
     {
-        TypeCache cache = GetScopedCache(provider);
+        ITypeShape typeShape = provider.GetTypeShapeOrThrow(type);
+        TypeCache cache = GetScopedCache(typeShape);
         return cache.GetOrAdd(type);
     }
 }

--- a/tests/PolyType.Tests/CacheTests.cs
+++ b/tests/PolyType.Tests/CacheTests.cs
@@ -311,9 +311,12 @@ public static class CacheTests
     {
         MultiProviderTypeCache cache = new();
 
-        Assert.Same(cache.GetScopedCache(Witness.GeneratedTypeShapeProvider), cache.GetScopedCache(Witness.GeneratedTypeShapeProvider));
-        Assert.Same(cache.GetScopedCache(ReflectionTypeShapeProvider.Default), cache.GetScopedCache(ReflectionTypeShapeProvider.Default));
-        Assert.NotSame(cache.GetScopedCache(Witness.GeneratedTypeShapeProvider), cache.GetScopedCache(ReflectionTypeShapeProvider.Default));
+        ITypeShape sourceGenShape = Witness.GeneratedTypeShapeProvider.GetTypeShapeOrThrow<int>();
+        ITypeShape reflectionShape = ReflectionTypeShapeProvider.Default.GetTypeShapeOrThrow<int>();
+
+        Assert.Same(cache.GetScopedCache(sourceGenShape), cache.GetScopedCache(sourceGenShape));
+        Assert.Same(cache.GetScopedCache(reflectionShape), cache.GetScopedCache(reflectionShape));
+        Assert.NotSame(cache.GetScopedCache(sourceGenShape), cache.GetScopedCache(reflectionShape));
     }
 
     [Fact]
@@ -326,7 +329,8 @@ public static class CacheTests
             ValueBuilderFactory = _ => new IdBuilderFactory(),
         };
 
-        TypeCache sourceGenCache = cache.GetScopedCache(Witness.GeneratedTypeShapeProvider);
+        ITypeShape sourceGenShape = Witness.GeneratedTypeShapeProvider.GetTypeShapeOrThrow<int>();
+        TypeCache sourceGenCache = cache.GetScopedCache(sourceGenShape);
         Assert.Same(Witness.GeneratedTypeShapeProvider, sourceGenCache.Provider);
         Assert.Equal(cache.CacheExceptions, sourceGenCache.CacheExceptions);
         Assert.Same(cache.DelayedValueFactory, sourceGenCache.DelayedValueFactory);


### PR DESCRIPTION
Tweak the `MultiProviderTypeCache` APIs so that localized caches are resolved based on the `ITypeShape.Provider` property.

Fix #305.

FYI @AArnott 