### PR TITLE
Use StringComparer.Ordinal in source generator emission sorts

### DIFF
--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enum.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Enum.cs
@@ -52,7 +52,7 @@ internal sealed partial class SourceFormatter
             """);
 
         writer.Indentation += 2;
-        foreach (var member in enumTypeShape.Members.OrderBy(m => m.Key))
+        foreach (var member in enumTypeShape.Members.OrderBy(m => m.Key, StringComparer.Ordinal))
         {
             writer.WriteLine($"""["{member.Key}"] = {member.Value},""");
         }

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.TypeShapeProvider.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.TypeShapeProvider.cs
@@ -71,7 +71,7 @@ internal sealed partial class SourceFormatter
             """);
 
         writer.Indentation += 2;
-        foreach (TypeShapeModel typeModel in provider.ProvidedTypes.Values.OrderBy(t => t.SourceIdentifier))
+        foreach (TypeShapeModel typeModel in provider.ProvidedTypes.Values.OrderBy(t => t.SourceIdentifier, StringComparer.Ordinal))
         {
             writer.WriteLine($$"""
                 case {{FormatStringLiteral(typeModel.ReflectionName)}}:
@@ -123,7 +123,7 @@ internal sealed partial class SourceFormatter
                 writer.WriteLine($"{typeDeclaration.TypeDeclarationHeader} :");
                 writer.WriteLine("#nullable disable annotations // Use nullable-oblivious interface implementation", disableIndentation: true);
                 writer.Indentation++;
-                foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations.OrderBy(t => t.FullyQualifiedName))
+                foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations.OrderBy(t => t.FullyQualifiedName, StringComparer.Ordinal))
                 {
                     string separator = --count == 0 ? "" : ",";
                     writer.WriteLine($"global::PolyType.IShapeable<{typeToImplement.FullyQualifiedName}>{separator}");
@@ -150,7 +150,7 @@ internal sealed partial class SourceFormatter
         
         if (provider.TargetSupportsIShapeableOfT)
         {
-            foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations.OrderBy(t => t.FullyQualifiedName))
+            foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations.OrderBy(t => t.FullyQualifiedName, StringComparer.Ordinal))
             {
                 if (emittedMembers++ > 0)
                 {
@@ -180,7 +180,7 @@ internal sealed partial class SourceFormatter
 
             writer.Indentation += 2;
 
-            foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations.OrderBy(t => t.FullyQualifiedName))
+            foreach (TypeId typeToImplement in typeDeclaration.ShapeableImplementations.OrderBy(t => t.FullyQualifiedName, StringComparer.Ordinal))
             {
                 writer.WriteLine($$"""
                     if (type == typeof({{typeToImplement.FullyQualifiedName}}))

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.cs
@@ -34,7 +34,7 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
         context.CancellationToken.ThrowIfCancellationRequested();
         context.AddSource($"{provider.ProviderDeclaration.SourceFilenamePrefix}.g.cs", FormatTypeShapeProviderMainFile(provider));
 
-        foreach (TypeShapeModel type in provider.ProvidedTypes.Values.OrderBy(t => t.SourceIdentifier))
+        foreach (TypeShapeModel type in provider.ProvidedTypes.Values.OrderBy(t => t.SourceIdentifier, StringComparer.Ordinal))
         {
             context.CancellationToken.ThrowIfCancellationRequested();
             context.AddSource($"{provider.ProviderDeclaration.SourceFilenamePrefix}.{type.SourceIdentifier}.g.cs", FormatProvidedType(provider, type));
@@ -289,7 +289,7 @@ internal sealed partial class SourceFormatter(TypeShapeProviderModel provider)
             """);
 
         writer.Indentation += 2;
-        foreach (AssociatedTypeId associatedType in objectShapeModel.AssociatedTypes.OrderBy(t => t.ClosedTypeReflectionName))
+        foreach (AssociatedTypeId associatedType in objectShapeModel.AssociatedTypes.OrderBy(t => t.ClosedTypeReflectionName, StringComparer.Ordinal))
         {
             if (associatedType.OpenTypeInfo is { } openTypeInfo)
             {


### PR DESCRIPTION
The \OrderBy\ calls added in #413 use the default string comparer, which is culture-dependent (\StringComparer.CurrentCulture\). This could produce different sort orders on machines with different locale settings, breaking deterministic output.

This PR switches all string-based \OrderBy\ calls in the \SourceFormatter\ to use \StringComparer.Ordinal\.