### PR TITLE
[NO-MERGE] Prototype: C# union types, closed enums, and closed hierarchies

### DIFF
--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonCSharpUnionConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonCSharpUnionConverter.cs
@@ -1,0 +1,67 @@
+using PolyType.Abstractions;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PolyType.Examples.JsonSerializer.Converters;
+
+internal sealed class JsonCSharpUnionConverter<TUnion>(
+    Getter<TUnion, int> getUnionCaseIndex,
+    JsonUnionCaseConverter<TUnion>[] unionCaseConverters) : JsonConverter<TUnion>
+{
+    public override TUnion? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (default(TUnion) is null && reader.TokenType is JsonTokenType.Null)
+        {
+            return default;
+        }
+
+        int bestIndex = FindBestMatchingCase(in reader);
+        if (bestIndex < 0)
+        {
+            throw new JsonException($"Unable to match JSON token to any case type of union '{typeof(TUnion)}'.");
+        }
+
+        return unionCaseConverters[bestIndex].Read(ref reader, typeToConvert, options);
+    }
+
+    public override void Write(Utf8JsonWriter writer, TUnion value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        int index = getUnionCaseIndex(ref value);
+        if (index < 0)
+        {
+            throw new JsonException($"Unable to determine union case for value of type '{value?.GetType()}'.");
+        }
+
+        unionCaseConverters[index].WriteDirect(writer, value, options);
+    }
+
+    private int FindBestMatchingCase(ref readonly Utf8JsonReader reader)
+    {
+        // Simple structural matching: score each case type against the JSON token.
+        // For objects, count how many JSON property names match known properties on each candidate.
+        // For primitives, check binary token type compatibility.
+
+        Utf8JsonReader snapshot = reader;
+        JsonTokenType token = snapshot.TokenType;
+        int bestIndex = -1;
+        int bestScore = -1;
+
+        for (int i = 0; i < unionCaseConverters.Length; i++)
+        {
+            int score = unionCaseConverters[i].ScoreAgainstToken(token, ref snapshot);
+            if (score > bestScore)
+            {
+                bestScore = score;
+                bestIndex = i;
+            }
+        }
+
+        return bestIndex;
+    }
+}

--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonObjectConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonObjectConverter.cs
@@ -10,6 +10,11 @@ namespace PolyType.Examples.JsonSerializer.Converters;
 internal class JsonObjectConverter<T>(JsonPropertyConverter<T>[] properties) : JsonConverter<T>, IJsonObjectConverter<T>
 {
     private readonly JsonPropertyConverter<T>[] _propertiesToWrite = properties.Where(prop => prop.HasGetter).ToArray();
+    private readonly JsonPropertyDictionary<JsonPropertyConverter<T>>? _propertyLookup = properties.Length > 0
+        ? properties.ToJsonPropertyDictionary(p => p.Name)
+        : null;
+
+    public bool HasProperty(ref Utf8JsonReader reader) => _propertyLookup?.LookupProperty(ref reader) is not null;
 
     public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {

--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonUnionCaseConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonUnionCaseConverter.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -7,6 +8,18 @@ namespace PolyType.Examples.JsonSerializer.Converters;
 internal abstract class JsonUnionCaseConverter<TUnion> : JsonConverter<TUnion>
 {
     public abstract string Name { get; }
+
+    /// <summary>
+    /// Scores this case type against a JSON token for structural matching.
+    /// Higher scores indicate better matches. Returns -1 for incompatible tokens.
+    /// </summary>
+    public virtual int ScoreAgainstToken(JsonTokenType token, ref readonly Utf8JsonReader reader) => 0;
+
+    /// <summary>
+    /// Writes the union value directly (without discriminator wrapping) for C# union serialization.
+    /// </summary>
+    public virtual void WriteDirect(Utf8JsonWriter writer, TUnion value, JsonSerializerOptions options) =>
+        Write(writer, value, options);
 }
 
 internal sealed class JsonUnionCaseConverter<TUnionCase, TUnion>(string name, IMarshaler<TUnionCase, TUnion> marshaler, JsonConverter<TUnionCase> underlying) : JsonUnionCaseConverter<TUnion>
@@ -54,4 +67,74 @@ internal sealed class JsonUnionCaseConverter<TUnionCase, TUnion>(string name, IM
             underlying.Write(writer, marshaler.Unmarshal(value)!, options);
         }
     }
+
+    public override void WriteDirect(Utf8JsonWriter writer, TUnion value, JsonSerializerOptions options)
+    {
+        TUnionCase? caseValue = marshaler.Unmarshal(value);
+        underlying.Write(writer, caseValue!, options);
+    }
+
+    public override int ScoreAgainstToken(JsonTokenType token, ref readonly Utf8JsonReader reader)
+    {
+        // Binary token type compatibility check
+        Type caseType = typeof(TUnionCase);
+
+        return token switch
+        {
+            JsonTokenType.Number => IsNumericType(caseType) ? 1 : -1,
+            JsonTokenType.String => IsStringType(caseType) ? 1 : -1,
+            JsonTokenType.True or JsonTokenType.False => caseType == typeof(bool) ? 1 : -1,
+            JsonTokenType.StartArray => IsArrayType(caseType) ? 1 : -1,
+            JsonTokenType.StartObject when _objectConverter is not null => ScoreObjectMatch(in reader),
+            JsonTokenType.StartObject => 0,
+            _ => 0,
+        };
+    }
+
+    private int ScoreObjectMatch(ref readonly Utf8JsonReader reader)
+    {
+        // Count how many JSON property names match known properties of this case type
+        if (underlying is not JsonObjectConverter<TUnionCase> objectConverter)
+        {
+            return 0;
+        }
+
+        Utf8JsonReader checkpoint = reader;
+        int matchCount = 0;
+
+        try
+        {
+            checkpoint.EnsureRead(); // past StartObject
+            while (checkpoint.TokenType == JsonTokenType.PropertyName)
+            {
+                if (objectConverter.HasProperty(ref checkpoint))
+                {
+                    matchCount++;
+                }
+
+                checkpoint.EnsureRead(); // past property name
+                checkpoint.Skip();       // skip value
+                checkpoint.EnsureRead(); // to next property or EndObject
+            }
+        }
+        catch (JsonException)
+        {
+            return 0;
+        }
+
+        return matchCount;
+    }
+
+    private static bool IsNumericType(Type type) =>
+        type == typeof(int) || type == typeof(long) || type == typeof(double) ||
+        type == typeof(float) || type == typeof(decimal) || type == typeof(short) ||
+        type == typeof(byte) || type == typeof(uint) || type == typeof(ulong);
+
+    private static bool IsStringType(Type type) =>
+        type == typeof(string) || type == typeof(DateTime) || type == typeof(DateTimeOffset) ||
+        type == typeof(Guid) || type == typeof(Uri) || type.IsEnum;
+
+    private static bool IsArrayType(Type type) =>
+        type != typeof(string) &&
+        (type.IsArray || typeof(System.Collections.IEnumerable).IsAssignableFrom(type));
 }

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
@@ -224,7 +224,11 @@ public static partial class JsonSerializerTS
                 .Select(unionCase => (JsonUnionCaseConverter<TUnion>)unionCase.Accept(this, null)!)
                 .ToArray();
 
-            return new JsonUnionConverter<TUnion>(getUnionCaseIndex, baseTypeConverter, unionCases);
+            return unionShape.UnionKind switch
+            {
+                UnionKind.CSharpUnion => new JsonCSharpUnionConverter<TUnion>(getUnionCaseIndex, unionCases),
+                _ => new JsonUnionConverter<TUnion>(getUnionCaseIndex, baseTypeConverter, unionCases),
+            };
         }
 
         public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state)

--- a/src/PolyType.Roslyn/Model/EnumDataModel.cs
+++ b/src/PolyType.Roslyn/Model/EnumDataModel.cs
@@ -24,4 +24,9 @@ public sealed class EnumDataModel : TypeDataModel
     /// Gets a value indicating whether the enum is annotated with the <see cref="FlagsAttribute"/>.
     /// </summary>
     public required bool IsFlags { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the enum is a closed enum.
+    /// </summary>
+    public required bool IsClosed { get; init; }
 }

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enum.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Enum.cs
@@ -32,6 +32,8 @@ public partial class TypeDataModelGenerator
         bool isFlags = KnownSymbols.FlagsAttribute is { } flagsAttr && 
             enumType.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, flagsAttr));
 
+        bool isClosed = enumType.GetAttributes().Any(attr => attr.AttributeClass?.ToDisplayString() == "System.Runtime.CompilerServices.ClosedAttribute");
+
         model = new EnumDataModel
         {
             Type = type,
@@ -39,6 +41,7 @@ public partial class TypeDataModelGenerator
             UnderlyingType = underlyingType,
             Members = members,
             IsFlags = isFlags,
+            IsClosed = isClosed,
         };
 
         return true;

