### PR TITLE
Wrap argument state parameters in `StrongBox<T>` to minimize generic instantiations in method visitors

### DIFF
--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Methods.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Methods.cs
@@ -137,7 +137,7 @@ internal sealed partial class SourceFormatter
             };
 
             string requiredParametersMaskFieldName = FormatRequiredParametersMaskFieldName(declaringType, method)!;
-            return $"static () => new {methodArgumentStateFQN}({stateValueExpr}, count: {method.Parameters.Length}, requiredArgumentsMask: {requiredParametersMaskFieldName})";
+            return $"static () => new {methodArgumentStateFQN}(new({stateValueExpr}), count: {method.Parameters.Length}, requiredArgumentsMask: {requiredParametersMaskFieldName})";
             
             static string FormatTupleConstructor(IEnumerable<string> parameters)
                 => $"({string.Join(", ", parameters)})";
@@ -197,8 +197,8 @@ internal sealed partial class SourceFormatter
                 };
                 
                 return isSingleParameter
-                    ? $"{refPrefix}state.Arguments{(requiresSuppression ? "!" : "")}"
-                    : $"{refPrefix}state.Arguments.Item{parameter.Position + 1}{(requiresSuppression ? "!" : "")}";
+                    ? $"{refPrefix}state.Arguments.Value!"
+                    : $"{refPrefix}state.Arguments.Value.Item{parameter.Position + 1}{(requiresSuppression ? "!" : "")}";
             }
         }
 
@@ -265,8 +265,8 @@ internal sealed partial class SourceFormatter
 
                 return method.Parameters.Length switch
                 {
-                    1 => $"state.Arguments{(suppressGetter ? "!" : "")}",
-                    _ => $"state.Arguments.Item{parameter.Position + 1}{(suppressGetter ? "!" : "")}",
+                    1 => $"state.Arguments.Value!",
+                    _ => $"state.Arguments.Value.Item{parameter.Position + 1}{(suppressGetter ? "!" : "")}",
                 };
             }
 
@@ -281,8 +281,8 @@ internal sealed partial class SourceFormatter
                 
                 string assignValueExpr = method.Parameters.Length switch
                 {
-                    1 => $"state.Arguments = value{(suppressSetter ? "!" : "")}",
-                    _ => $"state.Arguments.Item{parameter.Position + 1} = value{(suppressSetter ? "!" : "")}",
+                    1 => $"state.Arguments.Value = value{(suppressSetter ? "!" : "")}",
+                    _ => $"state.Arguments.Value.Item{parameter.Position + 1} = value{(suppressSetter ? "!" : "")}",
                 };
 
                 return $$"""{ {{assignValueExpr}}; state.MarkArgumentSet({{parameter.Position}}); }""";
@@ -312,8 +312,8 @@ internal sealed partial class SourceFormatter
         return method.ArgumentStateType switch
         {
             ArgumentStateType.EmptyArgumentState => $"global::PolyType.SourceGenModel.EmptyArgumentState",
-            ArgumentStateType.SmallArgumentState => $"global::PolyType.SourceGenModel.SmallArgumentState<{typeParameter}>",
-            ArgumentStateType.LargeArgumentState => $"global::PolyType.SourceGenModel.LargeArgumentState<{typeParameter}>",
+            ArgumentStateType.SmallArgumentState => $"global::PolyType.SourceGenModel.SmallArgumentState<global::System.Runtime.CompilerServices.StrongBox<{typeParameter}>>",
+            ArgumentStateType.LargeArgumentState => $"global::PolyType.SourceGenModel.LargeArgumentState<global::System.Runtime.CompilerServices.StrongBox<{typeParameter}>>",
             _ => throw new InvalidOperationException(method.ArgumentStateType.ToString()),
         };
 


### PR DESCRIPTION
This creates a slight regression in the form of a single strong box allocation per argument state instance:

## Main

| Method                         | Mean     | Ratio | Gen0   | Allocated | Alloc Ratio |
|------------------------------- |---------:|------:|-------:|----------:|------------:|
| Deserialize_StjReflection      | 612.2 ns |  1.00 | 0.0420 |    1016 B |        1.00 |
| Deserialize_StjSourceGen       | 576.1 ns |  0.94 | 0.0410 |     992 B |        0.98 |
| Deserialize_PolyTypeSourceGen  | 271.8 ns |  0.44 | 0.0181 |     440 B |        0.43 |

## PR

| Method                         | Mean     | Ratio | Gen0   | Allocated | Alloc Ratio |
|------------------------------- |---------:|------:|-------:|----------:|------------:|
| Deserialize_StjReflection      | 639.7 ns |  1.00 | 0.0420 |    1016 B |        1.00 |
| Deserialize_StjSourceGen       | 574.9 ns |  0.90 | 0.0410 |     992 B |        0.98 |
| Deserialize_PolyTypeSourceGen  | 277.7 ns |  0.43 | 0.0200 |     488 B |        0.48 |