### PR TITLE
Sort ProvidedTypes iteration for deterministic source output

### DIFF
--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enum.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enum.cs
@@ -52,7 +52,7 @@ internal sealed partial class SourceFormatter
             """);
 
         writer.Indentation += 2;
-        foreach (var member in enumTypeShape.Members)
+        foreach (var member in enumTypeShape.Members.OrderBy(m => m.Key))
         {
             writer.WriteLine($"""["{member.Key}"] = {member.Value},""");
         }

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.TypeShapeProvider.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.TypeShapeProvider.cs
@@ -123,7 +123,7 @@ internal sealed partial class SourceFormatter
                 writer.WriteLine($"{typeDeclaration.TypeDeclarationHeader} :");
                 writer.WriteLine("#nullable disable annotations // Use nullable-oblivious interface implementation", disableIndentation: true);
                 writer.Indentation++;
-                foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations)
+                foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations.OrderBy(t => t.FullyQualifiedName))
                 {
                     string separator = --count == 0 ? "" : ",";
                     writer.WriteLine($"global::PolyType.IShapeable<{typeToImplement.FullyQualifiedName}>{separator}");
@@ -150,7 +150,7 @@ internal sealed partial class SourceFormatter
         
         if (provider.TargetSupportsIShapeableOfT)
         {
-            foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations)
+            foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations.OrderBy(t => t.FullyQualifiedName))
             {
                 if (emittedMembers++ > 0)
                 {
@@ -180,7 +180,7 @@ internal sealed partial class SourceFormatter
 
             writer.Indentation += 2;
 
-            foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations)
+            foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations.OrderBy(t => t.FullyQualifiedName))
             {
                 writer.WriteLine($$"""
                     if (type == typeof({{typeToImplement.FullyQualifiedName}}))

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.TypeShapeProvider.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.TypeShapeProvider.cs
@@ -71,7 +71,7 @@ internal sealed partial class SourceFormatter
             """);
 
         writer.Indentation += 2;
-        foreach (TypeShapeModel typeModel in provider.ProvidedTypes.Values)
+        foreach (TypeShapeModel typeModel in provider.ProvidedTypes.Values.OrderBy(t => t.SourceIdentifier))
         {
             writer.WriteLine($$"""
                 case {{FormatStringLiteral(typeModel.ReflectionName)}}:

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
@@ -289,7 +289,7 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
             """);
 
         writer.Indentation += 2;
-        foreach (AssociatedTypeId associatedType in objectShapeModel.AssociatedTypes)
+        foreach (AssociatedTypeId associatedType in objectShapeModel.AssociatedTypes.OrderBy(t => t.ClosedTypeReflectionName))
         {
             if (associatedType.OpenTypeInfo is { } openTypeInfo)
             {

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
@@ -34,7 +34,7 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
         context.CancellationToken.ThrowIfCancellationRequested();
         context.AddSource($"{provider.ProviderDeclaration.SourceFilenamePrefix}.g.cs", FormatTypeShapeProviderMainFile(provider));
 
-        foreach (TypeShapeModel type in provider.ProvidedTypes.Values)
+        foreach (TypeShapeModel type in provider.ProvidedTypes.Values.OrderBy(t => t.SourceIdentifier))
         {
             context.CancellationToken.ThrowIfCancellationRequested();
             context.AddSource($"{provider.ProviderDeclaration.SourceFilenamePrefix}.{type.SourceIdentifier}.g.cs", FormatProvidedType(provider, type));

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
@@ -28,8 +28,8 @@ namespace PolyType.SourceGenerator
         {
             return new global::System.Collections.Generic.Dictionary<string, int>
             {
-                ["None"] = 0,
                 ["First"] = 1,
+                ["None"] = 0,
                 ["Second"] = 2,
                 ["Third"] = 3,
             };

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
@@ -18,9 +18,9 @@ namespace TestNamespace
         {
             global::PolyType.ITypeShape? global::PolyType.ITypeShapeProvider.GetTypeShape(global::System.Type type)
             {
-                if (type == typeof(global::TestNamespace.Person))
+                if (type == typeof(global::System.Collections.Generic.List<global::TestNamespace.Person>))
                 {
-                    return global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
+                    return global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
                 }
 
                 if (type == typeof(global::TestNamespace.Address))
@@ -28,9 +28,9 @@ namespace TestNamespace
                     return global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Address;
                 }
 
-                if (type == typeof(global::System.Collections.Generic.List<global::TestNamespace.Person>))
+                if (type == typeof(global::TestNamespace.Person))
                 {
-                    return global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
+                    return global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
                 }
 
                 return null;

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
@@ -28,8 +28,8 @@ namespace PolyType.SourceGenerator
         {
             return new global::System.Collections.Generic.Dictionary<string, int>
             {
-                ["None"] = 0,
                 ["First"] = 1,
+                ["None"] = 0,
                 ["Second"] = 2,
                 ["Third"] = 3,
             };

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
@@ -18,9 +18,9 @@ namespace TestNamespace
         {
             global::PolyType.ITypeShape? global::PolyType.ITypeShapeProvider.GetTypeShape(global::System.Type type)
             {
-                if (type == typeof(global::TestNamespace.Person))
+                if (type == typeof(global::System.Collections.Generic.List<global::TestNamespace.Person>))
                 {
-                    return global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
+                    return global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
                 }
 
                 if (type == typeof(global::TestNamespace.Address))
@@ -28,9 +28,9 @@ namespace TestNamespace
                     return global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Address;
                 }
 
-                if (type == typeof(global::System.Collections.Generic.List<global::TestNamespace.Person>))
+                if (type == typeof(global::TestNamespace.Person))
                 {
-                    return global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
+                    return global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
                 }
 
                 return null;

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
@@ -28,8 +28,8 @@ namespace PolyType.SourceGenerator
         {
             return new global::System.Collections.Generic.Dictionary<string, int>
             {
-                ["None"] = 0,
                 ["First"] = 1,
+                ["None"] = 0,
                 ["Second"] = 2,
                 ["Third"] = 3,
             };

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
@@ -8,22 +8,22 @@ namespace TestNamespace
 {
     public partial class MultiProvider :
     #nullable disable annotations // Use nullable-oblivious interface implementation
-        global::PolyType.IShapeable<global::TestNamespace.Person>,
+        global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>,
         global::PolyType.IShapeable<global::TestNamespace.Address>,
-        global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>
+        global::PolyType.IShapeable<global::TestNamespace.Person>
     #nullable enable annotations // Use nullable-oblivious interface implementation
     {
         /// <summary>Gets the source generated <see cref="global::PolyType.SourceGenModel.SourceGenTypeShapeProvider"/> corresponding to the current assembly.</summary>
         public static global::PolyType.SourceGenModel.SourceGenTypeShapeProvider GeneratedTypeShapeProvider =>
             global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default;
 
-        static global::PolyType.ITypeShape<global::TestNamespace.Person> global::PolyType.IShapeable<global::TestNamespace.Person>.GetTypeShape() =>
-            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
+        static global::PolyType.ITypeShape<global::System.Collections.Generic.List<global::TestNamespace.Person>> global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>.GetTypeShape() =>
+            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
 
         static global::PolyType.ITypeShape<global::TestNamespace.Address> global::PolyType.IShapeable<global::TestNamespace.Address>.GetTypeShape() =>
             global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Address;
 
-        static global::PolyType.ITypeShape<global::System.Collections.Generic.List<global::TestNamespace.Person>> global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>.GetTypeShape() =>
-            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
+        static global::PolyType.ITypeShape<global::TestNamespace.Person> global::PolyType.IShapeable<global::TestNamespace.Person>.GetTypeShape() =>
+            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
     }
 }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
@@ -28,8 +28,8 @@ namespace PolyType.SourceGenerator
         {
             return new global::System.Collections.Generic.Dictionary<string, int>
             {
-                ["None"] = 0,
                 ["First"] = 1,
+                ["None"] = 0,
                 ["Second"] = 2,
                 ["Third"] = 3,
             };

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
@@ -8,22 +8,22 @@ namespace TestNamespace
 {
     public partial class MultiProvider :
     #nullable disable annotations // Use nullable-oblivious interface implementation
-        global::PolyType.IShapeable<global::TestNamespace.Person>,
+        global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>,
         global::PolyType.IShapeable<global::TestNamespace.Address>,
-        global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>
+        global::PolyType.IShapeable<global::TestNamespace.Person>
     #nullable enable annotations // Use nullable-oblivious interface implementation
     {
         /// <summary>Gets the source generated <see cref="global::PolyType.SourceGenModel.SourceGenTypeShapeProvider"/> corresponding to the current assembly.</summary>
         public static global::PolyType.SourceGenModel.SourceGenTypeShapeProvider GeneratedTypeShapeProvider =>
             global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default;
 
-        static global::PolyType.ITypeShape<global::TestNamespace.Person> global::PolyType.IShapeable<global::TestNamespace.Person>.GetTypeShape() =>
-            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
+        static global::PolyType.ITypeShape<global::System.Collections.Generic.List<global::TestNamespace.Person>> global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>.GetTypeShape() =>
+            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
 
         static global::PolyType.ITypeShape<global::TestNamespace.Address> global::PolyType.IShapeable<global::TestNamespace.Address>.GetTypeShape() =>
             global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Address;
 
-        static global::PolyType.ITypeShape<global::System.Collections.Generic.List<global::TestNamespace.Person>> global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>.GetTypeShape() =>
-            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
+        static global::PolyType.ITypeShape<global::TestNamespace.Person> global::PolyType.IShapeable<global::TestNamespace.Person>.GetTypeShape() =>
+            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
     }
 }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
@@ -28,8 +28,8 @@ namespace PolyType.SourceGenerator
         {
             return new global::System.Collections.Generic.Dictionary<string, int>
             {
-                ["None"] = 0,
                 ["First"] = 1,
+                ["None"] = 0,
                 ["Second"] = 2,
                 ["Third"] = 3,
             };

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
@@ -8,22 +8,22 @@ namespace TestNamespace
 {
     public partial class MultiProvider :
     #nullable disable annotations // Use nullable-oblivious interface implementation
-        global::PolyType.IShapeable<global::TestNamespace.Person>,
+        global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>,
         global::PolyType.IShapeable<global::TestNamespace.Address>,
-        global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>
+        global::PolyType.IShapeable<global::TestNamespace.Person>
     #nullable enable annotations // Use nullable-oblivious interface implementation
     {
         /// <summary>Gets the source generated <see cref="global::PolyType.SourceGenModel.SourceGenTypeShapeProvider"/> corresponding to the current assembly.</summary>
         public static global::PolyType.SourceGenModel.SourceGenTypeShapeProvider GeneratedTypeShapeProvider =>
             global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default;
 
-        static global::PolyType.ITypeShape<global::TestNamespace.Person> global::PolyType.IShapeable<global::TestNamespace.Person>.GetTypeShape() =>
-            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
+        static global::PolyType.ITypeShape<global::System.Collections.Generic.List<global::TestNamespace.Person>> global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>.GetTypeShape() =>
+            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
 
         static global::PolyType.ITypeShape<global::TestNamespace.Address> global::PolyType.IShapeable<global::TestNamespace.Address>.GetTypeShape() =>
             global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Address;
 
-        static global::PolyType.ITypeShape<global::System.Collections.Generic.List<global::TestNamespace.Person>> global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>.GetTypeShape() =>
-            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
+        static global::PolyType.ITypeShape<global::TestNamespace.Person> global::PolyType.IShapeable<global::TestNamespace.Person>.GetTypeShape() =>
+            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
     }
 }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/EnumType/PolyType.SourceGenerator.TypeShapeProvider.MyEnum.g.cs.txt
@@ -28,8 +28,8 @@ namespace PolyType.SourceGenerator
         {
             return new global::System.Collections.Generic.Dictionary<string, int>
             {
-                ["None"] = 0,
                 ["First"] = 1,
+                ["None"] = 0,
                 ["Second"] = 2,
                 ["Third"] = 3,
             };

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/MultiTypeProvider/TestNamespace.MultiProvider.g.cs.txt
@@ -8,22 +8,22 @@ namespace TestNamespace
 {
     public partial class MultiProvider :
     #nullable disable annotations // Use nullable-oblivious interface implementation
-        global::PolyType.IShapeable<global::TestNamespace.Person>,
+        global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>,
         global::PolyType.IShapeable<global::TestNamespace.Address>,
-        global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>
+        global::PolyType.IShapeable<global::TestNamespace.Person>
     #nullable enable annotations // Use nullable-oblivious interface implementation
     {
         /// <summary>Gets the source generated <see cref="global::PolyType.SourceGenModel.SourceGenTypeShapeProvider"/> corresponding to the current assembly.</summary>
         public static global::PolyType.SourceGenModel.SourceGenTypeShapeProvider GeneratedTypeShapeProvider =>
             global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default;
 
-        static global::PolyType.ITypeShape<global::TestNamespace.Person> global::PolyType.IShapeable<global::TestNamespace.Person>.GetTypeShape() =>
-            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
+        static global::PolyType.ITypeShape<global::System.Collections.Generic.List<global::TestNamespace.Person>> global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>.GetTypeShape() =>
+            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
 
         static global::PolyType.ITypeShape<global::TestNamespace.Address> global::PolyType.IShapeable<global::TestNamespace.Address>.GetTypeShape() =>
             global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Address;
 
-        static global::PolyType.ITypeShape<global::System.Collections.Generic.List<global::TestNamespace.Person>> global::PolyType.IShapeable<global::System.Collections.Generic.List<global::TestNamespace.Person>>.GetTypeShape() =>
-            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.List_Person;
+        static global::PolyType.ITypeShape<global::TestNamespace.Person> global::PolyType.IShapeable<global::TestNamespace.Person>.GetTypeShape() =>
+            global::PolyType.SourceGenerator.TypeShapeProvider_TestAssembly.Default.Person;
     }
 }


### PR DESCRIPTION
The source generator iterates `provider.ProvidedTypes.Values` in two places:

1. `SourceFormatter.AddAllSourceFiles` — emits per-type source files
2. `SourceFormatter.FormatGetShapeProviderMethod` — emits `switch` cases in `GetTypeShape`

Since `ProvidedTypes` is an `ImmutableEquatableDictionary` backed by `Dictionary<TKey, TValue>`, iteration order is non-deterministic. This causes the generated source to vary between compilations even when inputs are identical.

## Impact

This breaks incremental build for downstream projects. When a project referencing a PolyType-using library is built:

1. Any source change triggers recompilation of the library
2. PolyType source generator re-runs, producing fields/cases in a different order
3. The reference assembly content changes (different field numbering in the compiler's `<>O` display class)
4. Downstream projects see a newer reference assembly and recompile unnecessarily

In our case, a single implementation-only change in one project caused `csc` to run for a downstream project that should have been skipped entirely.

## Fix

Sort by `SourceIdentifier` (a unique, stable, type-name-derived key) before iterating in both locations. This is a two-line change.