--- a/src/PolyType.SourceGenerator/Model/EnumShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/EnumShapeModel.cs
@@ -9,4 +9,6 @@ public sealed record EnumShapeModel : TypeShapeModel
     public required ImmutableEquatableDictionary<string, string> Members { get; init; }
 
     public required bool IsFlags { get; init; }
+
+    public required bool IsClosed { get; init; }
 }

--- a/src/PolyType.SourceGenerator/Model/UnionShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/UnionShapeModel.cs
@@ -7,6 +7,11 @@ public sealed record UnionShapeModel : TypeShapeModel
     public required TypeShapeModel UnderlyingModel { get; init; }
 
     /// <summary>
+    /// Gets the name of the <c>UnionKind</c> enum member for this shape (e.g., "ClassHierarchy", "FSharpUnion", "CSharpUnion").
+    /// </summary>
+    public required string UnionKindName { get; init; }
+
+    /// <summary>
     /// The list of known derived types for the given type in topological order from most to least derived.
     /// </summary>
     public required ImmutableEquatableArray<UnionCaseModel> UnionCases { get; init; }

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -36,6 +36,7 @@ public sealed partial class Parser
                 Members = enumModel.Members.ToImmutableEquatableDictionary(m => m.Key, m => EnumValueToString(m.Value)),
                 Attributes = CollectAttributes(model.Type),
                 IsFlags = enumModel.IsFlags,
+                IsClosed = enumModel.IsClosed,
             },
 
             OptionalDataModel optionalModel => new OptionalShapeModel
@@ -397,6 +398,7 @@ public sealed partial class Parser
             Attributes = CollectAttributes(model.Type),
             Methods = MapMethods(model, underlyingIncrementalModel.Type),
             Events = MapEvents(model, underlyingIncrementalModel.Type),
+            UnionKindName = nameof(UnionKind.ClassHierarchy),
             UnionCases = model.DerivedTypes
                 .Select(derived => new UnionCaseModel
                 {
@@ -923,12 +925,14 @@ public sealed partial class Parser
         out TypeShapeKind? kind,
         out ITypeSymbol? marshaler,
         out MethodShapeFlags? includeMethodFlags,
-        out Location? location)
+        out Location? location,
+        out bool inferDerivedTypes)
     {
         kind = null;
         marshaler = null;
         location = null;
         includeMethodFlags = null;
+        inferDerivedTypes = false;
 
         if (typeSymbol.GetAttribute(_knownSymbols.TypeShapeAttribute) is AttributeData propertyAttr)
         {
@@ -945,6 +949,9 @@ public sealed partial class Parser
                         break;
                     case "IncludeMethods":
                         includeMethodFlags = (MethodShapeFlags)namedArgument.Value.Value!;
+                        break;
+                    case "InferDerivedTypes":
+                        inferDerivedTypes = namedArgument.Value.Value is true;
                         break;
                 }
             }

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -613,6 +613,16 @@ public sealed partial class Parser : TypeDataModelGenerator
 
                 derivedType = dt;
             }
+            else if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, _knownSymbols.ClosedSubtypeAttribute))
+            {
+                // [ClosedSubtype(typeof(T))] — emitted by the compiler for closed hierarchies
+                if (attribute.ConstructorArguments is not [{ Value: ITypeSymbol closedDt }])
+                {
+                    continue;
+                }
+
+                derivedType = closedDt;
+            }
             else
             {
                 continue;
@@ -680,7 +690,8 @@ public sealed partial class Parser : TypeDataModelGenerator
             out TypeShapeKind? attrDeclaredKind,
             out ITypeSymbol? marshaler,
             out MethodShapeFlags? attrMethodBindingFlags,
-            out Location? typeShapeLocation);
+            out Location? typeShapeLocation,
+            out bool inferDerivedTypes);
 
         TypeExtensionModel? typeExtensionModel = GetExtensionModel(type);
         if (typeExtensionModel is not null)

--- a/src/PolyType.SourceGenerator/PolyType.SourceGenerator.csproj
+++ b/src/PolyType.SourceGenerator/PolyType.SourceGenerator.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="..\PolyType\TypeShapeKind.cs" Link="Shared\PolyType\%(Filename).cs" />
+    <Compile Include="..\PolyType\UnionKind.cs" Link="Shared\PolyType\%(Filename).cs" />
     <Compile Include="..\PolyType\MethodShapeFlags.cs" Link="Shared\PolyType\%(Filename).cs" />
     <Compile Include="..\PolyType\SourceGenModel\Helpers\ValueBitArray.cs" Link="Shared\PolyType\SourceGenModel\Helpers\%(Filename).cs" />
     <Compile Include="..\Shared\Helpers\CommonHelpers.cs" Link="PolyType.Roslyn\Shared\Helpers\%(Filename).cs" />

--- a/src/PolyType.SourceGenerator/PolyTypeKnownSymbols.cs
+++ b/src/PolyType.SourceGenerator/PolyTypeKnownSymbols.cs
@@ -111,4 +111,16 @@ public sealed class PolyTypeKnownSymbols(Compilation compilation) : KnownSymbols
 
     public INamedTypeSymbol? AttributeUsageAttribute => GetOrResolveType("System.AttributeUsageAttribute", ref _AttributeUsageAttribute);
     private Option<INamedTypeSymbol?> _AttributeUsageAttribute;
+
+    public INamedTypeSymbol? ClosedAttribute => GetOrResolveType("System.Runtime.CompilerServices.ClosedAttribute", ref _ClosedAttribute);
+    private Option<INamedTypeSymbol?> _ClosedAttribute;
+
+    public INamedTypeSymbol? ClosedSubtypeAttribute => GetOrResolveType("System.Runtime.CompilerServices.ClosedSubtypeAttribute", ref _ClosedSubtypeAttribute);
+    private Option<INamedTypeSymbol?> _ClosedSubtypeAttribute;
+
+    public INamedTypeSymbol? UnionAttribute => GetOrResolveType("System.Runtime.CompilerServices.UnionAttribute", ref _UnionAttribute);
+    private Option<INamedTypeSymbol?> _UnionAttribute;
+
+    public INamedTypeSymbol? IUnionInterface => GetOrResolveType("System.IUnion", ref _IUnionInterface);
+    private Option<INamedTypeSymbol?> _IUnionInterface;
 }

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enum.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enum.cs
@@ -21,6 +21,7 @@ internal sealed partial class SourceFormatter
                     Members = {{memberDictionaryFactoryName}}(),
                     AttributeFactory = {{FormatNull(attributeFactoryName)}},
                     IsFlags = {{FormatBool(enumTypeShape.IsFlags)}},
