### PR TITLE
ci: fix dependabot NuGet updates blocked by allow/ignore conflict

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,15 +15,16 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    # Exclude System.* and most Microsoft.* packages - these should only be updated manually
-    # Exception: Microsoft.Testing.* packages are allowed for MTP updates
+    # Exclude packages that track .NET runtime versions - these should only be
+    # updated manually as part of broader .NET version updates.
+    # Note: do NOT use a top-level `allow:` block here. When `allow:` is set,
+    # Dependabot only considers the listed dependencies and silently drops
+    # everything else (xunit, TUnit, BenchmarkDotNet, StyleCop, etc.).
     ignore:
       - dependency-name: "System.*"
-      - dependency-name: "Microsoft.*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
-    allow:
-      - dependency-name: "Microsoft.Testing.*"
-      - dependency-name: "Microsoft.CodeAnalysis.*"
+      - dependency-name: "Microsoft.Bcl.*"
+      - dependency-name: "Microsoft.Extensions.*"
+      - dependency-name: "Microsoft.NET.Test.Sdk"
     groups:
       # Group test framework updates together
       test-frameworks:


### PR DESCRIPTION
## Problem

The NuGet ecosystem entry for / in .github/dependabot.yml has produced **zero PRs since 2026-01-27** (PR #387). The 	ools: (.config/) and ci: (github-actions) streams kept working, but no deps: PRs landed for `xunit*`, `TUnit*`, `BenchmarkDotNet`, `StyleCop.Analyzers`, `PolySharp`, `Nerdbank.GitVersioning`, `FSharp.Core`, `YamlDotNet`, `JsonSchema.Net`, etc.

## Root cause

PR #390 (`Migrate to MTP`, 2026-01-30) added an `allow:` block alongside the existing `ignore:`:

```yaml
ignore:
  - dependency-name: "System.*"
  - dependency-name: "Microsoft.*"
    update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
allow:
  - dependency-name: "Microsoft.Testing.*"
  - dependency-name: "Microsoft.CodeAnalysis.*"
``` 

Per Dependabot semantics, when `allow:` is set it restricts candidates to the listed entries first, then `ignore:` filters further. Result:

1. Only `Microsoft.Testing.*` and `Microsoft.CodeAnalysis.*` were considered.
2. The `Microsoft.*` ignore (covering major/minor/patch) then dropped both of those too.

Net effect: the entire NuGet pipeline for `/` was silenced, including the configured groups.

## Fix

Drop the `allow:` block and tighten `ignore:` to just the prefixes that track .NET runtime versions and must be bumped manually (`System.*`, `Microsoft.Bcl.*`, `Microsoft.Extensions.*`, `Microsoft.NET.Test.Sdk`). All other NuGet packages - including `Microsoft.Testing.*` and `Microsoft.CodeAnalysis.*` - resume normal updates, and the existing `test-frameworks` / `build-tools` / `benchmarking` groups become effective again.

## Verification after merge

1. Open Insights -> Dependency graph -> Dependabot and click "Check for updates" on the NuGet `/` job to force an immediate run instead of waiting for Tuesday.
2. Confirm the config tab shows no parse errors.
3. Verify expected PRs (xunit, TUnit, BenchmarkDotNet, StyleCop, etc.) start appearing.