### PR TITLE
Reduce allocations in TypeShapeResolver.ResolveDynamicOrThrow

### DIFF
--- a/src/PolyType/Abstractions/TypeShapeResolver.cs
+++ b/src/PolyType/Abstractions/TypeShapeResolver.cs
@@ -52,7 +52,7 @@ public static class TypeShapeResolver
     [RequiresDynamicCode(ResolveDynamicMessage)]
 #endif
     public static ITypeShape<T>? ResolveDynamic<T>() =>
-        ResolveDynamicFactoryCache<T, T>.GetFactory()?.Invoke();
+        ResolveDynamicFactoryCache<T, T>.GetTypeShape();
 
     /// <summary>
     /// Uses reflection to resolve the source generated <see cref="ITypeShape{T}"/> implementation from another type.
@@ -75,7 +75,7 @@ public static class TypeShapeResolver
     [RequiresDynamicCode(ResolveDynamicMessage)]
 #endif
     public static ITypeShape<T>? ResolveDynamic<T, TProvider>() =>
-        ResolveDynamicFactoryCache<T, TProvider>.GetFactory()?.Invoke();
+        ResolveDynamicFactoryCache<T, TProvider>.GetTypeShape();
 
     /// <summary>
     /// Uses reflection to resolve the source generated <see cref="ITypeShape{T}"/> implementation of the type.