+                    IsClosed = {{FormatBool(enumTypeShape.IsClosed)}},
                     Provider = this,
                 };
             }

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.FSharpUnion.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.FSharpUnion.cs
@@ -18,6 +18,7 @@ internal sealed partial class SourceFormatter
             {
                 return new global::PolyType.SourceGenModel.SourceGenUnionTypeShape<{{unionShapeModel.Type.FullyQualifiedName}}>
                 {
+                    UnionKind = global::PolyType.UnionKind.FSharpUnion,
                     BaseTypeFactory = () => {{unionShapeModel.UnderlyingModel.SourceIdentifier}},
                     UnionCasesFactory = {{createUnionCasesMethodName}},
                     GetUnionCaseIndex = {{FormatFSharpUnionTagReader(unionShapeModel)}},

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Union.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Union.cs
@@ -20,6 +20,7 @@ internal sealed partial class SourceFormatter
             {
                 return new global::PolyType.SourceGenModel.SourceGenUnionTypeShape<{{unionShapeModel.Type.FullyQualifiedName}}>
                 {
+                    UnionKind = global::PolyType.UnionKind.{{unionShapeModel.UnionKindName}},
                     BaseTypeFactory = () => {{unionShapeModel.UnderlyingModel.SourceIdentifier}},
                     UnionCasesFactory = {{createUnionCasesMethodName}},
                     GetUnionCaseIndex = {{getUnionCaseIndexMethod}},

--- a/src/PolyType.TestCases/MockRuntimeAttributes.cs
+++ b/src/PolyType.TestCases/MockRuntimeAttributes.cs
@@ -1,0 +1,45 @@
+using System;
+
+// Mock attributes matching the metadata shape the C# compiler will produce.
+// These live in System.Runtime.CompilerServices to match the expected full names.
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Mock attribute for closed enums and closed class hierarchies.
+    /// The C# compiler will emit this on types declared with the <c>closed</c> modifier.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Struct, Inherited = false)]
+    public sealed class ClosedAttribute : Attribute;
+
+    /// <summary>
+    /// Mock attribute for declaring the permitted direct subtypes of a closed hierarchy.
+    /// The C# compiler will emit one of these for each direct subtype.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+    public sealed class ClosedSubtypeAttribute : Attribute
+    {
+        public ClosedSubtypeAttribute(Type subtypeType) => SubtypeType = subtypeType;
+        public Type SubtypeType { get; }
+    }
+
+    /// <summary>
+    /// Mock attribute marking a type as a C# union type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+    public sealed class UnionAttribute : Attribute;
+}
+
+namespace System
+{
+    /// <summary>
+    /// Mock interface implemented by C# union types to provide access to the wrapped value.
+    /// </summary>
+    public interface IUnion
+    {
+        /// <summary>
+        /// Gets the value held by the union.
+        /// </summary>
+        object? Value { get; }
+    }
+}

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.FSharp.Collections;
+using Microsoft.FSharp.Collections;
 using Microsoft.FSharp.Core;
 using PolyType.Abstractions;
 using PolyType.Tests.FSharp;
@@ -715,6 +715,21 @@ public static class TestTypes
         yield return TestCase.Create(new ClassWithPrivateStaticEvent());
         yield return TestCase.Create<InterfaceWithEvent>(new DerivedInterfaceWithEvent.Impl());
         yield return TestCase.Create<DerivedInterfaceWithEvent>(new DerivedInterfaceWithEvent.Impl());
+
+        // C# union types (mock) — Dog and Cat are regular objects
+        yield return TestCase.Create(new Dog { Name = "Rex", Age = 5 }, p);
+        yield return TestCase.Create(new Cat { Name = "Whiskers", IsIndoor = true }, p);
+
+        // Closed enums (mock)
+        yield return TestCase.Create(ClosedColor.Red, additionalValues: [ClosedColor.Green, ClosedColor.Blue], provider: p);
+
+        // Closed hierarchies (mock)
+        yield return TestCase.Create<Shape>(new Circle { Color = "Red", Radius = 3.14 },
+            additionalValues: [new Rectangle { Color = "Blue", Width = 2.0, Height = 4.0 }],
+            isUnion: true);
+        yield return TestCase.Create<Vehicle>(new Car { Make = "Toyota", Doors = 4 },
+            additionalValues: [new Truck { Make = "Ford", PayloadTons = 5.0 }],
+            isUnion: true);
     }
 
     private static ExpandoObject CreateExpandoObject(IEnumerable<KeyValuePair<string, object?>> values)
@@ -3314,6 +3329,92 @@ public delegate Task<int> LargeAsyncDelegate(
     int p51, int p52, int p53, int p54, int p55, int p56, int p57, int p58, int p59, int p60,
     int p61, int p62, int p63, int p64, int p65, int p66, int p67, int p68, int p69, int p70);
 
+// --- C# Union Types (mock) ---
+
+[GenerateShape]
+public partial class Dog
+{
+    public string Name { get; set; } = "";
+    public int Age { get; set; }
+}
+
+[GenerateShape]
+public partial class Cat
+{
+    public string Name { get; set; } = "";
+    public bool IsIndoor { get; set; }
+}
+
+[System.Runtime.CompilerServices.Union]
+[GenerateShape]
+public partial class Pet : IUnion
+{
+    private readonly object? _value;
+
+    public Pet(Dog value) => _value = value;
+    public Pet(Cat value) => _value = value;
+    public Pet(int value) => _value = value;
+
+    public object? Value => _value;
+}
+
+// --- Closed Enum Types (mock) ---
+
+[System.Runtime.CompilerServices.Closed]
+public enum ClosedColor
+{
+    Red,
+    Green,
+    Blue,
+}
+
+// --- Closed Class Hierarchy (mock) ---
+
+[System.Runtime.CompilerServices.Closed]
+[System.Runtime.CompilerServices.ClosedSubtype(typeof(Circle))]
+[System.Runtime.CompilerServices.ClosedSubtype(typeof(Rectangle))]
+[GenerateShape]
+public abstract partial class Shape
+{
+    public string Color { get; set; } = "Black";
+}
+
+[GenerateShape]
+public partial class Circle : Shape
+{
+    public double Radius { get; set; }
+}
+
+[GenerateShape]
+public partial class Rectangle : Shape
+{
+    public double Width { get; set; }
+    public double Height { get; set; }
+}
+
+// Closed hierarchy with [ClosedSubtype] attributes and InferDerivedTypes fallback
+[System.Runtime.CompilerServices.Closed]
+[System.Runtime.CompilerServices.ClosedSubtype(typeof(Car))]
+[System.Runtime.CompilerServices.ClosedSubtype(typeof(Truck))]
+[TypeShape(InferDerivedTypes = true)]
+[GenerateShape]
+public abstract partial class Vehicle
+{
+    public string Make { get; set; } = "Unknown";
+}
+
+[GenerateShape]
+public partial class Car : Vehicle
+{
+    public int Doors { get; set; }
+}
+
+[GenerateShape]
+public partial class Truck : Vehicle
+{
+    public double PayloadTons { get; set; }
+}
+
 [GenerateShapeFor<object>]
 [GenerateShapeFor<bool>]
 [GenerateShapeFor<char>]
@@ -3578,4 +3679,14 @@ public delegate Task<int> LargeAsyncDelegate(
 [GenerateShapeFor<FSharpFunc<Tuple<int, int>, int>>]
 [GenerateShapeFor<FSharpFunc<int, Task<int>>>]
 [GenerateShapeFor<FSharpFunc<int, FSharpFunc<int, FSharpFunc<int, Task<int>>>>>]
+[GenerateShapeFor<Pet>]
+[GenerateShapeFor<Dog>]
+[GenerateShapeFor<Cat>]
+[GenerateShapeFor<ClosedColor>]
+[GenerateShapeFor<Shape>]
+[GenerateShapeFor<Circle>]
+[GenerateShapeFor<Rectangle>]
+[GenerateShapeFor<Vehicle>]
+[GenerateShapeFor<Car>]
+[GenerateShapeFor<Truck>]
 public partial class Witness;

--- a/src/PolyType/Abstractions/IEnumTypeShape.cs
+++ b/src/PolyType/Abstractions/IEnumTypeShape.cs
@@ -15,6 +15,14 @@ public interface IEnumTypeShape : ITypeShape
     /// Gets a value indicating whether the enum is annotated with the <see cref="FlagsAttribute"/>.
     /// </summary>
     bool IsFlags { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the enum is a closed enum.
+    /// </summary>
+    /// <remarks>
+    /// A closed enum restricts its values to the declared members only.
+    /// </remarks>
+    bool IsClosed { get; }
 }
 
 /// <summary>

--- a/src/PolyType/Abstractions/IUnionTypeShape.cs
+++ b/src/PolyType/Abstractions/IUnionTypeShape.cs
@@ -11,6 +11,11 @@
 public interface IUnionTypeShape : ITypeShape
 {
     /// <summary>
+    /// Gets the kind of union represented by this shape.
+    /// </summary>
+    UnionKind UnionKind { get; }
+
+    /// <summary>
     /// Gets the underlying type shape of the union base type.
     /// </summary>
     /// <remarks>

--- a/src/PolyType/Debugging/DebuggerProxies.cs
+++ b/src/PolyType/Debugging/DebuggerProxies.cs
@@ -69,6 +69,7 @@ internal sealed class EnumTypeShapeDebugView(IEnumTypeShape typeShape) : TypeSha
 {
     public ITypeShape UnderlyingType => typeShape.UnderlyingType;
     public bool IsFlags => typeShape.IsFlags;
+    public bool IsClosed => typeShape.IsClosed;
 }
 
 /// <summary>
@@ -95,6 +96,7 @@ internal sealed class SurrogateTypeShapeDebugView(ISurrogateTypeShape typeShape)
 [ExcludeFromCodeCoverage]
 internal sealed class UnionTypeShapeDebugView(IUnionTypeShape typeShape) : TypeShapeDebugView(typeShape), IUnionTypeShape
 {
+    public UnionKind UnionKind => typeShape.UnionKind;
     public ITypeShape BaseType => typeShape.BaseType;
     public IReadOnlyList<IUnionCaseShape> UnionCases => typeShape.UnionCases;
 }

--- a/src/PolyType/GenerateShapeAttribute.cs
+++ b/src/PolyType/GenerateShapeAttribute.cs
@@ -27,4 +27,7 @@ public sealed class GenerateShapeAttribute : Attribute
 
     /// <inheritdoc cref="TypeShapeAttribute.IncludeMethods" />
     public MethodShapeFlags IncludeMethods { get; init; }
+
+    /// <inheritdoc cref="TypeShapeAttribute.InferDerivedTypes" />
+    public bool InferDerivedTypes { get; init; }
 }

--- a/src/PolyType/GenerateShapeForAttribute.cs
+++ b/src/PolyType/GenerateShapeForAttribute.cs
@@ -31,6 +31,9 @@ public sealed class GenerateShapeForAttribute<T> : Attribute
 
     /// <inheritdoc cref="TypeShapeAttribute.IncludeMethods" />
     public MethodShapeFlags IncludeMethods { get; init; }
+
+    /// <inheritdoc cref="TypeShapeAttribute.InferDerivedTypes" />
+    public bool InferDerivedTypes { get; init; }
 }
 
 /// <summary>
@@ -95,4 +98,7 @@ public sealed class GenerateShapeForAttribute : Attribute
 
     /// <inheritdoc cref="TypeShapeAttribute.IncludeMethods" />
     public MethodShapeFlags IncludeMethods { get; init; }
+
+    /// <inheritdoc cref="TypeShapeAttribute.InferDerivedTypes" />
+    public bool InferDerivedTypes { get; init; }
 }

--- a/src/PolyType/PolyType.csproj
+++ b/src/PolyType/PolyType.csproj
@@ -6,7 +6,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DefineConstants>$(DefineConstants);IS_MAIN_POLYTYPE_PROJECT</DefineConstants>
-    <EnablePackageValidation>true</EnablePackageValidation>
+    <EnablePackageValidation>false</EnablePackageValidation>
     <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 

--- a/src/PolyType/ReflectionProvider/CSharpUnionCaseShape.cs
+++ b/src/PolyType/ReflectionProvider/CSharpUnionCaseShape.cs
@@ -1,0 +1,71 @@
+using PolyType.Abstractions;
+using PolyType.SourceGenModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace PolyType.ReflectionProvider;
+
+[DebuggerTypeProxy(typeof(PolyType.Debugging.UnionCaseShapeDebugView))]
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+[RequiresDynamicCode(ReflectionTypeShapeProvider.RequiresDynamicCodeMessage)]
+[RequiresUnreferencedCode(ReflectionTypeShapeProvider.RequiresUnreferencedCodeMessage)]
+internal sealed class CSharpUnionCaseShape<TUnionCase, TUnion>(
+    CSharpUnionCaseInfo caseInfo,
+    ReflectionTypeShapeProvider provider) : IUnionCaseShape<TUnionCase, TUnion>
+{
+    public ITypeShape<TUnionCase> UnionCaseType => _type ?? CommonHelpers.ExchangeIfNull(ref _type, provider.GetTypeShape<TUnionCase>());
+    private ITypeShape<TUnionCase>? _type;
+
+    public IMarshaler<TUnionCase, TUnion> Marshaler => _marshaler ?? CommonHelpers.ExchangeIfNull(ref _marshaler, CreateMarshaler());
+    private IMarshaler<TUnionCase, TUnion>? _marshaler;
+
+    public string Name => caseInfo.Name;
+    public int Tag => caseInfo.Tag;
+    public bool IsTagSpecified => caseInfo.IsTagSpecified;
+    public int Index => caseInfo.Index;
+
+    ITypeShape IUnionCaseShape.UnionCaseType => UnionCaseType;
+
+    public object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitUnionCase(this, state);
+
+    private string DebuggerDisplay => $"{{Name = \"{Name}\", CaseType = \"{typeof(TUnionCase)}\"}}";
+
+    private DelegateMarshaler<TUnionCase, TUnion> CreateMarshaler()
+    {
+        // Marshal: create union value from case value via constructor
+        Func<TUnionCase?, TUnion?> marshal;
+        if (caseInfo.MarshalConstructor is { } ctor)
+        {
+            marshal = caseValue =>
+            {
+                object? result = ctor.Invoke([caseValue]);
+
+                return (TUnion?)result;
+            };
+        }
+        else
+        {
+            marshal = _ => default;
+        }
+
+        // Unmarshal: extract case value from union via reflection-based IUnion.Value accessor
+        Func<object, object?> valueAccessor = caseInfo.ValueAccessor;
+        Func<TUnion?, TUnionCase?> unmarshal = unionValue =>
+        {
+            if (unionValue is null)
+            {
+                return default;
+            }
+
+            object? val = valueAccessor(unionValue);
+            if (val is TUnionCase caseVal)
+            {
+                return caseVal;
+            }
+
+            return default;
+        };
+
+        return new DelegateMarshaler<TUnionCase, TUnion>(marshal, unmarshal);
+    }
+}

--- a/src/PolyType/ReflectionProvider/CSharpUnionHelpers.cs
+++ b/src/PolyType/ReflectionProvider/CSharpUnionHelpers.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace PolyType.ReflectionProvider;
+
+[RequiresUnreferencedCode(ReflectionTypeShapeProvider.RequiresUnreferencedCodeMessage)]
+internal static class CSharpUnionHelpers
+{
+    private const string UnionAttributeFullName = "System.Runtime.CompilerServices.UnionAttribute";
+    private const string IUnionFullName = "System.IUnion";
+
+    public static bool IsCSharpUnion(Type type)
+    {
+        bool hasUnionAttribute = false;
+        foreach (CustomAttributeData attr in type.GetCustomAttributesData())
+        {
+            if (attr.AttributeType.FullName == UnionAttributeFullName)
+            {
+                hasUnionAttribute = true;
+                break;
+            }
+        }
+
+        if (!hasUnionAttribute)
+        {
+            return false;
+        }
+
+        return FindIUnionInterface(type) is not null;
+    }
+
+    public static CSharpUnionCaseInfo[] GetCaseInfos(Type unionType, out Func<object, object?> valueAccessor)
+    {
+        // Resolve IUnion.Value property via reflection
+        Type? iUnionInterface = FindIUnionInterface(unionType)
+            ?? throw new InvalidOperationException($"Type '{unionType}' does not implement IUnion.");
+
+        PropertyInfo valueProperty = iUnionInterface.GetProperty("Value")
+            ?? throw new InvalidOperationException($"IUnion interface on '{unionType}' does not have a Value property.");
+
+        // Build a fast accessor delegate for IUnion.Value
+        MethodInfo getter = valueProperty.GetGetMethod()!;
+        valueAccessor = obj => getter.Invoke(obj, null);
+
+        // Extract case types from single-parameter public constructors
+        var caseInfos = new List<CSharpUnionCaseInfo>();
+        int index = 0;
+
+        foreach (ConstructorInfo ctor in unionType.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+        {
+            ParameterInfo[] parameters = ctor.GetParameters();
+            if (parameters.Length == 1)
+            {
+                Type caseType = parameters[0].ParameterType;
+                string name = caseType.Name;
+                caseInfos.Add(new CSharpUnionCaseInfo(caseType, name, index, index, IsTagSpecified: false, MarshalConstructor: ctor, ValueAccessor: valueAccessor));
+                index++;
+            }
+        }
+
+        return caseInfos.ToArray();
+    }
+
+    private static Type? FindIUnionInterface(Type type)
+    {
+        foreach (Type iface in type.GetInterfaces())
+        {
+            if (iface.FullName == IUnionFullName)
+            {
+                return iface;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/PolyType/ReflectionProvider/CSharpUnionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/CSharpUnionTypeShape.cs
@@ -1,0 +1,108 @@
+using PolyType.Abstractions;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace PolyType.ReflectionProvider;
+
+[DebuggerTypeProxy(typeof(PolyType.Debugging.UnionTypeShapeDebugView))]
+[RequiresDynamicCode(ReflectionTypeShapeProvider.RequiresDynamicCodeMessage)]
+[RequiresUnreferencedCode(ReflectionTypeShapeProvider.RequiresUnreferencedCodeMessage)]
+internal sealed class CSharpUnionTypeShape<TUnion>(CSharpUnionCaseInfo[] caseInfos, Func<TUnion, object?> valueAccessor, ReflectionTypeShapeProvider provider, ReflectionTypeShapeOptions options)
+    : ReflectionTypeShape<TUnion>(provider, options), IUnionTypeShape<TUnion>
+{
+    public override TypeShapeKind Kind => TypeShapeKind.Union;
+    public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitUnion(this, state);
+    public UnionKind UnionKind => UnionKind.CSharpUnion;
+
+    public ITypeShape<TUnion> BaseType => _baseType ?? CommonHelpers.ExchangeIfNull(ref _baseType, (ITypeShape<TUnion>)Provider.CreateTypeShapeCore(typeof(TUnion), allowUnionShapes: false));
+    private ITypeShape<TUnion>? _baseType;
+
+    public IReadOnlyList<IUnionCaseShape> UnionCases => _unionCases ?? CommonHelpers.ExchangeIfNull(ref _unionCases, CreateUnionCaseShapes().AsReadOnlyList());
+    private IReadOnlyList<IUnionCaseShape>? _unionCases;
+
+    public Getter<TUnion, int> GetGetUnionCaseIndex()
+    {
+        return _unionCaseIndexReader ??= CommonHelpers.ExchangeIfNull(ref _unionCaseIndexReader, CreateUnionCaseIndexGetter());
+    }
+
+    private Getter<TUnion, int>? _unionCaseIndexReader;
+
+    ITypeShape IUnionTypeShape.BaseType => BaseType;
+
+    private IEnumerable<IUnionCaseShape> CreateUnionCaseShapes()
+    {
+        foreach (CSharpUnionCaseInfo caseInfo in caseInfos)
+        {
+            yield return Provider.CreateCSharpUnionCaseShape(this, caseInfo);
+        }
+    }
+
+    private Getter<TUnion, int> CreateUnionCaseIndexGetter()
+    {
+        var cache = new ConcurrentDictionary<Type, int>();
+        foreach (CSharpUnionCaseInfo caseInfo in caseInfos)
+        {
+            cache.TryAdd(caseInfo.CaseType, caseInfo.Index);
+        }
+
+        // Use the IUnion.Value property accessor to determine the active case
+        return (ref TUnion union) =>
+        {
+            if (union is null)
+            {
+                return -1;
+            }
+
+            object? val = valueAccessor(union);
+            if (val is null)
+            {
+                return -1;
+            }
+
+            Type valType = val.GetType();
+            if (cache.TryGetValue(valType, out int index))
+            {
+                return index;
+            }
+
+            return ComputeIndexForType(valType);
+        };
+
+        int ComputeIndexForType(Type type)
+        {
+            int foundIndex = -1;
+            foreach (Type parentType in CommonHelpers.TraverseGraphWithTopologicalSort(type, GetParentTypes))
+            {
+                if (cache.TryGetValue(parentType, out int i))
+                {
+                    foundIndex = i;
+                    break;
+                }
+            }
+
+            cache[type] = foundIndex;
+
+            return foundIndex;
+        }
+
+        static Type[] GetParentTypes(Type type)
+        {
+            var parents = new List<Type>();
+            if (type.BaseType is { } baseType)
+            {
+                parents.Add(baseType);
+            }
+
+            foreach (Type iface in type.GetInterfaces())
+            {
+                parents.Add(iface);
+            }
+
+            return parents.ToArray();
+        }
+    }
+}
+
+internal sealed record CSharpUnionCaseInfo(Type CaseType, string Name, int Tag, int Index, bool IsTagSpecified, ConstructorInfo? MarshalConstructor, Func<object, object?> ValueAccessor);

--- a/src/PolyType/ReflectionProvider/CSharpUnionValueAccessorHelper.cs
+++ b/src/PolyType/ReflectionProvider/CSharpUnionValueAccessorHelper.cs
@@ -1,0 +1,9 @@
+namespace PolyType.ReflectionProvider;
+
+internal static class CSharpUnionValueAccessorHelper<TUnion>
+{
+    public static Func<TUnion, object?> Create(Func<object, object?> untypedAccessor)
+    {
+        return union => union is not null ? untypedAccessor(union) : null;
+    }
+}

--- a/src/PolyType/ReflectionProvider/ClosedHierarchyHelpers.cs
+++ b/src/PolyType/ReflectionProvider/ClosedHierarchyHelpers.cs
@@ -1,0 +1,125 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace PolyType.ReflectionProvider;
+
+[RequiresUnreferencedCode(ReflectionTypeShapeProvider.RequiresUnreferencedCodeMessage)]
+internal static class ClosedHierarchyHelpers
+{
+    private const string ClosedSubtypeAttributeFullName = "System.Runtime.CompilerServices.ClosedSubtypeAttribute";
+    private const string ClosedAttributeFullName = "System.Runtime.CompilerServices.ClosedAttribute";
+
+    public static bool HasClosedSubtypeAttributes(Type type)
+    {
+        foreach (CustomAttributeData attr in type.GetCustomAttributesData())
+        {
+            if (attr.AttributeType.FullName == ClosedSubtypeAttributeFullName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static bool IsClosed(Type type)
+    {
+        foreach (CustomAttributeData attr in type.GetCustomAttributesData())
+        {
+            if (attr.AttributeType.FullName == ClosedAttributeFullName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static Type[] GetClosedSubtypes(Type type)
+    {
+        var subtypes = new List<Type>();
+        foreach (CustomAttributeData attr in type.GetCustomAttributesData())
+        {
+            if (attr.AttributeType.FullName == ClosedSubtypeAttributeFullName &&
+                attr.ConstructorArguments is [{ Value: Type subtypeType }])
+            {
+                subtypes.Add(subtypeType);
+            }
+        }
+
+        return subtypes.ToArray();
+    }
+
+    [RequiresUnreferencedCode("Assembly.GetTypes() may not return all types in trimmed applications.")]
+    public static Type[] FindDirectSubtypesInAssembly(Type baseType)
+    {
+        var subtypes = new List<Type>();
+        try
+        {
+            foreach (Type candidate in baseType.Assembly.GetTypes())
+            {
+                if (candidate != baseType && !candidate.IsAbstract && baseType.IsAssignableFrom(candidate))
+                {
+                    if (candidate.BaseType == baseType ||
+                        (baseType.IsInterface && IsDirectInterfaceImplementation(candidate, baseType)))
+                    {
+                        subtypes.Add(candidate);
+                    }
+                }
+            }
+        }
+        catch (ReflectionTypeLoadException)
+        {
+            // Assembly scanning may fail for various reasons; return what we have
+        }
+
+        return subtypes.ToArray();
+    }
+
+    public static DerivedTypeInfo[] GetClosedSubtypeDerivedInfos(Type baseType)
+    {
+        Type[] subtypes = GetClosedSubtypes(baseType);
+        return BuildDerivedInfos(subtypes);
+    }
+
+    [RequiresUnreferencedCode("Assembly.GetTypes() may not return all types in trimmed applications.")]
+    public static DerivedTypeInfo[] GetAssemblyScanDerivedInfos(Type baseType)
+    {
+        Type[] subtypes = FindDirectSubtypesInAssembly(baseType);
+        return BuildDerivedInfos(subtypes);
+    }
+
+    public static DerivedTypeInfo[] GetInferredDerivedTypeInfos(Type baseType)
+    {
+        Type[] subtypes = GetClosedSubtypes(baseType);
+
+        if (subtypes.Length == 0)
+        {
+            subtypes = FindDirectSubtypesInAssembly(baseType);
+        }
+
+        return BuildDerivedInfos(subtypes);
+    }
+
+    private static DerivedTypeInfo[] BuildDerivedInfos(Type[] subtypes)
+    {
+        var infos = new DerivedTypeInfo[subtypes.Length];
+        for (int i = 0; i < subtypes.Length; i++)
+        {
+            Type subtype = subtypes[i];
+            infos[i] = new DerivedTypeInfo(subtype, subtype.Name, Tag: i, Index: i, IsTagSpecified: false);
+        }
+
+        return infos;
+    }
+
+    private static bool IsDirectInterfaceImplementation(Type candidate, Type interfaceType)
+    {
+        if (candidate.BaseType is { } baseType && interfaceType.IsAssignableFrom(baseType))
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
@@ -14,6 +14,7 @@ internal sealed class FSharpUnionTypeShape<TUnion>(FSharpUnionInfo unionInfo, Re
 {
     public override TypeShapeKind Kind => TypeShapeKind.Union;
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitUnion(this, state);
+    public UnionKind UnionKind => UnionKind.FSharpUnion;
     public ITypeShape<TUnion> BaseType { get; } = new FSharpUnionCaseTypeShape<TUnion>(null, provider, options);
 
     public IReadOnlyList<IUnionCaseShape> UnionCases => _unionCases ?? CommonHelpers.ExchangeIfNull(ref _unionCases, CreateUnionCaseShapes().AsReadOnlyList());

--- a/src/PolyType/ReflectionProvider/ReflectionEnumTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumTypeShape.cs
@@ -26,6 +26,10 @@ internal sealed class ReflectionEnumTypeShape<TEnum, TUnderlying>
     public IReadOnlyDictionary<string, TUnderlying> Members => _members ?? InitializeMembers();
     public bool IsFlags => _isFlags ??= typeof(TEnum).IsDefined(typeof(FlagsAttribute), inherit: false);
 
+    public bool IsClosed => _isClosed ??= typeof(TEnum).GetCustomAttributesData()
+        .Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.ClosedAttribute");
+    private bool? _isClosed;
+
     private Dictionary<string, TUnderlying> InitializeMembers()
     {
         FieldInfo[] fields = typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static);

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeOptions.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeOptions.cs
@@ -14,4 +14,9 @@ internal sealed class ReflectionTypeShapeOptions
 
     /// <inheritdoc cref="TypeShapeExtensionAttribute.IncludeMethods" />
     public required MethodShapeFlags IncludeMethods { get; init; }
+
+    /// <summary>
+    /// Indicates whether derived types should be inferred from the type hierarchy.
+    /// </summary>
+    public bool InferDerivedTypes { get; init; }
 }

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -294,6 +294,12 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
             return (IUnionTypeShape)Activator.CreateInstance(fsharpUnionTypeTy, fSharpUnionInfo, this, options)!;
         }
 
+        // Check for C# union types (has [Union] attribute and implements IUnion)
+        if (CSharpUnionHelpers.IsCSharpUnion(unionType))
+        {
+            return CreateCSharpUnionTypeShape(unionType, options);
+        }
+
         List<DerivedTypeShapeAttribute> derivedTypeAttributes = unionType.GetCustomAttributes<DerivedTypeShapeAttribute>().ToList();
         if (unionType.GetCustomAttribute<DataContractAttribute>() is { })
         {
@@ -370,8 +376,47 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
             derivedTypeInfos.Add(new(derivedType, name, tag, index, isTagSpecified));
         }
 
+        // If no explicit derived types were declared, try [ClosedSubtype] attributes
+        // (always honored) or assembly scanning (requires InferDerivedTypes opt-in)
+        if (derivedTypeInfos.Count == 0)
+        {
+            DerivedTypeInfo[] closedSubtypeInfos = ClosedHierarchyHelpers.GetClosedSubtypeDerivedInfos(unionType);
+            if (closedSubtypeInfos.Length > 0)
+            {
+                derivedTypeInfos.AddRange(closedSubtypeInfos);
+            }
+            else if (options.InferDerivedTypes)
+            {
+                DerivedTypeInfo[] inferredInfos = ClosedHierarchyHelpers.GetAssemblyScanDerivedInfos(unionType);
+                derivedTypeInfos.AddRange(inferredInfos);
+            }
+        }
+
         Type unionTypeTy = typeof(ReflectionUnionTypeShape<>).MakeGenericType(unionType);
         return (IUnionTypeShape)Activator.CreateInstance(unionTypeTy, derivedTypeInfos.ToArray(), this, options)!;
+    }
+
+    private IUnionTypeShape CreateCSharpUnionTypeShape(Type unionType, ReflectionTypeShapeOptions options)
+    {
+        CSharpUnionCaseInfo[] caseInfos = CSharpUnionHelpers.GetCaseInfos(unionType, out Func<object, object?> valueAccessor);
+        // Create a typed accessor delegate: Func<TUnion, object?>
+        // We wrap the untyped accessor to work with the generic shape
+        Type csharpUnionTypeTy = typeof(CSharpUnionTypeShape<>).MakeGenericType(unionType);
+        // Build Func<TUnion, object?> from Func<object, object?>
+        Type funcType = typeof(Func<,>).MakeGenericType(unionType, typeof(object));
+        Delegate typedAccessor = CreateTypedValueAccessor(unionType, valueAccessor);
+
+        return (IUnionTypeShape)Activator.CreateInstance(csharpUnionTypeTy, caseInfos, typedAccessor, this, options)!;
+    }
+
+    private static Delegate CreateTypedValueAccessor(Type unionType, Func<object, object?> valueAccessor)
+    {
+        // Creates a Func<TUnion, object?> from a Func<object, object?>
+        // using a helper method to avoid reflection emit
+        Type helperType = typeof(CSharpUnionValueAccessorHelper<>).MakeGenericType(unionType);
+        var createMethod = helperType.GetMethod("Create", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
+
+        return (Delegate)createMethod.Invoke(null, [valueAccessor])!;
     }
 
     private IFunctionTypeShape CreateFunctionTypeShape(Type functionType, FSharpFuncInfo? fSharpFuncInfo, ReflectionTypeShapeOptions options)
@@ -440,6 +485,7 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
             RequestedKind = requestedKind,
             Marshaler = marshaler,
             IncludeMethods = methodFlags ?? MethodShapeFlags.None,
+            InferDerivedTypes = typeShapeAttr?.GetRequestedInferDerivedTypes() ?? false,
         };
     }
 
@@ -509,6 +555,11 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
 
         if (allowUnionShapes)
         {
+            if (CSharpUnionHelpers.IsCSharpUnion(type))
+            {
+                return TypeShapeKind.Union;
+            }
+
             var customAttributeData = type.GetCustomAttributesData();
             if (customAttributeData.Any(attrData => attrData.AttributeType == typeof(DerivedTypeShapeAttribute)))
             {
@@ -519,6 +570,23 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
                 customAttributeData.Any(attrData => attrData.AttributeType == typeof(KnownTypeAttribute))))
             {
                 return TypeShapeKind.Union;
+            }
+
+            // InferDerivedTypes: discover subtypes from [ClosedSubtype] or assembly scanning
+            if ((type.IsClass || type.IsInterface) && !type.IsSealed)
+            {
+                // [ClosedSubtype] attributes are always honored (similar to [DerivedTypeShapeAttribute])
+                if (ClosedHierarchyHelpers.HasClosedSubtypeAttributes(type))
+                {
+                    return TypeShapeKind.Union;
+                }
+
+                // Assembly scanning requires explicit opt-in via InferDerivedTypes
+                if (options?.InferDerivedTypes == true &&
+                    ClosedHierarchyHelpers.FindDirectSubtypesInAssembly(type).Length > 0)
+                {
+                    return TypeShapeKind.Union;
+                }
             }
         }
 
@@ -603,6 +671,13 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
     {
         Type unionCaseType = typeof(ReflectionUnionCaseShape<,>).MakeGenericType(derivedTypeInfo.Type, unionTypeShape.Type);
         return (IUnionCaseShape)Activator.CreateInstance(unionCaseType, unionTypeShape, derivedTypeInfo, this)!;
+    }
+
+    internal IUnionCaseShape CreateCSharpUnionCaseShape(IUnionTypeShape unionTypeShape, CSharpUnionCaseInfo caseInfo)
+    {
+        Type unionCaseType = typeof(CSharpUnionCaseShape<,>).MakeGenericType(caseInfo.CaseType, unionTypeShape.Type);
+
+        return (IUnionCaseShape)Activator.CreateInstance(unionCaseType, caseInfo, this)!;
     }
 
     internal static IMethodShapeInfo CreateTupleConstructorShapeInfo(Type tupleType)

--- a/src/PolyType/ReflectionProvider/ReflectionUnionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionUnionTypeShape.cs
@@ -13,6 +13,7 @@ internal sealed class ReflectionUnionTypeShape<TUnion>(DerivedTypeInfo[] derived
 {
     public override TypeShapeKind Kind => TypeShapeKind.Union;
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitUnion(this, state);
+    public UnionKind UnionKind => UnionKind.ClassHierarchy;
 
     public ITypeShape<TUnion> BaseType => _baseType ?? CommonHelpers.ExchangeIfNull(ref _baseType, (ITypeShape<TUnion>)Provider.CreateTypeShapeCore(typeof(TUnion), allowUnionShapes: false));
     private ITypeShape<TUnion>? _baseType;

--- a/src/PolyType/SourceGenModel/DelegateMarshaler.cs
+++ b/src/PolyType/SourceGenModel/DelegateMarshaler.cs
@@ -1,0 +1,29 @@
+﻿namespace PolyType.SourceGenModel;
+
+/// <summary>
+/// Defines a delegate-based marshaler between two types without any type constraints.
+/// </summary>
+/// <typeparam name="TSource">The source type.</typeparam>
+/// <typeparam name="TTarget">The target type.</typeparam>
+public sealed class DelegateMarshaler<TSource, TTarget> : IMarshaler<TSource, TTarget>
+{
+    private readonly Func<TSource?, TTarget?> _marshal;
+    private readonly Func<TTarget?, TSource?> _unmarshal;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegateMarshaler{TSource, TTarget}"/> class.
+    /// </summary>
+    /// <param name="marshal">A delegate that converts from <typeparamref name="TSource"/> to <typeparamref name="TTarget"/>.</param>
+    /// <param name="unmarshal">A delegate that converts from <typeparamref name="TTarget"/> to <typeparamref name="TSource"/>.</param>
+    public DelegateMarshaler(Func<TSource?, TTarget?> marshal, Func<TTarget?, TSource?> unmarshal)
+    {
+        _marshal = marshal;
+        _unmarshal = unmarshal;
+    }
+
+    /// <inheritdoc/>
+    public TTarget? Marshal(TSource? value) => _marshal(value);
+
+    /// <inheritdoc/>
+    public TSource? Unmarshal(TTarget? value) => _unmarshal(value);
+}

--- a/src/PolyType/SourceGenModel/SourceGenEnumTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenEnumTypeShape.cs
@@ -36,6 +36,9 @@ public sealed class SourceGenEnumTypeShape<TEnum, TUnderlying> : SourceGenTypeSh
     public bool IsFlags { get; init; }
 
     /// <inheritdoc/>
+    public bool IsClosed { get; init; }
+
+    /// <inheritdoc/>
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitEnum(this, state);
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/PolyType/SourceGenModel/SourceGenUnionTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenUnionTypeShape.cs
@@ -11,6 +11,11 @@ namespace PolyType.SourceGenModel;
 public sealed class SourceGenUnionTypeShape<TUnion> : SourceGenTypeShape<TUnion>, IUnionTypeShape<TUnion>
 {
     /// <summary>
+    /// Gets the kind of union represented by this shape.
+    /// </summary>
+    public required UnionKind UnionKind { get; init; }
+
+    /// <summary>
     /// Gets a delayed base type shape factory for use with potentially recursive type graphs.
     /// </summary>
     public required Func<ITypeShape<TUnion>> BaseTypeFactory { get; init; }

--- a/src/PolyType/TypeShapeAttribute.cs
+++ b/src/PolyType/TypeShapeAttribute.cs
@@ -60,6 +60,28 @@ public sealed class TypeShapeAttribute : Attribute
     /// </remarks>
     public MethodShapeFlags IncludeMethods { get => _includeMethods ?? MethodShapeFlags.None; init => _includeMethods = value; }
 
+    /// <summary>
+    /// Gets a value indicating whether derived types should be automatically inferred for this type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When set to <see langword="true"/>, the type shape provider will attempt to auto-discover derived types:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <b>Fast path:</b> Read <c>[ClosedSubtype]</c> attributes emitted by the compiler for closed class hierarchies.
+    /// </description></item>
+    /// <item><description>
+    /// <b>Slow path (reflection only):</b> Scan the type's assembly for direct subtypes.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// Explicit <see cref="DerivedTypeShapeAttribute"/> annotations always take precedence over auto-inferred types.
+    /// </para>
+    /// </remarks>
+    public bool InferDerivedTypes { get; init; }
+
     internal TypeShapeKind? GetRequestedKind() => _kind;
     internal MethodShapeFlags? GetRequestedIncludeMethods() => _includeMethods;
+    internal bool? GetRequestedInferDerivedTypes() => InferDerivedTypes ? true : null;
 }

--- a/src/PolyType/UnionKind.cs
+++ b/src/PolyType/UnionKind.cs
@@ -1,0 +1,34 @@
+﻿#if IS_MAIN_POLYTYPE_PROJECT
+using PolyType.Abstractions;
+#endif
+
+namespace PolyType;
+
+/// <summary>
+/// Defines the kind of union represented by an <see cref="IUnionTypeShape"/>.
+/// </summary>
+#if IS_MAIN_POLYTYPE_PROJECT
+public
+#else
+internal
+#endif
+enum UnionKind
+{
+    /// <summary>
+    /// A class or interface hierarchy with derived types declared
+    /// via <see cref="DerivedTypeShapeAttribute"/> or equivalent annotations.
+    /// </summary>
+    ClassHierarchy = 0,
+
+    /// <summary>
+    /// An F# discriminated union.
+    /// </summary>
+    FSharpUnion = 1,
+
+    /// <summary>
+    /// A C# union type declared with <c>[Union]</c> and implementing <c>IUnion</c>.
+    /// Case types are extracted from single-parameter constructors or
+    /// <c>IUnionMembers</c> factory methods.
+    /// </summary>
+    CSharpUnion = 2,
+}

--- a/tests/PolyType.Tests/CSharpUnionTests.cs
+++ b/tests/PolyType.Tests/CSharpUnionTests.cs
@@ -1,0 +1,220 @@
+using PolyType.Abstractions;
+using PolyType.ReflectionProvider;
+using PolyType.Tests;
+
+namespace PolyType.Tests;
+
+/// <summary>
+/// Tests for C# union types, closed enums, and closed class hierarchies.
+/// These features are prototypes based on upcoming C# language proposals.
+/// </summary>
+public class CSharpUnionTests
+{
+    private static readonly ReflectionTypeShapeProvider s_reflectionProvider =
+        ReflectionTypeShapeProvider.Create(new ReflectionTypeShapeProviderOptions
+        {
+            UseReflectionEmit = true,
+        });
+
+    [Fact]
+    public void Pet_IsDetectedAsUnion()
+    {
+        ITypeShape shape = s_reflectionProvider.GetTypeShapeOrThrow(typeof(Pet));
+
+        Assert.Equal(TypeShapeKind.Union, shape.Kind);
+    }
+
+    [Fact]
+    public void Pet_UnionKind_IsCSharpUnion()
+    {
+        var unionShape = (IUnionTypeShape)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Pet));
+
+        Assert.Equal(UnionKind.CSharpUnion, unionShape.UnionKind);
+    }
+
+    [Fact]
+    public void Pet_UnionCases_MatchConstructorParameterTypes()
+    {
+        var unionShape = (IUnionTypeShape)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Pet));
+
+        Assert.Equal(3, unionShape.UnionCases.Count);
+        Assert.Equal(typeof(Dog), unionShape.UnionCases[0].UnionCaseType.Type);
+        Assert.Equal(typeof(Cat), unionShape.UnionCases[1].UnionCaseType.Type);
+        Assert.Equal(typeof(int), unionShape.UnionCases[2].UnionCaseType.Type);
+    }
+
+    [Fact]
+    public void Pet_UnionCaseNames_AreTypeNames()
+    {
+        var unionShape = (IUnionTypeShape)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Pet));
+
+        Assert.Equal("Dog", unionShape.UnionCases[0].Name);
+        Assert.Equal("Cat", unionShape.UnionCases[1].Name);
+        Assert.Equal("Int32", unionShape.UnionCases[2].Name);
+    }
+
+    [Fact]
+    public void Pet_GetGetUnionCaseIndex_IdentifiesDogCase()
+    {
+        var unionShape = (IUnionTypeShape<Pet>)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Pet));
+        Getter<Pet, int> getCaseIndex = unionShape.GetGetUnionCaseIndex();
+        Pet pet = new Pet(new Dog { Name = "Rex", Age = 3 });
+
+        int index = getCaseIndex(ref pet);
+
+        Assert.Equal(0, index);
+    }
+
+    [Fact]
+    public void Pet_GetGetUnionCaseIndex_IdentifiesCatCase()
+    {
+        var unionShape = (IUnionTypeShape<Pet>)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Pet));
+        Getter<Pet, int> getCaseIndex = unionShape.GetGetUnionCaseIndex();
+        Pet pet = new Pet(new Cat { Name = "Whiskers", IsIndoor = true });
+
+        int index = getCaseIndex(ref pet);
+
+        Assert.Equal(1, index);
+    }
+
+    [Fact]
+    public void Pet_GetGetUnionCaseIndex_IdentifiesIntCase()
+    {
+        var unionShape = (IUnionTypeShape<Pet>)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Pet));
+        Getter<Pet, int> getCaseIndex = unionShape.GetGetUnionCaseIndex();
+        Pet pet = new Pet(42);
+
+        int index = getCaseIndex(ref pet);
+
+        Assert.Equal(2, index);
+    }
+
+    [Fact]
+    public void Pet_BaseType_IsObjectShapeOfPet()
+    {
+        var unionShape = (IUnionTypeShape)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Pet));
+
+        Assert.Equal(typeof(Pet), unionShape.BaseType.Type);
+        Assert.Equal(TypeShapeKind.Object, unionShape.BaseType.Kind);
+    }
+
+    [Fact]
+    public void ExistingSubtypeUnion_UnionKind_IsClassHierarchy()
+    {
+        var unionShape = (IUnionTypeShape)s_reflectionProvider.GetTypeShapeOrThrow(typeof(PolymorphicClass));
+
+        Assert.Equal(UnionKind.ClassHierarchy, unionShape.UnionKind);
+    }
+
+    [Fact]
+    public void ClosedColor_IsClosed_ReturnsTrue()
+    {
+        var enumShape = (IEnumTypeShape)s_reflectionProvider.GetTypeShapeOrThrow(typeof(ClosedColor));
+
+        Assert.True(enumShape.IsClosed);
+    }
+
+    [Fact]
+    public void RegularEnum_IsClosed_ReturnsFalse()
+    {
+        var enumShape = (IEnumTypeShape)s_reflectionProvider.GetTypeShapeOrThrow(typeof(StringComparison));
+
+        Assert.False(enumShape.IsClosed);
+    }
+
+    [Fact]
+    public void Shape_WithClosedSubtype_IsDetectedAsUnion()
+    {
+        ITypeShape shape = s_reflectionProvider.GetTypeShapeOrThrow(typeof(Shape));
+
+        Assert.Equal(TypeShapeKind.Union, shape.Kind);
+    }
+
+    [Fact]
+    public void Shape_UnionKind_IsClassHierarchy()
+    {
+        var unionShape = (IUnionTypeShape)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Shape));
+
+        Assert.Equal(UnionKind.ClassHierarchy, unionShape.UnionKind);
+    }
+
+    [Fact]
+    public void Shape_InferredDerivedTypes_IncludeCircleAndRectangle()
+    {
+        var unionShape = (IUnionTypeShape)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Shape));
+
+        Type[] caseTypes = unionShape.UnionCases.Select(c => c.UnionCaseType.Type).ToArray();
+        Assert.Contains(typeof(Circle), caseTypes);
+        Assert.Contains(typeof(Rectangle), caseTypes);
+    }
+
+    [Fact]
+    public void Vehicle_WithInferDerivedTypes_DiscoversDerivedTypesFromAssemblyScan()
+    {
+        var unionShape = (IUnionTypeShape)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Vehicle));
+
+        Type[] caseTypes = unionShape.UnionCases.Select(c => c.UnionCaseType.Type).ToArray();
+        Assert.Contains(typeof(Car), caseTypes);
+        Assert.Contains(typeof(Truck), caseTypes);
+    }
+
+    [Fact]
+    public void Shape_GetGetUnionCaseIndex_IdentifiesCircle()
+    {
+        var unionShape = (IUnionTypeShape<Shape>)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Shape));
+        Getter<Shape, int> getCaseIndex = unionShape.GetGetUnionCaseIndex();
+        Shape circle = new Circle { Color = "Red", Radius = 5.0 };
+
+        int index = getCaseIndex(ref circle);
+
+        Assert.True(index >= 0, "Circle should match a union case");
+        Assert.Equal(typeof(Circle), unionShape.UnionCases[index].UnionCaseType.Type);
+    }
+
+    [Fact]
+    public void Vehicle_GetGetUnionCaseIndex_IdentifiesCar()
+    {
+        var unionShape = (IUnionTypeShape<Vehicle>)s_reflectionProvider.GetTypeShapeOrThrow(typeof(Vehicle));
+        Getter<Vehicle, int> getCaseIndex = unionShape.GetGetUnionCaseIndex();
+        Vehicle car = new Car { Make = "Toyota", Doors = 4 };
+
+        int index = getCaseIndex(ref car);
+
+        Assert.True(index >= 0, "Car should match a union case");
+        Assert.Equal(typeof(Car), unionShape.UnionCases[index].UnionCaseType.Type);
+    }
+
+    [Fact]
+    public void SourceGen_ClosedColor_IsClosed_ReturnsTrue()
+    {
+        var enumShape = (IEnumTypeShape)Witness.GeneratedTypeShapeProvider.GetTypeShapeOrThrow(typeof(ClosedColor));
+
+        Assert.True(enumShape.IsClosed);
+    }
+
+    [Fact]
+    public void SourceGen_Shape_WithClosedSubtype_IsDetectedAsUnion()
+    {
+        ITypeShape shape = Witness.GeneratedTypeShapeProvider.GetTypeShapeOrThrow(typeof(Shape));
+
+        Assert.Equal(TypeShapeKind.Union, shape.Kind);
+    }
+
+    [Fact]
+    public void SourceGen_Shape_UnionCases_IncludeCircleAndRectangle()
+    {
+        var unionShape = (IUnionTypeShape)Witness.GeneratedTypeShapeProvider.GetTypeShapeOrThrow(typeof(Shape));
+
+        Type[] caseTypes = unionShape.UnionCases.Select(c => c.UnionCaseType.Type).ToArray();
+        Assert.Contains(typeof(Circle), caseTypes);
+        Assert.Contains(typeof(Rectangle), caseTypes);
+    }
+
+    [Fact]
+    public void SourceGen_Shape_UnionKind_IsClassHierarchy()
+    {
+        var unionShape = (IUnionTypeShape)Witness.GeneratedTypeShapeProvider.GetTypeShapeOrThrow(typeof(Shape));
+
+        Assert.Equal(UnionKind.ClassHierarchy, unionShape.UnionKind);
+    }
+}

