### PR TITLE
fix: prevent  generation for nullable delegate parameters

### DIFF
--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Function.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Function.cs
@@ -176,7 +176,7 @@ internal sealed partial class SourceFormatter
             }
 
             string delegateSignature = string.Join(", ", functionShapeModel.Parameters
-                .Select(parameter => $"{FormatRefPrefix(parameter)}{parameter.ParameterType.FullyQualifiedName}{GetNullableSuffix(parameter)} {parameter.Name}"));
+                .Select(parameter => $"{FormatRefPrefix(parameter)}{FormatDelegateParameterType(parameter)} {parameter.Name}"));
 
             string argumentStateCtorExpr = functionShapeModel.Parameters switch
             {
@@ -199,7 +199,19 @@ internal sealed partial class SourceFormatter
 
             return $$"""static {{innerFuncVar}} => ({{delegateSignature}}) => { {{functionArgumentStateFQN}} {{stateVar}} = {{argumentStateCtorExpr}}; {{tailExpr}}; }""";
 
-            static string GetNullableSuffix(ParameterShapeModel parameter) => parameter.NullableAnnotation is NullableAnnotation.Annotated ? "?" : "";
+            static string FormatDelegateParameterType(ParameterShapeModel parameter)
+            {
+                string parameterType = parameter.ParameterType.FullyQualifiedName;
+                if (parameter.NullableAnnotation is not NullableAnnotation.Annotated)
+                {
+                    return parameterType;
+                }
+
+                return parameterType.Length > 0 && parameterType[^1] == '?'
+                    ? parameterType
+                    : parameterType + "?";
+            }
+
             static string GetSuppressionSuffix(ParameterShapeModel parameter) => parameter.ParameterTypeContainsNullabilityAnnotations ? "!" : "";
         }
 

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.FunctionShapes.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationTests.FunctionShapes.cs
@@ -44,6 +44,23 @@ public static partial class CompilationTests
     }
 
     [Fact]
+    public static void DelegateShapes_NullableBoolParameter_NoErrors()
+    {
+        // Regression test for nullable bool delegate parameters being emitted as bool??.
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            public delegate void BrokenCommand(bool? skipDuplicate = null);
+
+            [GenerateShapeFor(typeof(BrokenCommand))]
+            public partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public static void EventShapes_PublicInstanceAndStatic_NoErrors()
     {
         Compilation compilation = CompilationHelpers.CreateCompilation("""


### PR DESCRIPTION
- Ensure source generation for delegate signatures does not append a second nullable suffix when the type is already nullable (e.g. ).
- Add regression test  to cover nullable bool delegate parameters and prevent recurrence.

Reproducable code:

```
using PolyType;

_ = typeof(CliShapes);

[GenerateShapeFor(typeof(BrokenCommand))]
public partial class CliShapes;

public delegate Task<int> BrokenCommand(bool? skipDuplicate = null);
```