@@ -99,7 +99,7 @@ public static class TypeShapeResolver
 #endif
     public static ITypeShape<T> ResolveDynamicOrThrow<T>()
     {
-        ITypeShape<T>? result = ResolveDynamicFactoryCache<T, T>.GetFactory()?.Invoke();
+        ITypeShape<T>? result = ResolveDynamicFactoryCache<T, T>.GetTypeShape();
         if (result is null)
         {
             ThrowNotSupported();
@@ -134,7 +134,7 @@ public static class TypeShapeResolver
 #endif
     public static ITypeShape<T> ResolveDynamicOrThrow<T, TProvider>()
     {
-        ITypeShape<T>? result = ResolveDynamicFactoryCache<T, TProvider>.GetFactory()?.Invoke();
+        ITypeShape<T>? result = ResolveDynamicFactoryCache<T, TProvider>.GetTypeShape();
         if (result is null)
         {
             ThrowNotSupported();
@@ -151,38 +151,36 @@ public static class TypeShapeResolver
 #endif
     private static class ResolveDynamicFactoryCache<T, TProvider>
     {
-        private static Func<ITypeShape<T>?>? s_cachedFactory;
+        private static ITypeShape<T>? s_cachedShape;
         private static bool s_isCacheInitialized;
 
-        public static Func<ITypeShape<T>?>? GetFactory()
+        public static ITypeShape<T>? GetTypeShape()
         {
             if (!s_isCacheInitialized)
             {
-                s_cachedFactory = CreateResolveDynamicFactory();
+                if (typeof(TProvider).GetCustomAttribute<TypeShapeProviderAttribute>() is { TypeShapeProvider: Type providerType })
+                {
+                    var typeShapeProvider = (ITypeShapeProvider)Activator.CreateInstance(providerType)!;
+                    s_cachedShape = (ITypeShape<T>?)typeShapeProvider.GetTypeShape(typeof(T));
+                }
+#if NET
+                else
+                {
+                    // For forward compatibility with newer target frameworks
+                    // also resolve potential IShapeable<T> implementations.
+                    if (typeof(IShapeable<T>).IsAssignableFrom(typeof(TProvider)))
+                    {
+                        MethodInfo genericResolveMethod = typeof(TypeShapeResolver).GetMethod(nameof(Resolve), genericParameterCount: 2, BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null)!;
+                        MethodInfo resolveMethod = genericResolveMethod.MakeGenericMethod(typeof(T), typeof(TProvider));
+                        s_cachedShape = (ITypeShape<T>?)resolveMethod.Invoke(null, []);
+                    }
+                }
+#endif
+
                 Volatile.Write(ref s_isCacheInitialized, true);
             }
 
-            return s_cachedFactory;
-        }
-
-        private static Func<ITypeShape<T>?>? CreateResolveDynamicFactory()
-        {
-            if (typeof(TProvider).GetCustomAttribute<TypeShapeProviderAttribute>() is { TypeShapeProvider: Type providerType })
-            {
-                var typeShapeProvider = (ITypeShapeProvider)Activator.CreateInstance(providerType)!;
-                return () => (ITypeShape<T>?)typeShapeProvider.GetTypeShape(typeof(T));
-            }
-#if NET
-            // For forward compatibility with newer target frameworks
-            // also resolve potential IShapeable<T> implementations.
-            if (typeof(IShapeable<T>).IsAssignableFrom(typeof(TProvider)))
-            {
-                MethodInfo genericResolveMethod = typeof(TypeShapeResolver).GetMethod(nameof(Resolve), genericParameterCount: 2, BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null)!;
-                MethodInfo resolveMethod = genericResolveMethod.MakeGenericMethod(typeof(T), typeof(TProvider));
-                return resolveMethod.CreateDelegate<Func<ITypeShape<T>?>>();
-            }
-#endif
-            return null;
+            return s_cachedShape;
         }
     }
 }

--- a/src/PolyType/Abstractions/TypeShapeResolver.cs
+++ b/src/PolyType/Abstractions/TypeShapeResolver.cs
@@ -167,14 +167,10 @@ public static class TypeShapeResolver
 
         private static Func<ITypeShape<T>?>? CreateResolveDynamicFactory()
         {
-            if (typeof(TProvider).GetCustomAttribute<TypeShapeProviderAttribute>() is { } attr)
+            if (typeof(TProvider).GetCustomAttribute<TypeShapeProviderAttribute>() is { TypeShapeProvider: Type providerType })
             {
-                Type typeShapeProviderType = attr.TypeShapeProvider;
-                return () =>
-                {
-                    var typeShapeProvider = (ITypeShapeProvider)Activator.CreateInstance(typeShapeProviderType)!;
-                    return typeShapeProvider.GetTypeShape(typeof(T)) as ITypeShape<T>;
-                };
+                var typeShapeProvider = (ITypeShapeProvider)Activator.CreateInstance(providerType)!;
+                return () => (ITypeShape<T>?)typeShapeProvider.GetTypeShape(typeof(T));
             }
 #if NET
             // For forward compatibility with newer target frameworks

--- a/src/PolyType/Abstractions/TypeShapeResolver.cs
+++ b/src/PolyType/Abstractions/TypeShapeResolver.cs
@@ -52,7 +52,7 @@ public static class TypeShapeResolver
     [RequiresDynamicCode(ResolveDynamicMessage)]
 #endif
     public static ITypeShape<T>? ResolveDynamic<T>() =>
-        ResolveDynamicFactoryCache<T, T>.GetTypeShape();
+        ResolveDynamicFactoryCache<T, T>.Shape;
 
     /// <summary>
     /// Uses reflection to resolve the source generated <see cref="ITypeShape{T}"/> implementation from another type.
@@ -75,7 +75,7 @@ public static class TypeShapeResolver
     [RequiresDynamicCode(ResolveDynamicMessage)]
 #endif
     public static ITypeShape<T>? ResolveDynamic<T, TProvider>() =>
-        ResolveDynamicFactoryCache<T, TProvider>.GetTypeShape();
+        ResolveDynamicFactoryCache<T, TProvider>.Shape;
 
     /// <summary>
     /// Uses reflection to resolve the source generated <see cref="ITypeShape{T}"/> implementation of the type.
@@ -99,7 +99,7 @@ public static class TypeShapeResolver
 #endif
     public static ITypeShape<T> ResolveDynamicOrThrow<T>()
     {
-        ITypeShape<T>? result = ResolveDynamicFactoryCache<T, T>.GetTypeShape();
+        ITypeShape<T>? result = ResolveDynamicFactoryCache<T, T>.Shape;
         if (result is null)
         {
             ThrowNotSupported();
@@ -134,7 +134,7 @@ public static class TypeShapeResolver
 #endif
     public static ITypeShape<T> ResolveDynamicOrThrow<T, TProvider>()
     {
-        ITypeShape<T>? result = ResolveDynamicFactoryCache<T, TProvider>.GetTypeShape();
+        ITypeShape<T>? result = ResolveDynamicFactoryCache<T, TProvider>.Shape;
         if (result is null)
         {
             ThrowNotSupported();
@@ -151,36 +151,27 @@ public static class TypeShapeResolver
 #endif
     private static class ResolveDynamicFactoryCache<T, TProvider>
     {
-        private static ITypeShape<T>? s_cachedShape;
-        private static bool s_isCacheInitialized;
+        internal static ITypeShape<T>? Shape { get; } = GetTypeShape();
 
-        public static ITypeShape<T>? GetTypeShape()
+        private static ITypeShape<T>? GetTypeShape()
         {
-            if (!s_isCacheInitialized)
+            if (typeof(TProvider).GetCustomAttribute<TypeShapeProviderAttribute>() is { TypeShapeProvider: Type providerType })
             {
-                if (typeof(TProvider).GetCustomAttribute<TypeShapeProviderAttribute>() is { TypeShapeProvider: Type providerType })
-                {
-                    var typeShapeProvider = (ITypeShapeProvider)Activator.CreateInstance(providerType)!;
-                    s_cachedShape = (ITypeShape<T>?)typeShapeProvider.GetTypeShape(typeof(T));
-                }
+                var typeShapeProvider = (ITypeShapeProvider)Activator.CreateInstance(providerType)!;
+                return (ITypeShape<T>?)typeShapeProvider.GetTypeShape(typeof(T));
+            }
 #if NET
-                else
-                {
-                    // For forward compatibility with newer target frameworks
-                    // also resolve potential IShapeable<T> implementations.
-                    if (typeof(IShapeable<T>).IsAssignableFrom(typeof(TProvider)))
-                    {
-                        MethodInfo genericResolveMethod = typeof(TypeShapeResolver).GetMethod(nameof(Resolve), genericParameterCount: 2, BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null)!;
-                        MethodInfo resolveMethod = genericResolveMethod.MakeGenericMethod(typeof(T), typeof(TProvider));
-                        s_cachedShape = (ITypeShape<T>?)resolveMethod.Invoke(null, []);
-                    }
-                }
+            // For forward compatibility with newer target frameworks
+            // also resolve potential IShapeable<T> implementations.
+            if (typeof(IShapeable<T>).IsAssignableFrom(typeof(TProvider)))
+            {
+                MethodInfo genericResolveMethod = typeof(TypeShapeResolver).GetMethod(nameof(Resolve), genericParameterCount: 2, BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null)!;
+                MethodInfo resolveMethod = genericResolveMethod.MakeGenericMethod(typeof(T), typeof(TProvider));
+                return (ITypeShape<T>?)resolveMethod.Invoke(null, []);
+            }
 #endif
 
-                Volatile.Write(ref s_isCacheInitialized, true);
-            }
-
-            return s_cachedShape;
+            return null;
         }
     }
 }


### PR DESCRIPTION
The `TypeShapeResolver.ResolveDynamicOrThrow` method allocates a new type shape provider on every invocation, even though the type shape provider and type shape itself can be reasonably expected to be observably immutable.

These allocations showed up during VS startup. 

I prepared this change in three changes:

1. Cache the type shape provider instance instead of recreating it on every request for its (1) type shape. 
    *Assumption:* the type shape provider implementation will produce either an immutable type shape or a new type shape instance on every request for a type shape.
2. Shift from a _factory_ of the type shape to just caching and returning the type shape directly.
    *Assumption:* The type shape itself is immutable (and thus safe to cache and return to every caller).
3. Replace the manual caching logic with a static field initializer so the CLR can deal with the one-time initialization instead of our C# code.

@eiriktsarpalis Are the assumptions reasonable?