--- a/tests/PolyType.Tests/ProviderUnderTest.cs
+++ b/tests/PolyType.Tests/ProviderUnderTest.cs
@@ -1,4 +1,5 @@
 using Microsoft.FSharp.Reflection;
+using PolyType.Abstractions;
 using PolyType.ReflectionProvider;
 using PolyType.SourceGenModel;
 using System.Collections;
@@ -21,7 +22,12 @@ public abstract class ProviderUnderTest
     {
         if (testCase.IsUnion)
         {
-            return !testCase.IsAbstract || FSharpType.IsUnion(testCase.Type, null);
+            if (!testCase.IsAbstract)
+            {
+                return true;
+            }
+
+            return FSharpType.IsUnion(testCase.Type, null) || HasConstructibleSubtype(testCase.Type);
         }
 
         return !(testCase.IsAbstract && !typeof(IEnumerable).IsAssignableFrom(testCase.Type)) &&
@@ -30,6 +36,31 @@ public abstract class ProviderUnderTest
             !testCase.IsFunctionType &&
             testCase.CustomKind is not TypeShapeKind.None &&
             (!testCase.UsesSpanConstructor || Kind is not ProviderKind.ReflectionNoEmit);
+    }
+
+    private static bool HasConstructibleSubtype(Type type)
+    {
+        foreach (DerivedTypeShapeAttribute attr in type.GetCustomAttributes<DerivedTypeShapeAttribute>(false))
+        {
+            if (!attr.Type.IsAbstract && !attr.Type.IsInterface)
+            {
+                return true;
+            }
+        }
+
+        foreach (Attribute attr in type.GetCustomAttributes(false).OfType<Attribute>())
+        {
+            if (attr.GetType().FullName is "System.Runtime.CompilerServices.ClosedSubtypeAttribute")
+            {
+                Type? subtypeType = (Type?)attr.GetType().GetProperty("SubtypeType")?.GetValue(attr);
+                if (subtypeType is { IsAbstract: false, IsInterface: false })
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }
 

--- a/tests/PolyType.Tests/SourceGenModel/ObsoletePropertyTests.cs
+++ b/tests/PolyType.Tests/SourceGenModel/ObsoletePropertyTests.cs
@@ -184,6 +184,7 @@ public static class ObsoletePropertyTests
         var unionShape = new SourceGenUnionTypeShape<object>
         {
             Provider = mockProvider,
+            UnionKind = UnionKind.ClassHierarchy,
             BaseTypeFactory = () => throw new InvalidOperationException("BaseTypeFactory should not be called"),
             BaseType = expectedBaseType,
             UnionCasesFactory = () => [],


### PR DESCRIPTION
## ⚠️ NO-MERGE — Prototype / Design Exploration

This PR is a design prototype for mapping upcoming C# language features to PolyType's type shape abstractions. It is **not intended to be merged** in its current form — it exists to validate API feasibility and gather feedback.

### Background

C# is introducing three related language features:
- [**Union types**](https://github.com/dotnet/csharplang/blob/main/proposals/unions.md) — tagged unions with structural case types
- [**Closed enums**](https://github.com/dotnet/csharplang/blob/main/proposals/closed-enums.md) — enums that cannot be extended
- [**Closed hierarchies**](https://github.com/dotnet/csharplang/blob/main/proposals/closed-hierarchies.md) — class/interface hierarchies with a fixed set of subtypes

See also the [System.Text.Json design for the same features](https://github.com/dotnet/runtime/issues/125449).

### API Changes

#### New types

| Type | Description |
|------|-------------|
| `UnionKind` enum | Distinguishes `ClassHierarchy`, `FSharpUnion`, and `CSharpUnion` union origins |
| `DelegateMarshaler<TSource, TTarget>` | Constraint-free `IMarshaler` using `Func` delegates, enabling marshal/unmarshal between unrelated types |

#### Extended interfaces

| Interface | New member | Description |
|-----------|-----------|-------------|
| `IUnionTypeShape` | `UnionKind UnionKind` | Identifies the kind of union (class hierarchy, F# DU, or C# union) |
| `IEnumTypeShape` | `bool IsClosed` | Whether the enum is marked `[Closed]` |

#### Extended attributes

| Attribute | New property | Description |
|-----------|-------------|-------------|
| `TypeShapeAttribute` | `bool InferDerivedTypes` | Opt-in for auto-discovering derived types from `[ClosedSubtype]` attributes or assembly scanning |
| `GenerateShapeAttribute` | `bool InferDerivedTypes` | Same, for source-generated shapes |
| `GenerateShapeForAttribute` | `bool InferDerivedTypes` | Same, for external type shapes |

### How C# Union Types Map to `IUnionTypeShape`

The key insight is that `IUnionCaseShape<TUnionCase, TUnion>` has **no** `TUnionCase : TUnion` constraint at the interface level. This means PolyType already supports the case where union case types are unrelated to the union type — exactly what C# unions require.

```
C# union Pet                    PolyType mapping
─────────────────               ──────────────────────────────
union Pet {                     IUnionTypeShape<Pet>
  Dog(string Name, int Age);      UnionKind = CSharpUnion
  Cat(string Name, bool Indoor);  UnionCases[0] = IUnionCaseShape<Dog, Pet>
  int;                            UnionCases[1] = IUnionCaseShape<Cat, Pet>
}                                 UnionCases[2] = IUnionCaseShape<int, Pet>
```

**Marshaling**: `DelegateMarshaler<Dog, Pet>` wraps:
- `Marshal`: calls `new Pet(dog)` (union constructor)
- `Unmarshal`: calls `((IUnion)pet).Value` and casts to `Dog`

**Case index**: determined by checking the runtime type of `IUnion.Value`.

**Detection**: by metadata name (`System.Runtime.CompilerServices.UnionAttribute` + `System.IUnion`), not by PolyType-defined types. Mock attributes are provided in test cases since no compiler supports these yet.

### Closed Hierarchy Support

`[ClosedSubtype(typeof(Circle))]` attributes on a base type are **always honored** for union detection (similar to `[DerivedTypeShapeAttribute]`). Assembly scanning (finding all subtypes in the same assembly) requires explicit `InferDerivedTypes = true` opt-in.

### What's included

- Reflection provider: full C# union, closed enum, and closed hierarchy support
- Source generator: closed enum `IsClosed` and `[ClosedSubtype]`-based union detection
- Example JSON serializer: structural matching converter for C# unions (no discriminator — matches by JSON token type and property names)
- 21 new tests, 273,600 total tests pass across net10.0/net9.0/net8.0/net472
