### PR TITLE
Support open generic derived types in polymorphism

### DIFF
--- a/docs/docs/shape-providers.md
+++ b/docs/docs/shape-providers.md
@@ -348,42 +348,17 @@ record Mid<T> : Base<List<T>>;
 record Leaf<T>(List<T> Items) : Mid<T>;
 ```
 
-Open generic derived types are rejected at compile-time (for the source generator) or shape-construction time (for the reflection provider) when the registration is *fundamentally* invalid -- that is, no instantiation of the base type could ever satisfy it:
+Open generic derived types are rejected at compile time (for the source generator) or shape-construction time (for the reflection provider) when the registration cannot be resolved for the requested base type:
 
 * The derived type does not derive from or implement *any* instantiation of the base type.
+* The derived type targets a different construction of the generic base — e.g. `Derived<T> : Base<T, int>` registered for `Base<string, string>`.
 * The derived type has type parameters that cannot be inferred from any base specification — e.g. `Derived<T, U> : Base<T>` leaves `U` unbound.
+* The inferred type arguments do not satisfy a generic constraint declared by the derived type.
 * The derived type matches more than one ancestor instantiation of the base — only relevant for interface bases.
 
 The source generator emits diagnostic `PT0013` for these failures with a short message describing the reason; the reflection provider throws `InvalidOperationException` with an equivalent message.
 
-#### Per-instantiation filtering
-
-A registration that is well-formed in isolation but does not apply to the *particular* closed base being resolved is silently filtered rather than reported as an error. This allows a single declaration to span multiple closed instantiations naturally:
-
-```csharp
-// Cat targets Animal<int>; Dog targets Animal<string>. The two attributes coexist:
-// when resolving Animal<int>, Cat is included and Dog is filtered; the converse holds for Animal<string>.
-[DerivedTypeShape(typeof(Cat))]
-[DerivedTypeShape(typeof(Dog))]
-partial class Animal<T>;
-class Cat : Animal<int>;
-class Dog : Animal<string>;
-```
-
-```csharp
-// A constraint on the derived type filters per closed base. For Base<List<int>> the derivation
-// applies; for Base<string> (where string does not implement IEnumerable<int>) it is filtered.
-[DerivedTypeShape(typeof(Derived<>))]
-partial class Base<T>;
-class Derived<T> : Base<T> where T : IEnumerable<int>;
-```
-
-The two failure modes that are silently filtered (rather than diagnosed) are:
-
-* **Unification mismatch** — a closed derived registered for `Base<int>` simply does not apply when resolving `Base<string>`; the same is true for an open derived whose base specification cannot be unified with the requested closed base (e.g. `Wrapped<T> : Base<List<T>>` against `Base<int>`).
-* **Constraint violation** — the resolved substitution does not satisfy a `where T : …` constraint on the derived type for this particular closed base.
-
-In both cases the registration is dropped silently; if all registrations are filtered out, the resulting union shape simply has no derived cases.
+Every declared registration participates in the union configuration. PolyType does not filter registrations that only apply to another closed construction of the base. For example, registering both `Cat : Animal<int>` and `Dog : Animal<string>` on `Animal<T>` makes the configuration invalid for either closed base because one registration is not assignable. Define separate closed base declarations when different constructions require different derived-type sets.
 
 ### PropertyShapeAttribute
 

--- a/docs/docs/shape-providers.md
+++ b/docs/docs/shape-providers.md
@@ -345,15 +345,42 @@ record Mid<T> : Base<List<T>>;
 record Leaf<T>(List<T> Items) : Mid<T>;
 ```
 
-Open generic derived types are rejected at compile-time (for the source generator) or shape-construction time (for the reflection provider) when:
+Open generic derived types are rejected at compile-time (for the source generator) or shape-construction time (for the reflection provider) when the registration is *fundamentally* invalid -- that is, no instantiation of the base type could ever satisfy it:
 
-* The derived type does not derive from or implement the base type.
-* The derived type's base specification cannot be unified with the closed base — for example, `Derived<T> : Base<int>` against `Base<string>`.
-* The derived type has type parameters that cannot be inferred from the base — e.g. `Derived<T, U> : Base<T>` leaves `U` unbound.
-* The unified substitution does not satisfy the generic constraints on the derived type.
+* The derived type does not derive from or implement *any* instantiation of the base type.
+* The derived type has type parameters that cannot be inferred from any base specification — e.g. `Derived<T, U> : Base<T>` leaves `U` unbound.
 * The derived type matches more than one ancestor instantiation of the base — only relevant for interface bases.
 
-The source generator emits diagnostic `PT0013` for any of these failures with a short message describing the reason; the reflection provider throws `InvalidOperationException` with an equivalent message.
+The source generator emits diagnostic `PT0013` for these failures with a short message describing the reason; the reflection provider throws `InvalidOperationException` with an equivalent message.
+
+#### Per-instantiation filtering
+
+A registration that is well-formed in isolation but does not apply to the *particular* closed base being resolved is silently filtered rather than reported as an error. This allows a single declaration to span multiple closed instantiations naturally:
+
+```csharp
+// Cat targets Animal<int>; Dog targets Animal<string>. The two attributes coexist:
+// when resolving Animal<int>, Cat is included and Dog is filtered; the converse holds for Animal<string>.
+[DerivedTypeShape(typeof(Cat))]
+[DerivedTypeShape(typeof(Dog))]
+partial class Animal<T>;
+class Cat : Animal<int>;
+class Dog : Animal<string>;
+```
+
+```csharp
+// A constraint on the derived type filters per closed base. For Base<List<int>> the derivation
+// applies; for Base<string> (where string does not implement IEnumerable<int>) it is filtered.
+[DerivedTypeShape(typeof(Derived<>))]
+partial class Base<T>;
+class Derived<T> : Base<T> where T : IEnumerable<int>;
+```
+
+The two failure modes that are silently filtered (rather than diagnosed) are:
+
+* **Unification mismatch** — a closed derived registered for `Base<int>` simply does not apply when resolving `Base<string>`; the same is true for an open derived whose base specification cannot be unified with the requested closed base (e.g. `Wrapped<T> : Base<List<T>>` against `Base<int>`).
+* **Constraint violation** — the resolved substitution does not satisfy a `where T : …` constraint on the derived type for this particular closed base.
+
+In both cases the registration is dropped silently; if all registrations are filtered out, the resulting union shape simply has no derived cases.
 
 ### PropertyShapeAttribute
 

--- a/docs/docs/shape-providers.md
+++ b/docs/docs/shape-providers.md
@@ -297,6 +297,64 @@ class Impl : IDerived1, IDerived2;
 
 Instances of type `Impl` could resolve as either `IDerived1` or `IDerived2`, depending on the particular runtime and shape provider implementation. This ambiguity can be resolved by explicitly adding a `DerivedTypeShape` declaration for `Impl` or any intermediate interface type implementing both `IDerived1` and `IDerived2`.
 
+#### Generic polymorphism
+
+`DerivedTypeShape` accepts both closed and open generic types. When the derived type is a constructed generic, it is registered as-is:
+
+```csharp
+[DerivedTypeShape(typeof(Derived<int>), Name = "DerivedInt")]
+[DerivedTypeShape(typeof(Derived<string>), Name = "DerivedString")]
+partial record Base
+{
+    public record Derived<T>(T Value) : Base;
+}
+```
+
+When the derived type is an open generic, PolyType attempts to unify its base specification with the closed base type at shape resolution time. This makes a single attribute applicable across every closed instantiation of the base. The following patterns are supported:
+
+```csharp
+// 1. Identity binding — derived's parameters flow through directly.
+[DerivedTypeShape(typeof(Derived<>), Name = "Derived")]
+partial record Base<T>;
+record Derived<T>(T Value) : Base<T>;
+
+// 2. Reordered or remapped parameters.
+[DerivedTypeShape(typeof(Reordered<,>))]
+partial record Base<T1, T2>;
+record Reordered<U, V>(U Left, V Right) : Base<V, U>;
+
+// 3. Partial concretization — derived pins down some base parameters.
+[DerivedTypeShape(typeof(Partial<>))]
+partial record Base<T1, T2>;
+record Partial<T>(T Value) : Base<T, int>;
+
+// 4. Wrapped or nested type arguments.
+[DerivedTypeShape(typeof(Wrapped<>))]
+partial record Base<T>;
+record Wrapped<T>(List<T> Data) : Base<List<T>>;
+
+// 5. Interface bases — at most one matching instantiation per closed base.
+[DerivedTypeShape(typeof(Impl<>))]
+partial interface IBase<T>;
+record Impl<T>(T? Value) : IBase<T>;
+
+// 6. Multi-level hierarchies — substitution flows through intermediate generic ancestors.
+[DerivedTypeShape(typeof(Leaf<>))]
+partial record Base<T>;
+record Mid<T> : Base<List<T>>;
+record Leaf<T>(List<T> Items) : Mid<T>;
+```
+
+Open generic derived types are rejected at compile-time (for the source generator) or shape-construction time (for the reflection provider) when:
+
+* The derived type does not derive from or implement the base type.
+* The derived type's base specification cannot be unified with the closed base — for example, `Derived<T> : Base<int>` against `Base<string>`.
+* The derived type has type parameters that cannot be inferred from the base — e.g. `Derived<T, U> : Base<T>` leaves `U` unbound.
+* The unified substitution does not satisfy the generic constraints on the derived type.
+* The derived type matches more than one ancestor instantiation of the base — only relevant for interface bases.
+
+The source generator emits diagnostic `PT0013` for any of these failures with a short message describing the reason; the reflection provider throws `InvalidOperationException` with an equivalent message.
+
 ### PropertyShapeAttribute
 
 Configures aspects of a generated property shape, for example:

--- a/docs/docs/shape-providers.md
+++ b/docs/docs/shape-providers.md
@@ -310,7 +310,7 @@ partial record Base
 }
 ```
 
-When the derived type is an open generic, PolyType attempts to unify its base specification with the closed base type at shape resolution time. This makes a single attribute applicable across every closed instantiation of the base. The following patterns are supported:
+When the derived type is an open generic, PolyType attempts to unify its base specification with the requested closed base type at shape resolution time. A single attribute can therefore cover multiple closed instantiations when each specialization satisfies the derived type's base specification and generic constraints. The following patterns are supported:
 
 ```csharp
 // 1. Identity binding — derived's parameters flow through directly.
@@ -356,7 +356,7 @@ Open generic derived types are rejected at compile time (for the source generato
 * The inferred type arguments do not satisfy a generic constraint declared by the derived type.
 * The derived type matches more than one ancestor instantiation of the base — only relevant for interface bases.
 
-The source generator emits diagnostic `PT0013` for these failures with a short message describing the reason; the reflection provider throws `InvalidOperationException` with an equivalent message.
+The source generator emits diagnostic `PT0013` for these failures with a short message describing the reason; the reflection provider throws `InvalidOperationException` with an equivalent message. Invalid subtype registrations and duplicate metadata produce `PT0011` and `PT0012`, respectively. These diagnostics are non-configurable errors: suppressing one would otherwise let source generation silently omit an invalid registration and produce a hierarchy that differs from reflection.
 
 Every declared registration participates in the union configuration. PolyType does not filter registrations that only apply to another closed construction of the base. For example, registering both `Cat : Animal<int>` and `Dog : Animal<string>` on `Animal<T>` makes the configuration invalid for either closed base because one registration is not assignable. Define separate closed base declarations when different constructions require different derived-type sets.
 

--- a/docs/docs/shape-providers.md
+++ b/docs/docs/shape-providers.md
@@ -335,7 +335,10 @@ record Wrapped<T>(List<T> Data) : Base<List<T>>;
 
 // 5. Interface bases — at most one matching instantiation per closed base.
 [DerivedTypeShape(typeof(Impl<>))]
-partial interface IBase<T>;
+partial interface IBase<T>
+{
+    T? Value { get; }
+}
 record Impl<T>(T? Value) : IBase<T>;
 
 // 6. Multi-level hierarchies — substitution flows through intermediate generic ancestors.

--- a/src/PolyType.Roslyn/Helpers/RoslynHelpers.cs
+++ b/src/PolyType.Roslyn/Helpers/RoslynHelpers.cs
@@ -474,9 +474,9 @@ internal static class RoslynHelpers
     /// </summary>
     /// <remarks>
     /// This implementation mirrors the corresponding reflection helper
-    /// <c>PolyType.Utilities.ReflectionUtilities.GetMatchingGenericBaseTypes</c>. Any change
-    /// to the enumeration order or matching rules MUST be applied on both sides to keep
-    /// reflection and source-gen behaviour in sync.
+    /// <c>PolyType.ReflectionProvider.OpenGenericDerivedTypeResolver.GetMatchingGenericBaseTypes</c>.
+    /// Any change to the enumeration order or matching rules MUST be applied on both sides to
+    /// keep reflection and source-gen behaviour in sync.
     /// </remarks>
     public static IEnumerable<INamedTypeSymbol> GetCompatibleGenericBaseTypes(this ITypeSymbol type, INamedTypeSymbol baseTypeDefinition)
     {

--- a/src/PolyType.Roslyn/Helpers/RoslynHelpers.cs
+++ b/src/PolyType.Roslyn/Helpers/RoslynHelpers.cs
@@ -462,28 +462,50 @@ internal static class RoslynHelpers
             return null;
         }
 
-        Debug.Assert(genericType.IsGenericTypeDefinition());
+        return type.GetCompatibleGenericBaseTypes(genericType).FirstOrDefault();
+    }
 
-        if (genericType.TypeKind is TypeKind.Interface)
+    /// <summary>
+    /// Enumerates every ancestor of <paramref name="type"/> whose original definition matches
+    /// <paramref name="baseTypeDefinition"/>. For interface bases this yields every implementing
+    /// instantiation (a type can implement the same interface definition with different type
+    /// arguments); for class bases it yields at most the first match found while walking the
+    /// base-type chain (only one such instantiation is reachable).
+    /// </summary>
+    /// <remarks>
+    /// This implementation mirrors the corresponding reflection helper
+    /// <c>PolyType.Utilities.ReflectionUtilities.GetMatchingGenericBaseTypes</c>. Any change
+    /// to the enumeration order or matching rules MUST be applied on both sides to keep
+    /// reflection and source-gen behaviour in sync.
+    /// </remarks>
+    public static IEnumerable<INamedTypeSymbol> GetCompatibleGenericBaseTypes(this ITypeSymbol type, INamedTypeSymbol baseTypeDefinition)
+    {
+        Debug.Assert(baseTypeDefinition.IsGenericTypeDefinition());
+
+        if (baseTypeDefinition.TypeKind is TypeKind.Interface)
         {
             foreach (INamedTypeSymbol interfaceType in type.AllInterfaces)
             {
-                if (IsMatchingGenericType(interfaceType, genericType))
+                if (IsMatchingGenericType(interfaceType, baseTypeDefinition))
                 {
-                    return interfaceType;
+                    yield return interfaceType;
                 }
             }
+
+            // Note: do NOT yield break here. `AllInterfaces` does not include `type` itself,
+            // so when `type` IS the interface we're looking for, the fall-through to the
+            // BaseType walk below picks it up via the self-check on the first iteration
+            // (interface symbols have a null BaseType, so the loop terminates immediately).
         }
 
-        for (INamedTypeSymbol? current = type as INamedTypeSymbol; current != null; current = current.BaseType)
+        for (INamedTypeSymbol? current = type as INamedTypeSymbol; current is not null; current = current.BaseType)
         {
-            if (IsMatchingGenericType(current, genericType))
+            if (IsMatchingGenericType(current, baseTypeDefinition))
             {
-                return current;
+                yield return current;
+                yield break;
             }
         }
-
-        return null;
 
         static bool IsMatchingGenericType(INamedTypeSymbol candidate, INamedTypeSymbol baseType)
         {

--- a/src/PolyType.SourceGenerator/Helpers/OpenGenericDerivedTypeHelpers.cs
+++ b/src/PolyType.SourceGenerator/Helpers/OpenGenericDerivedTypeHelpers.cs
@@ -405,3 +405,15 @@ internal enum OpenGenericResolutionFailure
     /// <summary>The derived type matches the base type through multiple distinct ancestors.</summary>
     AmbiguousMatch,
 }
+
+internal static class OpenGenericResolutionFailureExtensions
+{
+    // Returns true when the failure is caused by the registration not matching THIS particular
+    // closed base, but where the same registration could plausibly apply to a different
+    // instantiation of the base. Such failures are silently skipped rather than reported as
+    // diagnostics, allowing a single attribute on an open base to span multiple closed
+    // instantiations naturally.
+    public static bool IsPerInstantiationFailure(this OpenGenericResolutionFailure failure) =>
+        failure is OpenGenericResolutionFailure.UnificationFailed
+            or OpenGenericResolutionFailure.ConstraintViolation;
+}

--- a/src/PolyType.SourceGenerator/Helpers/OpenGenericDerivedTypeHelpers.cs
+++ b/src/PolyType.SourceGenerator/Helpers/OpenGenericDerivedTypeHelpers.cs
@@ -5,8 +5,8 @@
 // behaviour in sync.
 //
 // The algorithm is a port of the resolver added in dotnet/runtime#127318 (System.Text.Json
-// support for open generic [JsonDerivedType]). See the PR description for the full set of
-// supported and rejected patterns.
+// support for open generic [JsonDerivedType]), with failure semantics aligned to the refinements
+// in dotnet/runtime#130808. See those PRs for the supported and rejected patterns.
 
 using Microsoft.CodeAnalysis;
 using PolyType.Roslyn.Helpers;
@@ -405,16 +405,4 @@ internal enum OpenGenericResolutionFailure
     ConstraintViolation,
     /// <summary>The derived type matches the base type through multiple distinct ancestors.</summary>
     AmbiguousMatch,
-}
-
-internal static class OpenGenericResolutionFailureExtensions
-{
-    // Returns true when the failure is caused by the registration not matching THIS particular
-    // closed base, but where the same registration could plausibly apply to a different
-    // instantiation of the base. Such failures are silently skipped rather than reported as
-    // diagnostics, allowing a single attribute on an open base to span multiple closed
-    // instantiations naturally.
-    public static bool IsPerInstantiationFailure(this OpenGenericResolutionFailure failure) =>
-        failure is OpenGenericResolutionFailure.UnificationFailed
-            or OpenGenericResolutionFailure.ConstraintViolation;
 }

--- a/src/PolyType.SourceGenerator/Helpers/OpenGenericDerivedTypeHelpers.cs
+++ b/src/PolyType.SourceGenerator/Helpers/OpenGenericDerivedTypeHelpers.cs
@@ -1,7 +1,8 @@
 ﻿// Implements the structural unification algorithm used to close open generic derived types
 // against a constructed base type. This file contains the source-generator-side mirror of the
-// reflection algorithm in PolyType.Utilities.ReflectionUtilities. Any structural change here
-// MUST be applied on both sides to keep reflection and source-gen behaviour in sync.
+// reflection algorithm in PolyType.ReflectionProvider.OpenGenericDerivedTypeResolver. Any
+// structural change here MUST be applied on both sides to keep reflection and source-gen
+// behaviour in sync.
 //
 // The algorithm is a port of the resolver added in dotnet/runtime#127318 (System.Text.Json
 // support for open generic [JsonDerivedType]). See the PR description for the full set of

--- a/src/PolyType.SourceGenerator/Helpers/OpenGenericDerivedTypeHelpers.cs
+++ b/src/PolyType.SourceGenerator/Helpers/OpenGenericDerivedTypeHelpers.cs
@@ -1,0 +1,407 @@
+﻿// Implements the structural unification algorithm used to close open generic derived types
+// against a constructed base type. This file contains the source-generator-side mirror of the
+// reflection algorithm in PolyType.Utilities.ReflectionUtilities. Any structural change here
+// MUST be applied on both sides to keep reflection and source-gen behaviour in sync.
+//
+// The algorithm is a port of the resolver added in dotnet/runtime#127318 (System.Text.Json
+// support for open generic [JsonDerivedType]). See the PR description for the full set of
+// supported and rejected patterns.
+
+using Microsoft.CodeAnalysis;
+using PolyType.Roslyn.Helpers;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace PolyType.SourceGenerator.Helpers;
+
+internal static class OpenGenericDerivedTypeHelpers
+{
+    /// <summary>
+    /// Returns the full set of type parameters that must be bound to construct
+    /// <paramref name="typeDef"/>: the type parameters of every enclosing type
+    /// (outermost first) followed by the type parameters declared on
+    /// <paramref name="typeDef"/> itself.
+    /// </summary>
+    public static List<ITypeParameterSymbol> GetAllTypeParameters(this INamedTypeSymbol typeDef)
+    {
+        var result = new List<ITypeParameterSymbol>();
+        AppendEnclosing(typeDef.ContainingType, result);
+        result.AddRange(typeDef.TypeParameters);
+        return result;
+
+        static void AppendEnclosing(INamedTypeSymbol? enclosing, List<ITypeParameterSymbol> list)
+        {
+            if (enclosing is null)
+            {
+                return;
+            }
+
+            AppendEnclosing(enclosing.ContainingType, list);
+            list.AddRange(enclosing.TypeParameters);
+        }
+    }
+
+    /// <summary>
+    /// Attempts to unify a <paramref name="pattern"/> type (which may contain type-parameter
+    /// references) with a <paramref name="target"/> type, recording bindings in
+    /// <paramref name="substitution"/>. Returns <see langword="true"/> if the pattern matches
+    /// the target under some extension of the current substitution.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors the reflection-side <c>TryUnifyWith</c> helper. Roslyn doesn't surface SZ-vs-rank-1
+    /// distinction or byref types in attribute syntax, so this implementation handles fewer kinds
+    /// than its reflection counterpart.
+    /// </remarks>
+    public static bool TryUnifyWith(this ITypeSymbol pattern, ITypeSymbol target, IDictionary<ITypeParameterSymbol, ITypeSymbol> substitution)
+    {
+        if (pattern is ITypeParameterSymbol patternParam)
+        {
+            if (substitution.TryGetValue(patternParam, out ITypeSymbol? existing))
+            {
+                return SymbolEqualityComparer.Default.Equals(existing, target);
+            }
+
+            substitution[patternParam] = target;
+            return true;
+        }
+
+        if (pattern is IArrayTypeSymbol patternArray)
+        {
+            return target is IArrayTypeSymbol targetArray
+                && patternArray.Rank == targetArray.Rank
+                && patternArray.ElementType.TryUnifyWith(targetArray.ElementType, substitution);
+        }
+
+        if (pattern is IPointerTypeSymbol patternPointer)
+        {
+            return target is IPointerTypeSymbol targetPointer
+                && patternPointer.PointedAtType.TryUnifyWith(targetPointer.PointedAtType, substitution);
+        }
+
+        if (pattern is INamedTypeSymbol { IsGenericType: true } patternNamed)
+        {
+            if (target is not INamedTypeSymbol { IsGenericType: true } targetNamed)
+            {
+                return false;
+            }
+
+            if (!SymbolEqualityComparer.Default.Equals(patternNamed.OriginalDefinition, targetNamed.OriginalDefinition))
+            {
+                return false;
+            }
+
+            // Walk ContainingType to mirror reflection's Type.GetGenericArguments() flattening
+            // behaviour for nested generic types. Without this recursion, the unifier would (a)
+            // miss enclosing-type mismatches (e.g. unify Outer<int>.Box<T> with
+            // Outer<string>.Box<int>, false accept), and (b) fail to bind type parameters that
+            // only appear in the enclosing type (e.g. Outer<T>.Box<int> against
+            // Outer<string>.Box<int>, false reject).
+            INamedTypeSymbol? patternContaining = patternNamed.ContainingType;
+            INamedTypeSymbol? targetContaining = targetNamed.ContainingType;
+            if (patternContaining is not null && targetContaining is not null &&
+                !patternContaining.TryUnifyWith(targetContaining, substitution))
+            {
+                return false;
+            }
+
+            ImmutableArray<ITypeSymbol> patternArgs = patternNamed.TypeArguments;
+            ImmutableArray<ITypeSymbol> targetArgs = targetNamed.TypeArguments;
+            if (patternArgs.Length != targetArgs.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < patternArgs.Length; i++)
+            {
+                if (!patternArgs[i].TryUnifyWith(targetArgs[i], substitution))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return SymbolEqualityComparer.Default.Equals(pattern, target);
+    }
+
+    /// <summary>
+    /// Returns the type that results from applying <paramref name="substitution"/> to every
+    /// type-parameter reference inside <paramref name="type"/>. Generic types and array types
+    /// are rebuilt recursively; other types are returned unchanged. For nested generic types,
+    /// the substitution is also applied to the containing type so that type parameters
+    /// declared on the enclosing type are correctly rebound.
+    /// </summary>
+    public static ITypeSymbol SubstituteTypeParameters(this Compilation compilation, ITypeSymbol type, IReadOnlyDictionary<ITypeParameterSymbol, ITypeSymbol> substitution)
+    {
+        if (type is ITypeParameterSymbol param)
+        {
+            return substitution.TryGetValue(param, out ITypeSymbol? mapped) ? mapped : type;
+        }
+
+        if (type is INamedTypeSymbol { IsGenericType: true } named)
+        {
+            INamedTypeSymbol? containingType = named.ContainingType;
+            INamedTypeSymbol? substitutedContaining = null;
+            bool containingChanged = false;
+            if (containingType is { IsGenericType: true })
+            {
+                substitutedContaining = (INamedTypeSymbol)compilation.SubstituteTypeParameters(containingType, substitution);
+                containingChanged = !SymbolEqualityComparer.Default.Equals(substitutedContaining, containingType);
+            }
+
+            ImmutableArray<ITypeSymbol> args = named.TypeArguments;
+            ITypeSymbol[]? newArgs = null;
+            for (int i = 0; i < args.Length; i++)
+            {
+                ITypeSymbol substituted = compilation.SubstituteTypeParameters(args[i], substitution);
+                if (!SymbolEqualityComparer.Default.Equals(substituted, args[i]))
+                {
+                    newArgs ??= args.ToArray();
+                    newArgs[i] = substituted;
+                }
+            }
+
+            if (newArgs is null && !containingChanged)
+            {
+                return type;
+            }
+
+            ITypeSymbol[] leafArgs = newArgs ?? args.ToArray();
+
+            if (substitutedContaining is null)
+            {
+                return named.OriginalDefinition.Construct(leafArgs);
+            }
+
+            INamedTypeSymbol nestedDef = substitutedContaining
+                .GetTypeMembers(named.Name, leafArgs.Length)
+                .Single(t => SymbolEqualityComparer.Default.Equals(t.OriginalDefinition, named.OriginalDefinition));
+            return leafArgs.Length == 0 ? nestedDef : nestedDef.Construct(leafArgs);
+        }
+
+        if (type is IArrayTypeSymbol array)
+        {
+            ITypeSymbol substituted = compilation.SubstituteTypeParameters(array.ElementType, substitution);
+            return SymbolEqualityComparer.Default.Equals(substituted, array.ElementType)
+                ? type
+                : compilation.CreateArrayTypeSymbol(substituted, array.Rank);
+        }
+
+        return type;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="arg"/> satisfies a
+    /// <c>where T : new()</c> constraint — i.e. it is a value type, or a non-abstract,
+    /// non-static reference type with an accessible public parameterless constructor.
+    /// </summary>
+    public static bool SatisfiesNewConstraint(this ITypeSymbol arg)
+    {
+        if (arg.IsValueType)
+        {
+            return true;
+        }
+
+        if (arg is not INamedTypeSymbol named || named.IsAbstract || named.IsStatic)
+        {
+            return false;
+        }
+
+        foreach (IMethodSymbol ctor in named.InstanceConstructors)
+        {
+            if (ctor.Parameters.Length == 0 && ctor.DeclaredAccessibility == Accessibility.Public)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Validates that every type parameter in <paramref name="parameters"/> has a substitution
+    /// in <paramref name="substitution"/> that satisfies the parameter's declared constraints
+    /// (reference type, value type, unmanaged, <c>new()</c>, and constraint types). Constraint
+    /// types are themselves substituted before checking, to handle F-bounded constraints such
+    /// as <c>where T : IFoo&lt;U&gt;</c>.
+    /// </summary>
+    public static bool TryValidateGenericConstraints(
+        this Compilation compilation,
+        IReadOnlyList<ITypeParameterSymbol> parameters,
+        IReadOnlyDictionary<ITypeParameterSymbol, ITypeSymbol> substitution,
+        [NotNullWhen(false)] out ITypeParameterSymbol? failedParameter,
+        out ITypeSymbol? failedArgument)
+    {
+        foreach (ITypeParameterSymbol param in parameters)
+        {
+            if (!substitution.TryGetValue(param, out ITypeSymbol? arg))
+            {
+                failedParameter = param;
+                failedArgument = null;
+                return false;
+            }
+
+            if (param.HasReferenceTypeConstraint && !arg.IsReferenceType)
+            {
+                failedParameter = param;
+                failedArgument = arg;
+                return false;
+            }
+
+            if (param.HasValueTypeConstraint)
+            {
+                if (!arg.IsValueType || arg is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T })
+                {
+                    failedParameter = param;
+                    failedArgument = arg;
+                    return false;
+                }
+            }
+
+            if (param.HasUnmanagedTypeConstraint && !arg.IsUnmanagedType)
+            {
+                failedParameter = param;
+                failedArgument = arg;
+                return false;
+            }
+
+            if (param.HasConstructorConstraint && !arg.SatisfiesNewConstraint())
+            {
+                failedParameter = param;
+                failedArgument = arg;
+                return false;
+            }
+
+            foreach (ITypeSymbol constraintType in param.ConstraintTypes)
+            {
+                ITypeSymbol substituted = compilation.SubstituteTypeParameters(constraintType, substitution);
+
+                // Use HasImplicitConversion so generic variance is respected (e.g.
+                // `where T : IEnumerable<object>` is satisfied by `List<string>` via the
+                // covariant `IEnumerable<out T>`).
+                if (!compilation.HasImplicitConversion(arg, substituted))
+                {
+                    failedParameter = param;
+                    failedArgument = arg;
+                    return false;
+                }
+            }
+        }
+
+        failedParameter = null;
+        failedArgument = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Constructs <paramref name="typeDef"/> using <paramref name="allArgs"/>, accounting for
+    /// nesting: the leading args bind enclosing-type parameters (outermost first) and the
+    /// trailing args bind <paramref name="typeDef"/>'s own parameters. Non-generic intermediate
+    /// enclosing types still need to be re-resolved against the constructed outer so that
+    /// references to their generic outers carry the supplied type arguments.
+    /// </summary>
+    public static INamedTypeSymbol ConstructWithEnclosingTypeArguments(this INamedTypeSymbol typeDef, IReadOnlyList<ITypeSymbol> allArgs)
+    {
+        int offset = 0;
+        INamedTypeSymbol? constructedContaining = ConstructEnclosing(typeDef.ContainingType, allArgs, ref offset);
+
+        int leafParamCount = typeDef.TypeParameters.Length;
+        ITypeSymbol[] leafArgs = new ITypeSymbol[leafParamCount];
+        for (int i = 0; i < leafParamCount; i++)
+        {
+            leafArgs[i] = allArgs[offset + i];
+        }
+
+        if (constructedContaining is not null)
+        {
+            INamedTypeSymbol nestedDef = constructedContaining
+                .GetTypeMembers(typeDef.Name, leafParamCount)
+                .Single(t => SymbolEqualityComparer.Default.Equals(t.OriginalDefinition, typeDef));
+            return leafParamCount == 0 ? nestedDef : nestedDef.Construct(leafArgs);
+        }
+
+        return leafParamCount == 0 ? typeDef : typeDef.Construct(leafArgs);
+
+        static INamedTypeSymbol? ConstructEnclosing(INamedTypeSymbol? enclosing, IReadOnlyList<ITypeSymbol> allArgs, ref int offset)
+        {
+            if (enclosing is null)
+            {
+                return null;
+            }
+
+            INamedTypeSymbol? constructedOuter = ConstructEnclosing(enclosing.ContainingType, allArgs, ref offset);
+
+            int paramCount = enclosing.TypeParameters.Length;
+            ITypeSymbol[] enclosingArgs = new ITypeSymbol[paramCount];
+            for (int i = 0; i < paramCount; i++)
+            {
+                enclosingArgs[i] = allArgs[offset + i];
+            }
+            offset += paramCount;
+
+            if (constructedOuter is null)
+            {
+                return paramCount == 0 ? enclosing : enclosing.Construct(enclosingArgs);
+            }
+
+            INamedTypeSymbol nestedDef = constructedOuter
+                .GetTypeMembers(enclosing.Name, paramCount)
+                .Single(t => SymbolEqualityComparer.Default.Equals(t.OriginalDefinition, enclosing));
+            return paramCount == 0 ? nestedDef : nestedDef.Construct(enclosingArgs);
+        }
+    }
+
+    /// <summary>
+    /// Adds every type-parameter symbol referenced inside <paramref name="pattern"/> (directly or
+    /// through generic, array, or pointer wrappers, including enclosing-type parameters) to
+    /// <paramref name="set"/>.
+    /// </summary>
+    public static void CollectReferencedParameters(ITypeSymbol pattern, HashSet<ITypeParameterSymbol> set)
+    {
+        switch (pattern)
+        {
+            case ITypeParameterSymbol tp:
+                set.Add(tp);
+                return;
+
+            case IArrayTypeSymbol array:
+                CollectReferencedParameters(array.ElementType, set);
+                return;
+
+            case IPointerTypeSymbol pointer:
+                CollectReferencedParameters(pointer.PointedAtType, set);
+                return;
+
+            case INamedTypeSymbol { IsGenericType: true } named:
+                if (named.ContainingType is { IsGenericType: true } containing)
+                {
+                    CollectReferencedParameters(containing, set);
+                }
+
+                foreach (ITypeSymbol arg in named.TypeArguments)
+                {
+                    CollectReferencedParameters(arg, set);
+                }
+                return;
+        }
+    }
+}
+
+/// <summary>
+/// Identifies why an open generic derived type could not be resolved against a constructed base.
+/// </summary>
+internal enum OpenGenericResolutionFailure
+{
+    /// <summary>The derived type cannot be assigned to the base type (no matching ancestor).</summary>
+    NotAssignable,
+    /// <summary>The base type's arguments could not be unified with the derived type's base specification.</summary>
+    UnificationFailed,
+    /// <summary>One of the derived type's type parameters is not bound by the base type's arguments.</summary>
+    UnboundParameter,
+    /// <summary>The closed derived type would violate one of its declared generic constraints.</summary>
+    ConstraintViolation,
+    /// <summary>The derived type matches the base type through multiple distinct ancestors.</summary>
+    AmbiguousMatch,
+}

--- a/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
@@ -105,8 +105,8 @@ public sealed partial class Parser
 
     private static DiagnosticDescriptor DerivedTypeUnsupportedGenerics { get; } = new DiagnosticDescriptor(
         id: "PT0013",
-        title: "Derived type uses unsupported generics.",
-        messageFormat: "The declared derived type '{0}' introduces unsupported type parameters over '{1}'.",
+        title: "Open generic derived type could not be resolved.",
+        messageFormat: "The open generic derived type '{0}' could not be resolved for the polymorphic base type '{1}': {2}.",
         category: "PolyType.SourceGenerator",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.Diagnostics.cs
@@ -93,7 +93,8 @@ public sealed partial class Parser
         messageFormat: "The declared derived type '{0}' is not a valid subtype of '{1}'.",
         category: "PolyType.SourceGenerator",
         defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        customTags: WellKnownDiagnosticTags.NotConfigurable);
 
     private static DiagnosticDescriptor DerivedTypeDuplicateMetadata { get; } = new DiagnosticDescriptor(
         id: "PT0012",
@@ -101,7 +102,8 @@ public sealed partial class Parser
         messageFormat: "Polymorphic type '{0}' uses duplicate assignments for {1} '{2}'.",
         category: "PolyType.SourceGenerator",
         defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        customTags: WellKnownDiagnosticTags.NotConfigurable);
 
     private static DiagnosticDescriptor DerivedTypeUnsupportedGenerics { get; } = new DiagnosticDescriptor(
         id: "PT0013",
@@ -109,7 +111,8 @@ public sealed partial class Parser
         messageFormat: "The open generic derived type '{0}' could not be resolved for the polymorphic base type '{1}': {2}.",
         category: "PolyType.SourceGenerator",
         defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        customTags: WellKnownDiagnosticTags.NotConfigurable);
 
     private static DiagnosticDescriptor AssociatedTypeArityMismatch { get; } = new DiagnosticDescriptor(
         id: "PT0016",

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -7,6 +7,7 @@ using PolyType.SourceGenerator.Helpers;
 using PolyType.SourceGenerator.Model;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -589,7 +590,6 @@ public sealed partial class Parser : TypeDataModelGenerator
         }
 
         int i = 0;
-        ITypeSymbol[]? baseTypeArgs = null;
         HashSet<ITypeSymbol> types = new(SymbolEqualityComparer.Default);
         HashSet<int> tags = new();
         HashSet<string> names = new(StringComparer.Ordinal);
@@ -623,11 +623,9 @@ public sealed partial class Parser : TypeDataModelGenerator
 
             if (derivedType is INamedTypeSymbol { IsUnboundGenericType: true } namedDerivedType)
             {
-                baseTypeArgs ??= ((INamedTypeSymbol)type).GetRecursiveTypeArguments();
-                INamedTypeSymbol? specializedDerivedType = namedDerivedType.OriginalDefinition.ConstructRecursive(baseTypeArgs);
-                if (specializedDerivedType is null || !type.IsAssignableFrom(specializedDerivedType))
+                if (!TryResolveOpenGenericDerivedType(namedDerivedType, type, out INamedTypeSymbol? specializedDerivedType, out OpenGenericResolutionFailure? failure, out string? failedDetail))
                 {
-                    ReportDiagnostic(DerivedTypeUnsupportedGenerics, attribute.GetLocation(), derivedType.ToDisplayString(), type.ToDisplayString());
+                    ReportDiagnostic(DerivedTypeUnsupportedGenerics, attribute.GetLocation(), derivedType.ToDisplayString(), type.ToDisplayString(), FormatOpenGenericFailureReason(failure!.Value, failedDetail));
                     continue;
                 }
 
@@ -672,6 +670,192 @@ public sealed partial class Parser : TypeDataModelGenerator
             };
 
             i++;
+        }
+    }
+
+    /// <summary>
+    /// Closes <paramref name="unboundDerived"/> against <paramref name="baseType"/> via
+    /// structural unification at compile time. Returns <see langword="true"/> when the
+    /// registration can be closed to a unique concrete type. Returns <see langword="false"/>
+    /// with a <see cref="OpenGenericResolutionFailure"/> classification when the derived type
+    /// cannot be resolved against this particular base.
+    /// </summary>
+    /// <remarks>
+    /// This implementation mirrors the reflection-side resolver
+    /// <c>PolyType.Utilities.ReflectionUtilities.TryResolveOpenGenericDerivedType</c>. Both
+    /// implementations -- the structural unbound pre-check, the per-ancestor unification, and
+    /// the ambiguity detection -- must be kept in lockstep so that source-gen and reflection
+    /// produce the same closed type for the same registration. Any algorithmic change here
+    /// must be applied in the reflection mirror as well.
+    ///
+    /// Known intentional asymmetry: source-gen rejects a managed value type (e.g. a struct
+    /// containing reference fields) supplied for a <c>where T : unmanaged</c> constraint because
+    /// emitting such a closed type would produce a C# compile error (CS8377). The reflection
+    /// resolver delegates constraint validation to <see cref="System.Type.MakeGenericType"/>,
+    /// which only enforces the underlying value-type part of the constraint at runtime.
+    /// </remarks>
+    private bool TryResolveOpenGenericDerivedType(
+        INamedTypeSymbol unboundDerived,
+        ITypeSymbol baseType,
+        [NotNullWhen(true)] out INamedTypeSymbol? resolvedType,
+        [NotNullWhen(false)] out OpenGenericResolutionFailure? failure,
+        out string? failureDetail)
+    {
+        resolvedType = null;
+        failure = null;
+        failureDetail = null;
+
+        if (baseType is not INamedTypeSymbol { IsGenericType: true } constructedBase)
+        {
+            failure = OpenGenericResolutionFailure.NotAssignable;
+            return false;
+        }
+
+        INamedTypeSymbol derivedDefinition = unboundDerived.OriginalDefinition;
+        INamedTypeSymbol baseDefinition = constructedBase.OriginalDefinition;
+
+        List<INamedTypeSymbol> matchingBases = derivedDefinition
+            .GetCompatibleGenericBaseTypes(baseDefinition)
+            .ToList();
+
+        if (matchingBases.Count == 0)
+        {
+            failure = OpenGenericResolutionFailure.NotAssignable;
+            return false;
+        }
+
+        List<ITypeParameterSymbol> requiredParams = derivedDefinition.GetAllTypeParameters();
+        ImmutableArray<ITypeSymbol> constructedBaseArgs = constructedBase.TypeArguments;
+
+        // Structural unbound pre-check: every required parameter must appear at least once
+        // in some matching ancestor's type arguments. If a parameter never appears at all,
+        // no closed base could ever bind it.
+        HashSet<ITypeParameterSymbol> referencedParams = new(SymbolEqualityComparer.Default);
+        foreach (INamedTypeSymbol mb in matchingBases)
+        {
+            foreach (ITypeSymbol arg in mb.TypeArguments)
+            {
+                OpenGenericDerivedTypeHelpers.CollectReferencedParameters(arg, referencedParams);
+            }
+        }
+        foreach (ITypeParameterSymbol required in requiredParams)
+        {
+            if (!referencedParams.Contains(required))
+            {
+                failure = OpenGenericResolutionFailure.UnboundParameter;
+                failureDetail = required.Name;
+                return false;
+            }
+        }
+
+        Dictionary<ITypeParameterSymbol, ITypeSymbol>? successfulSubstitution = null;
+        int successCount = 0;
+
+        foreach (INamedTypeSymbol matchingBase in matchingBases)
+        {
+            ImmutableArray<ITypeSymbol> matchingBaseArgs = matchingBase.TypeArguments;
+            Debug.Assert(matchingBaseArgs.Length == constructedBaseArgs.Length,
+                "matchingBase and constructedBase share the same generic definition, so arity must match.");
+
+            var substitution = new Dictionary<ITypeParameterSymbol, ITypeSymbol>(requiredParams.Count, SymbolEqualityComparer.Default);
+            bool unified = true;
+            for (int i = 0; i < matchingBaseArgs.Length; i++)
+            {
+                if (!matchingBaseArgs[i].TryUnifyWith(constructedBaseArgs[i], substitution))
+                {
+                    unified = false;
+                    break;
+                }
+            }
+
+            if (!unified)
+            {
+                continue;
+            }
+
+            // Unification succeeded for every position. Every required parameter must be
+            // bound; otherwise the resulting closed type would have unbound type arguments.
+            // A sibling ancestor may still bind this parameter, so failure here is not fatal.
+            bool allBound = true;
+            foreach (ITypeParameterSymbol p in requiredParams)
+            {
+                if (!substitution.ContainsKey(p))
+                {
+                    allBound = false;
+                    break;
+                }
+            }
+
+            if (!allBound)
+            {
+                continue;
+            }
+
+            successCount++;
+            if (successCount == 1)
+            {
+                successfulSubstitution = substitution;
+            }
+            else
+            {
+                failure = OpenGenericResolutionFailure.AmbiguousMatch;
+                return false;
+            }
+        }
+
+        if (successCount == 0 || successfulSubstitution is null)
+        {
+            failure = OpenGenericResolutionFailure.UnificationFailed;
+            return false;
+        }
+
+        if (!_knownSymbols.Compilation.TryValidateGenericConstraints(requiredParams, successfulSubstitution, out ITypeParameterSymbol? failedParam, out ITypeSymbol? failedArg))
+        {
+            failure = OpenGenericResolutionFailure.ConstraintViolation;
+            failureDetail = $"{failedParam.Name}|{failedArg?.ToDisplayString() ?? string.Empty}";
+            return false;
+        }
+
+        ITypeSymbol[] closedArgs = new ITypeSymbol[requiredParams.Count];
+        for (int i = 0; i < requiredParams.Count; i++)
+        {
+            closedArgs[i] = successfulSubstitution[requiredParams[i]];
+        }
+
+        resolvedType = derivedDefinition.ConstructWithEnclosingTypeArguments(closedArgs);
+        return true;
+    }
+
+    private static string FormatOpenGenericFailureReason(OpenGenericResolutionFailure failure, string? detail)
+    {
+        return failure switch
+        {
+            OpenGenericResolutionFailure.NotAssignable
+                => "the derived type is not assignable to the base type",
+            OpenGenericResolutionFailure.UnificationFailed
+                => "the base type's arguments do not match the derived type's base specification",
+            OpenGenericResolutionFailure.UnboundParameter
+                => $"the type parameter '{detail}' of the derived type is not bound by the base type's arguments",
+            OpenGenericResolutionFailure.AmbiguousMatch
+                => "the derived type matches the base type through multiple ancestors",
+            OpenGenericResolutionFailure.ConstraintViolation
+                => FormatConstraintFailure(detail),
+            _ => "the open generic derived type could not be resolved",
+        };
+
+        static string FormatConstraintFailure(string? detail)
+        {
+            if (string.IsNullOrEmpty(detail))
+            {
+                return "the closed derived type would violate one of its declared generic constraints";
+            }
+
+            string[] parts = detail!.Split(['|'], 2);
+            string paramName = parts[0];
+            string argName = parts.Length > 1 ? parts[1] : string.Empty;
+            return string.IsNullOrEmpty(argName)
+                ? $"the constraint on type parameter '{paramName}' is not satisfied"
+                : $"the constraint on type parameter '{paramName}' is not satisfied by '{argName}'";
         }
     }
 

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -700,8 +700,8 @@ public sealed partial class Parser : TypeDataModelGenerator
     /// </summary>
     /// <remarks>
     /// This implementation mirrors the reflection-side resolver
-    /// <c>PolyType.Utilities.ReflectionUtilities.TryResolveOpenGenericDerivedType</c>. Both
-    /// implementations -- the structural unbound pre-check, the per-ancestor unification, and
+    /// <c>PolyType.ReflectionProvider.OpenGenericDerivedTypeResolver.TryResolveOpenGenericDerivedType</c>.
+    /// Both implementations -- the structural unbound pre-check, the per-ancestor unification, and
     /// the ambiguity detection -- must be kept in lockstep so that source-gen and reflection
     /// produce the same closed type for the same registration. Any algorithmic change here
     /// must be applied in the reflection mirror as well.

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -625,6 +625,14 @@ public sealed partial class Parser : TypeDataModelGenerator
             {
                 if (!TryResolveOpenGenericDerivedType(namedDerivedType, type, out INamedTypeSymbol? specializedDerivedType, out OpenGenericResolutionFailure? failure, out string? failedDetail))
                 {
+                    if (failure!.Value.IsPerInstantiationFailure())
+                    {
+                        // The registration is valid in isolation but does not apply to this
+                        // particular closed base. A different closed instantiation of the
+                        // same base definition may still match it; silently skip.
+                        continue;
+                    }
+
                     ReportDiagnostic(DerivedTypeUnsupportedGenerics, attribute.GetLocation(), derivedType.ToDisplayString(), type.ToDisplayString(), FormatOpenGenericFailureReason(failure!.Value, failedDetail));
                     continue;
                 }
@@ -633,6 +641,16 @@ public sealed partial class Parser : TypeDataModelGenerator
             }
             else if (!type.IsAssignableFrom(derivedType))
             {
+                // The closed derived type does not fit this particular closed base. If the
+                // base is a generic instantiation AND the derived inherits from some other
+                // instantiation of the same base definition, silently skip -- the registration
+                // is targeted at a different closed base. Otherwise treat as a hard error.
+                if (type is INamedTypeSymbol { IsGenericType: true } namedBase &&
+                    derivedType.GetCompatibleGenericBaseTypes(namedBase.OriginalDefinition).Any())
+                {
+                    continue;
+                }
+
                 ReportDiagnostic(DerivedTypeNotAssignableToBase, attribute.GetLocation(), derivedType.ToDisplayString(), type.ToDisplayString());
                 continue;
             }

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -625,14 +625,6 @@ public sealed partial class Parser : TypeDataModelGenerator
             {
                 if (!TryResolveOpenGenericDerivedType(namedDerivedType, type, out INamedTypeSymbol? specializedDerivedType, out OpenGenericResolutionFailure? failure, out string? failedDetail))
                 {
-                    if (failure!.Value.IsPerInstantiationFailure())
-                    {
-                        // The registration is valid in isolation but does not apply to this
-                        // particular closed base. A different closed instantiation of the
-                        // same base definition may still match it; silently skip.
-                        continue;
-                    }
-
                     ReportDiagnostic(DerivedTypeUnsupportedGenerics, attribute.GetLocation(), derivedType.ToDisplayString(), type.ToDisplayString(), FormatOpenGenericFailureReason(failure!.Value, failedDetail));
                     continue;
                 }
@@ -641,16 +633,6 @@ public sealed partial class Parser : TypeDataModelGenerator
             }
             else if (!type.IsAssignableFrom(derivedType))
             {
-                // The closed derived type does not fit this particular closed base. If the
-                // base is a generic instantiation AND the derived inherits from some other
-                // instantiation of the same base definition, silently skip -- the registration
-                // is targeted at a different closed base. Otherwise treat as a hard error.
-                if (type is INamedTypeSymbol { IsGenericType: true } namedBase &&
-                    derivedType.GetCompatibleGenericBaseTypes(namedBase.OriginalDefinition).Any())
-                {
-                    continue;
-                }
-
                 ReportDiagnostic(DerivedTypeNotAssignableToBase, attribute.GetLocation(), derivedType.ToDisplayString(), type.ToDisplayString());
                 continue;
             }

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -589,7 +589,8 @@ public sealed partial class Parser : TypeDataModelGenerator
             yield break;
         }
 
-        int i = 0;
+        int registrationIndex = 0;
+        int derivedTypeIndex = 0;
         HashSet<ITypeSymbol> types = new(SymbolEqualityComparer.Default);
         HashSet<int> tags = new();
         HashSet<string> names = new(StringComparer.Ordinal);
@@ -621,56 +622,114 @@ public sealed partial class Parser : TypeDataModelGenerator
                 continue;
             }
 
-            if (derivedType is INamedTypeSymbol { IsUnboundGenericType: true } namedDerivedType)
+            int currentRegistrationIndex = registrationIndex++;
+            if (TryCreateDerivedTypeModel(
+                    type,
+                    attribute,
+                    derivedType,
+                    name,
+                    tag,
+                    currentRegistrationIndex,
+                    derivedTypeIndex,
+                    types,
+                    tags,
+                    names,
+                    out DerivedTypeModel? model))
             {
-                if (!TryResolveOpenGenericDerivedType(namedDerivedType, type, out INamedTypeSymbol? specializedDerivedType, out OpenGenericResolutionFailure? failure, out string? failedDetail))
-                {
-                    ReportDiagnostic(DerivedTypeUnsupportedGenerics, attribute.GetLocation(), derivedType.ToDisplayString(), type.ToDisplayString(), FormatOpenGenericFailureReason(failure!.Value, failedDetail));
-                    continue;
-                }
-
-                derivedType = specializedDerivedType;
+                derivedTypeIndex++;
+                yield return model;
             }
-            else if (!type.IsAssignableFrom(derivedType))
-            {
-                ReportDiagnostic(DerivedTypeNotAssignableToBase, attribute.GetLocation(), derivedType.ToDisplayString(), type.ToDisplayString());
-                continue;
-            }
-
-            bool isTagSpecified = tag >= 0;
-            tag = isTagSpecified ? tag : i;
-            name ??= derivedType.GetDerivedTypeShapeName();
-
-            if (!types.Add(derivedType))
-            {
-                ReportDiagnostic(DerivedTypeDuplicateMetadata, attribute.GetLocation(), type.ToDisplayString(), "type", derivedType.ToDisplayString());
-                continue;
-            }
-
-            if (!tags.Add(tag))
-            {
-                ReportDiagnostic(DerivedTypeDuplicateMetadata, attribute.GetLocation(), type.ToDisplayString(), "tag", tag);
-                continue;
-            }
-
-            if (!names.Add(name))
-            {
-                ReportDiagnostic(DerivedTypeDuplicateMetadata, attribute.GetLocation(), type.ToDisplayString(), "name", name);
-                continue;
-            }
-
-            yield return new DerivedTypeModel
-            {
-                Type = derivedType,
-                Name = name,
-                Tag = tag,
-                IsTagSpecified = isTagSpecified,
-                Index = i,
-                IsBaseType = SymbolEqualityComparer.Default.Equals(derivedType, type),
-            };
-
-            i++;
         }
+    }
+
+    private bool TryCreateDerivedTypeModel(
+        ITypeSymbol baseType,
+        AttributeData attribute,
+        ITypeSymbol declaredDerivedType,
+        string? name,
+        int tag,
+        int registrationIndex,
+        int derivedTypeIndex,
+        HashSet<ITypeSymbol> types,
+        HashSet<int> tags,
+        HashSet<string> names,
+        [NotNullWhen(true)] out DerivedTypeModel? model)
+    {
+        Location? location = attribute.GetLocation();
+        ITypeSymbol? resolvedDerivedType = declaredDerivedType;
+        bool isValid = true;
+
+        // Match reflection's attribute semantics by deriving the default name from the declared
+        // type rather than from a closed specialization produced below.
+        name ??= declaredDerivedType.GetDerivedTypeShapeName();
+
+        if (declaredDerivedType is INamedTypeSymbol { IsUnboundGenericType: true } namedDerivedType)
+        {
+            if (!TryResolveOpenGenericDerivedType(namedDerivedType, baseType, out INamedTypeSymbol? specializedDerivedType, out OpenGenericResolutionFailure? failure, out string? failedDetail))
+            {
+                ReportDiagnostic(
+                    DerivedTypeUnsupportedGenerics,
+                    location,
+                    declaredDerivedType.ToDisplayString(),
+                    baseType.ToDisplayString(),
+                    FormatOpenGenericFailureReason(failure!.Value, failedDetail));
+
+                resolvedDerivedType = null;
+                isValid = false;
+            }
+            else
+            {
+                resolvedDerivedType = specializedDerivedType;
+            }
+        }
+
+        if (resolvedDerivedType is not null && !baseType.IsAssignableFrom(resolvedDerivedType))
+        {
+            ReportDiagnostic(DerivedTypeNotAssignableToBase, location, resolvedDerivedType.ToDisplayString(), baseType.ToDisplayString());
+            isValid = false;
+        }
+
+        bool isTagSpecified = tag >= 0;
+        tag = isTagSpecified ? tag : registrationIndex;
+
+        // Run every metadata check even if type resolution or assignability failed. This keeps
+        // diagnostics independent of whether the registration required generic specialization.
+        ITypeSymbol metadataType = resolvedDerivedType ?? declaredDerivedType;
+        if (!types.Add(metadataType))
+        {
+            ReportDiagnostic(DerivedTypeDuplicateMetadata, location, baseType.ToDisplayString(), "type", metadataType.ToDisplayString());
+            isValid = false;
+        }
+
+        if (!tags.Add(tag))
+        {
+            ReportDiagnostic(DerivedTypeDuplicateMetadata, location, baseType.ToDisplayString(), "tag", tag);
+            isValid = false;
+        }
+
+        if (!names.Add(name))
+        {
+            ReportDiagnostic(DerivedTypeDuplicateMetadata, location, baseType.ToDisplayString(), "name", name);
+            isValid = false;
+        }
+
+        if (!isValid)
+        {
+            model = null;
+            return false;
+        }
+
+        model = new DerivedTypeModel
+        {
+            Type = resolvedDerivedType!,
+            Name = name,
+            Tag = tag,
+            IsTagSpecified = isTagSpecified,
+            Index = derivedTypeIndex,
+            IsBaseType = SymbolEqualityComparer.Default.Equals(resolvedDerivedType, baseType),
+        };
+
+        return true;
     }
 
     /// <summary>

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -612,6 +612,29 @@ public static class TestTypes
             (OpenGenericMultiLevelBase<List<int>>)new OpenGenericMultiLevelLeaf<int>([10, 20]),
             isUnion: true,
             provider: p);
+        yield return TestCase.Create(
+            (OpenGenericRepeatedBase<int, int>)new OpenGenericRepeatedDerived<int>(1, 2, "valid"),
+            isUnion: true,
+            provider: p);
+        yield return TestCase.Create(
+            (OpenGenericInterfaceConstraintBase<List<int>>)new OpenGenericInterfaceConstraintDerived<List<int>>([1, 2], "valid"),
+            isUnion: true,
+            provider: p);
+        yield return TestCase.Create(
+            (OpenGenericNewConstraintBase<OpenGenericNewConstraintArgument>)new OpenGenericNewConstraintDerived<OpenGenericNewConstraintArgument>(new() { Value = 42 }, "valid"),
+            isUnion: true,
+            provider: p);
+        yield return TestCase.Create(
+            (OpenGenericDeepJaggedBase<List<int[][][]>>)new OpenGenericDeepJaggedDerived<int>(
+            [
+                [
+                    [
+                        [1, 2],
+                    ],
+                ],
+            ]),
+            isUnion: true,
+            provider: p);
 
         yield return TestCase.Create(new RecordWithoutNamespace(42));
         yield return TestCase.Create(new GenericRecordWithoutNamespace<int>(42), p);
@@ -2771,6 +2794,29 @@ public partial record OpenGenericMultiLevelBase<T>;
 public partial record OpenGenericMultiLevelMid<T> : OpenGenericMultiLevelBase<List<T>>;
 public partial record OpenGenericMultiLevelLeaf<T>(List<T> Items) : OpenGenericMultiLevelMid<T>;
 
+[DerivedTypeShape(typeof(OpenGenericRepeatedDerived<>), Name = "repeated")]
+public partial record OpenGenericRepeatedBase<T1, T2>;
+public partial record OpenGenericRepeatedDerived<T>(T First, T Second, string Marker) : OpenGenericRepeatedBase<T, T>;
+
+[DerivedTypeShape(typeof(OpenGenericInterfaceConstraintDerived<>), Name = "interfaceConstraint")]
+public partial record OpenGenericInterfaceConstraintBase<T>;
+public partial record OpenGenericInterfaceConstraintDerived<T>(T Value, string Marker) : OpenGenericInterfaceConstraintBase<T>
+    where T : IEnumerable<int>;
+
+[DerivedTypeShape(typeof(OpenGenericNewConstraintDerived<>), Name = "newConstraint")]
+public partial record OpenGenericNewConstraintBase<T>;
+public partial record OpenGenericNewConstraintDerived<T>(T Value, string Marker) : OpenGenericNewConstraintBase<T>
+    where T : class, new();
+
+public partial class OpenGenericNewConstraintArgument
+{
+    public int Value { get; set; }
+}
+
+[DerivedTypeShape(typeof(OpenGenericDeepJaggedDerived<>), Name = "deepJagged")]
+public partial record OpenGenericDeepJaggedBase<T>;
+public partial record OpenGenericDeepJaggedDerived<T>(List<T[][][]> Value) : OpenGenericDeepJaggedBase<List<T[][][]>>;
+
 [GenerateShape]
 public partial record PropertyRequiredByAttribute
 {
@@ -3599,6 +3645,10 @@ public delegate Task<int> LargeAsyncDelegate(
 [GenerateShapeFor<OpenGenericArrayBase<int[]>>]
 [GenerateShapeFor<IOpenGenericInterfaceBase<int>>]
 [GenerateShapeFor<OpenGenericMultiLevelBase<List<int>>>]
+[GenerateShapeFor<OpenGenericRepeatedBase<int, int>>]
+[GenerateShapeFor<OpenGenericInterfaceConstraintBase<List<int>>>]
+[GenerateShapeFor<OpenGenericNewConstraintBase<OpenGenericNewConstraintArgument>>]
+[GenerateShapeFor<OpenGenericDeepJaggedBase<List<int[][][]>>>]
 [GenerateShapeFor<GenericRecordWithoutNamespace<int>>]
 [GenerateShapeFor<GenericContainerWithoutNamespace<int>.Record<string>>]
 [GenerateShapeFor<IAsyncEnumerable<int>>]

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -609,6 +609,22 @@ public static class TestTypes
             isUnion: true,
             provider: p);
         yield return TestCase.Create(
+            (IOpenGenericInterfaceBase<int>)new OpenGenericInterfaceImpl<int>(42),
+            p,
+            isUnion: true);
+        yield return TestCase.Create(
+            (OpenGenericNestedBase<(string, int)>)new OpenGenericOuter<string>.Middle.Leaf<int>("outer", 42),
+            p,
+            isUnion: true);
+        yield return TestCase.Create(
+            (IOpenGenericHierarchyBase<int>)new OpenGenericHierarchyImpl<int>(42),
+            p,
+            isUnion: true);
+        yield return TestCase.Create(
+            (IOpenGenericMultipleInterfaceBase<int>)new OpenGenericMultipleInterfaceImpl<int>(42),
+            p,
+            isUnion: true);
+        yield return TestCase.Create(
             (OpenGenericMultiLevelBase<List<int>>)new OpenGenericMultiLevelLeaf<int>([10, 20]),
             isUnion: true,
             provider: p);
@@ -618,6 +634,10 @@ public static class TestTypes
             provider: p);
         yield return TestCase.Create(
             (OpenGenericInterfaceConstraintBase<List<int>>)new OpenGenericInterfaceConstraintDerived<List<int>>([1, 2], "valid"),
+            isUnion: true,
+            provider: p);
+        yield return TestCase.Create(
+            (OpenGenericCovariantConstraintBase<List<string>>)new OpenGenericCovariantConstraintDerived<List<string>>(["a", "b"], "valid"),
             isUnion: true,
             provider: p);
         yield return TestCase.Create(
@@ -633,6 +653,10 @@ public static class TestTypes
                     ],
                 ],
             ]),
+            isUnion: true,
+            provider: p);
+        yield return TestCase.Create(
+            (OpenGenericDefaultNameBase<int>)new OpenGenericDefaultNameDerived<int>(42),
             isUnion: true,
             provider: p);
 
@@ -2789,6 +2813,32 @@ public partial interface IOpenGenericInterfaceBase<T>
 
 public partial record OpenGenericInterfaceImpl<T>(T? Value) : IOpenGenericInterfaceBase<T>;
 
+[DerivedTypeShape(typeof(OpenGenericOuter<>.Middle.Leaf<>), Name = "nested")]
+public partial record OpenGenericNestedBase<T>;
+
+public partial class OpenGenericOuter<TOuter>
+{
+    public partial class Middle
+    {
+        public partial record Leaf<TLeaf>(TOuter OuterValue, TLeaf LeafValue) : OpenGenericNestedBase<(TOuter, TLeaf)>;
+    }
+}
+
+[DerivedTypeShape(typeof(OpenGenericHierarchyImpl<>), Name = "hierarchy")]
+public partial interface IOpenGenericHierarchyBase<T>;
+
+public partial interface IOpenGenericHierarchyLeft<T> : IOpenGenericHierarchyBase<T>;
+public partial interface IOpenGenericHierarchyRight<T> : IOpenGenericHierarchyBase<T>;
+public partial interface IOpenGenericHierarchyDiamond<T> : IOpenGenericHierarchyLeft<T>, IOpenGenericHierarchyRight<T>;
+public partial record OpenGenericHierarchyImpl<T>(T Value) : IOpenGenericHierarchyDiamond<T>;
+
+[DerivedTypeShape(typeof(OpenGenericMultipleInterfaceImpl<>), Name = "multiple")]
+public partial interface IOpenGenericMultipleInterfaceBase<T>;
+
+public partial record OpenGenericMultipleInterfaceImpl<T>(T Value) :
+    IOpenGenericMultipleInterfaceBase<T>,
+    IOpenGenericMultipleInterfaceBase<List<T>>;
+
 [DerivedTypeShape(typeof(OpenGenericMultiLevelLeaf<>), Name = "leaf")]
 public partial record OpenGenericMultiLevelBase<T>;
 public partial record OpenGenericMultiLevelMid<T> : OpenGenericMultiLevelBase<List<T>>;
@@ -2803,6 +2853,11 @@ public partial record OpenGenericInterfaceConstraintBase<T>;
 public partial record OpenGenericInterfaceConstraintDerived<T>(T Value, string Marker) : OpenGenericInterfaceConstraintBase<T>
     where T : IEnumerable<int>;
 
+[DerivedTypeShape(typeof(OpenGenericCovariantConstraintDerived<>), Name = "covariantConstraint")]
+public partial record OpenGenericCovariantConstraintBase<T>;
+public partial record OpenGenericCovariantConstraintDerived<T>(T Value, string Marker) : OpenGenericCovariantConstraintBase<T>
+    where T : IEnumerable<object>;
+
 [DerivedTypeShape(typeof(OpenGenericNewConstraintDerived<>), Name = "newConstraint")]
 public partial record OpenGenericNewConstraintBase<T>;
 public partial record OpenGenericNewConstraintDerived<T>(T Value, string Marker) : OpenGenericNewConstraintBase<T>
@@ -2815,7 +2870,13 @@ public partial class OpenGenericNewConstraintArgument
 
 [DerivedTypeShape(typeof(OpenGenericDeepJaggedDerived<>), Name = "deepJagged")]
 public partial record OpenGenericDeepJaggedBase<T>;
+
 public partial record OpenGenericDeepJaggedDerived<T>(List<T[][][]> Value) : OpenGenericDeepJaggedBase<List<T[][][]>>;
+
+[DerivedTypeShape(typeof(OpenGenericDefaultNameDerived<>))]
+public partial record OpenGenericDefaultNameBase<T>;
+
+public partial record OpenGenericDefaultNameDerived<T>(T Value) : OpenGenericDefaultNameBase<T>;
 
 [GenerateShape]
 public partial record PropertyRequiredByAttribute
@@ -3644,11 +3705,16 @@ public delegate Task<int> LargeAsyncDelegate(
 [GenerateShapeFor<OpenGenericWrappedBase<List<string>>>]
 [GenerateShapeFor<OpenGenericArrayBase<int[]>>]
 [GenerateShapeFor<IOpenGenericInterfaceBase<int>>]
+[GenerateShapeFor<OpenGenericNestedBase<(string, int)>>]
+[GenerateShapeFor<IOpenGenericHierarchyBase<int>>]
+[GenerateShapeFor<IOpenGenericMultipleInterfaceBase<int>>]
 [GenerateShapeFor<OpenGenericMultiLevelBase<List<int>>>]
 [GenerateShapeFor<OpenGenericRepeatedBase<int, int>>]
 [GenerateShapeFor<OpenGenericInterfaceConstraintBase<List<int>>>]
+[GenerateShapeFor<OpenGenericCovariantConstraintBase<List<string>>>]
 [GenerateShapeFor<OpenGenericNewConstraintBase<OpenGenericNewConstraintArgument>>]
 [GenerateShapeFor<OpenGenericDeepJaggedBase<List<int[][][]>>>]
+[GenerateShapeFor<OpenGenericDefaultNameBase<int>>]
 [GenerateShapeFor<GenericRecordWithoutNamespace<int>>]
 [GenerateShapeFor<GenericContainerWithoutNamespace<int>.Record<string>>]
 [GenerateShapeFor<IAsyncEnumerable<int>>]

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -592,6 +592,26 @@ public static class TestTypes
         yield return TestCase.Create((GenericTree<string>)new GenericTree<string>.Node("str", new GenericTree<string>.Leaf(), new GenericTree<string>.Leaf()), additionalValues: [new GenericTree<string>.Leaf()], isUnion: true, provider: p);
         yield return TestCase.Create((GenericTree<int>)new GenericTree<int>.Node(42, new GenericTree<int>.Leaf(), new GenericTree<int>.Leaf()), additionalValues: [new GenericTree<int>.Leaf()], isUnion: true, provider: p);
         yield return TestCase.Create<ClassWithGenericDerivedType>(new ClassWithGenericDerivedType.Derived<int>(42), additionalValues: [new ClassWithGenericDerivedType.Derived<ClassWithGenericDerivedType.Arg1>(new())], isUnion: true);
+        yield return TestCase.Create(
+            (OpenGenericReorderedBase<int, string>)new OpenGenericReorderedDerived<string, int>("left", 42),
+            isUnion: true,
+            provider: p);
+        yield return TestCase.Create(
+            (OpenGenericPartialBase<string, int>)new OpenGenericPartialDerived<string>("hello"),
+            isUnion: true,
+            provider: p);
+        yield return TestCase.Create(
+            (OpenGenericWrappedBase<List<string>>)new OpenGenericWrappedDerived<string>(["a", "b"]),
+            isUnion: true,
+            provider: p);
+        yield return TestCase.Create(
+            (OpenGenericArrayBase<int[]>)new OpenGenericArrayDerived<int>([1, 2, 3]),
+            isUnion: true,
+            provider: p);
+        yield return TestCase.Create(
+            (OpenGenericMultiLevelBase<List<int>>)new OpenGenericMultiLevelLeaf<int>([10, 20]),
+            isUnion: true,
+            provider: p);
 
         yield return TestCase.Create(new RecordWithoutNamespace(42));
         yield return TestCase.Create(new GenericRecordWithoutNamespace<int>(42), p);
@@ -2714,6 +2734,43 @@ public partial record ClassWithGenericDerivedType
     public class Arg2;
 }
 
+[DerivedTypeShape(typeof(OpenGenericReorderedDerived<,>), Name = "reordered")]
+public partial record OpenGenericReorderedBase<T1, T2>
+{
+    public T1? Value1 { get; set; }
+    public T2? Value2 { get; set; }
+}
+
+public partial record OpenGenericReorderedDerived<U, V>(U Left, V Right) : OpenGenericReorderedBase<V, U>;
+
+[DerivedTypeShape(typeof(OpenGenericPartialDerived<>), Name = "partial")]
+public partial record OpenGenericPartialBase<T1, T2>;
+
+public partial record OpenGenericPartialDerived<T>(T? Value) : OpenGenericPartialBase<T, int>;
+
+[DerivedTypeShape(typeof(OpenGenericWrappedDerived<>), Name = "wrapped")]
+public partial record OpenGenericWrappedBase<T>;
+
+public partial record OpenGenericWrappedDerived<T>(List<T> Data) : OpenGenericWrappedBase<List<T>>;
+
+[DerivedTypeShape(typeof(OpenGenericArrayDerived<>), Name = "array")]
+public partial record OpenGenericArrayBase<T>;
+
+public partial record OpenGenericArrayDerived<T>(T[] Values) : OpenGenericArrayBase<T[]>;
+
+[DerivedTypeShape(typeof(OpenGenericInterfaceImpl<>), Name = "impl")]
+public partial interface IOpenGenericInterfaceBase<T>
+{
+    T? Value { get; }
+}
+
+public partial record OpenGenericInterfaceImpl<T>(T? Value) : IOpenGenericInterfaceBase<T>;
+
+[DerivedTypeShape(typeof(OpenGenericMultiLevelLeaf<>), Name = "leaf")]
+public partial record OpenGenericMultiLevelBase<T>;
+public partial record OpenGenericMultiLevelMid<T> : OpenGenericMultiLevelBase<List<T>>;
+public partial record OpenGenericMultiLevelLeaf<T>(List<T> Items) : OpenGenericMultiLevelMid<T>;
+
 [GenerateShape]
 public partial record PropertyRequiredByAttribute
 {
@@ -3536,6 +3593,12 @@ public delegate Task<int> LargeAsyncDelegate(
 [GenerateShapeFor<GenericDictionaryWithMarshaler<string, int>>]
 [GenerateShapeFor<GenericTree<string>>]
 [GenerateShapeFor<GenericTree<int>>]
+[GenerateShapeFor<OpenGenericReorderedBase<int, string>>]
+[GenerateShapeFor<OpenGenericPartialBase<string, int>>]
+[GenerateShapeFor<OpenGenericWrappedBase<List<string>>>]
+[GenerateShapeFor<OpenGenericArrayBase<int[]>>]
+[GenerateShapeFor<IOpenGenericInterfaceBase<int>>]
+[GenerateShapeFor<OpenGenericMultiLevelBase<List<int>>>]
 [GenerateShapeFor<GenericRecordWithoutNamespace<int>>]
 [GenerateShapeFor<GenericContainerWithoutNamespace<int>.Record<string>>]
 [GenerateShapeFor<IAsyncEnumerable<int>>]

--- a/src/PolyType/ReflectionProvider/OpenGenericDerivedTypeResolver.cs
+++ b/src/PolyType/ReflectionProvider/OpenGenericDerivedTypeResolver.cs
@@ -176,13 +176,16 @@ internal static class OpenGenericDerivedTypeResolver
         Type openDerivedType,
         Type baseType,
         [NotNullWhen(true)] out Type? closedDerivedType,
-        [NotNullWhen(false)] out string? failureReason)
+        [NotNullWhen(false)] out string? failureReason,
+        out OpenGenericResolutionFailureKind failureKind)
     {
         closedDerivedType = null;
         failureReason = null;
+        failureKind = default;
 
         if (!baseType.IsGenericType)
         {
+            failureKind = OpenGenericResolutionFailureKind.NotAssignable;
             failureReason = "the derived type is not assignable to the base type";
             return false;
         }
@@ -202,6 +205,7 @@ internal static class OpenGenericDerivedTypeResolver
 
         if (matchingBases.Count == 0)
         {
+            failureKind = OpenGenericResolutionFailureKind.NotAssignable;
             failureReason = "the derived type is not assignable to the base type";
             return false;
         }
@@ -227,6 +231,7 @@ internal static class OpenGenericDerivedTypeResolver
         {
             if (!referencedParams.Contains(required))
             {
+                failureKind = OpenGenericResolutionFailureKind.UnboundParameter;
                 failureReason = $"the type parameter '{required.Name}' of the derived type is not bound by the base type's arguments";
                 return false;
             }
@@ -287,6 +292,7 @@ internal static class OpenGenericDerivedTypeResolver
             }
             else
             {
+                failureKind = OpenGenericResolutionFailureKind.AmbiguousMatch;
                 failureReason = "the derived type matches the base type through multiple ancestors";
                 return false;
             }
@@ -294,6 +300,7 @@ internal static class OpenGenericDerivedTypeResolver
 
         if (successCount == 0 || successfulArgs is null)
         {
+            failureKind = OpenGenericResolutionFailureKind.UnificationFailed;
             failureReason = "the base type's arguments do not match the derived type's base specification";
             return false;
         }
@@ -305,8 +312,41 @@ internal static class OpenGenericDerivedTypeResolver
         }
         catch (Exception ex) when (ex is ArgumentException or TypeLoadException)
         {
+            failureKind = OpenGenericResolutionFailureKind.ConstraintViolation;
             failureReason = "the closed derived type would violate one of its declared generic constraints";
             return false;
         }
     }
+}
+
+// Identifies why an open generic derived type could not be resolved against a constructed base.
+// Mirrors PolyType.SourceGenerator.Helpers.OpenGenericResolutionFailure on the source-gen side.
+internal enum OpenGenericResolutionFailureKind
+{
+    /// <summary>The derived type cannot be assigned to the base type (no matching ancestor at all).</summary>
+    NotAssignable,
+
+    /// <summary>A matching ancestor exists but its type arguments do not unify with this particular closed base.</summary>
+    UnificationFailed,
+
+    /// <summary>One of the derived type's parameters is not referenced by any matching ancestor's base specification.</summary>
+    UnboundParameter,
+
+    /// <summary>The resolved substitution does not satisfy the derived type's declared generic constraints.</summary>
+    ConstraintViolation,
+
+    /// <summary>The derived type unifies with the closed base through more than one ancestor.</summary>
+    AmbiguousMatch,
+}
+
+// Helpers for classifying open generic resolution failures.
+internal static class OpenGenericResolutionFailureKindExtensions
+{
+    // Returns true when the failure is caused by the registration not matching THIS particular
+    // closed base, but where the same registration could plausibly apply to a different
+    // instantiation of the base. Callers that close attributes against a specific base may
+    // silently skip such registrations rather than surfacing them as errors.
+    public static bool IsPerInstantiationFailure(this OpenGenericResolutionFailureKind kind) =>
+        kind is OpenGenericResolutionFailureKind.UnificationFailed
+            or OpenGenericResolutionFailureKind.ConstraintViolation;
 }

--- a/src/PolyType/ReflectionProvider/OpenGenericDerivedTypeResolver.cs
+++ b/src/PolyType/ReflectionProvider/OpenGenericDerivedTypeResolver.cs
@@ -5,8 +5,8 @@
 // behaviour in sync.
 //
 // The algorithm is a port of the resolver added in dotnet/runtime#127318 (System.Text.Json
-// support for open generic [JsonDerivedType]). See the PR description for the full set of
-// supported and rejected patterns.
+// support for open generic [JsonDerivedType]), with failure semantics aligned to the refinements
+// in dotnet/runtime#130808. See those PRs for the supported and rejected patterns.
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -176,16 +176,13 @@ internal static class OpenGenericDerivedTypeResolver
         Type openDerivedType,
         Type baseType,
         [NotNullWhen(true)] out Type? closedDerivedType,
-        [NotNullWhen(false)] out string? failureReason,
-        out OpenGenericResolutionFailureKind failureKind)
+        [NotNullWhen(false)] out string? failureReason)
     {
         closedDerivedType = null;
         failureReason = null;
-        failureKind = default;
 
         if (!baseType.IsGenericType)
         {
-            failureKind = OpenGenericResolutionFailureKind.NotAssignable;
             failureReason = "the derived type is not assignable to the base type";
             return false;
         }
@@ -205,7 +202,6 @@ internal static class OpenGenericDerivedTypeResolver
 
         if (matchingBases.Count == 0)
         {
-            failureKind = OpenGenericResolutionFailureKind.NotAssignable;
             failureReason = "the derived type is not assignable to the base type";
             return false;
         }
@@ -231,7 +227,6 @@ internal static class OpenGenericDerivedTypeResolver
         {
             if (!referencedParams.Contains(required))
             {
-                failureKind = OpenGenericResolutionFailureKind.UnboundParameter;
                 failureReason = $"the type parameter '{required.Name}' of the derived type is not bound by the base type's arguments";
                 return false;
             }
@@ -292,7 +287,6 @@ internal static class OpenGenericDerivedTypeResolver
             }
             else
             {
-                failureKind = OpenGenericResolutionFailureKind.AmbiguousMatch;
                 failureReason = "the derived type matches the base type through multiple ancestors";
                 return false;
             }
@@ -300,7 +294,6 @@ internal static class OpenGenericDerivedTypeResolver
 
         if (successCount == 0 || successfulArgs is null)
         {
-            failureKind = OpenGenericResolutionFailureKind.UnificationFailed;
             failureReason = "the base type's arguments do not match the derived type's base specification";
             return false;
         }
@@ -312,41 +305,8 @@ internal static class OpenGenericDerivedTypeResolver
         }
         catch (Exception ex) when (ex is ArgumentException or TypeLoadException)
         {
-            failureKind = OpenGenericResolutionFailureKind.ConstraintViolation;
             failureReason = "the closed derived type would violate one of its declared generic constraints";
             return false;
         }
     }
-}
-
-// Identifies why an open generic derived type could not be resolved against a constructed base.
-// Mirrors PolyType.SourceGenerator.Helpers.OpenGenericResolutionFailure on the source-gen side.
-internal enum OpenGenericResolutionFailureKind
-{
-    /// <summary>The derived type cannot be assigned to the base type (no matching ancestor at all).</summary>
-    NotAssignable,
-
-    /// <summary>A matching ancestor exists but its type arguments do not unify with this particular closed base.</summary>
-    UnificationFailed,
-
-    /// <summary>One of the derived type's parameters is not referenced by any matching ancestor's base specification.</summary>
-    UnboundParameter,
-
-    /// <summary>The resolved substitution does not satisfy the derived type's declared generic constraints.</summary>
-    ConstraintViolation,
-
-    /// <summary>The derived type unifies with the closed base through more than one ancestor.</summary>
-    AmbiguousMatch,
-}
-
-// Helpers for classifying open generic resolution failures.
-internal static class OpenGenericResolutionFailureKindExtensions
-{
-    // Returns true when the failure is caused by the registration not matching THIS particular
-    // closed base, but where the same registration could plausibly apply to a different
-    // instantiation of the base. Callers that close attributes against a specific base may
-    // silently skip such registrations rather than surfacing them as errors.
-    public static bool IsPerInstantiationFailure(this OpenGenericResolutionFailureKind kind) =>
-        kind is OpenGenericResolutionFailureKind.UnificationFailed
-            or OpenGenericResolutionFailureKind.ConstraintViolation;
 }

--- a/src/PolyType/ReflectionProvider/OpenGenericDerivedTypeResolver.cs
+++ b/src/PolyType/ReflectionProvider/OpenGenericDerivedTypeResolver.cs
@@ -1,0 +1,312 @@
+﻿// Implements the structural unification algorithm used to close open generic derived types
+// against a constructed base type. This file contains the reflection-side mirror of the
+// source-generator algorithm in PolyType.SourceGenerator.Helpers.OpenGenericDerivedTypeHelpers.
+// Any structural change here MUST be applied on both sides to keep reflection and source-gen
+// behaviour in sync.
+//
+// The algorithm is a port of the resolver added in dotnet/runtime#127318 (System.Text.Json
+// support for open generic [JsonDerivedType]). See the PR description for the full set of
+// supported and rejected patterns.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace PolyType.ReflectionProvider;
+
+internal static class OpenGenericDerivedTypeResolver
+{
+    // Enumerates every ancestor of `type` whose generic type definition matches
+    // `baseTypeDefinition`. For interface bases this yields every implementing instantiation
+    // (a type can implement the same interface definition with different type arguments); for
+    // class bases it yields at most the first match found while walking the base-type chain
+    // (only one such instantiation is reachable).
+    //
+    // Mirrors PolyType.Roslyn.Helpers.RoslynHelpers.GetCompatibleGenericBaseTypes.
+    [RequiresUnreferencedCode("Touches derived-type interfaces supplied via [DerivedTypeShape]; the interface metadata is rooted at the attribute usage site and survives trimming.")]
+    public static IEnumerable<Type> GetMatchingGenericBaseTypes(this Type type, Type baseTypeDefinition)
+    {
+        Debug.Assert(baseTypeDefinition.IsGenericTypeDefinition);
+
+        if (baseTypeDefinition.IsInterface)
+        {
+            foreach (Type iface in type.GetInterfaces())
+            {
+                if (iface.IsGenericType && iface.GetGenericTypeDefinition() == baseTypeDefinition)
+                {
+                    yield return iface;
+                }
+            }
+
+            // Note: do NOT yield break here. Type.GetInterfaces() does not include `type` itself,
+            // so when `type` IS the interface we're looking for, the fall-through to the
+            // BaseType walk below picks it up via the self-check on the first iteration
+            // (Type.BaseType returns null for interfaces, so the loop terminates immediately).
+        }
+
+        for (Type? current = type; current is not null; current = current.BaseType)
+        {
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == baseTypeDefinition)
+            {
+                yield return current;
+                yield break;
+            }
+        }
+    }
+
+    // Attempts to unify a `pattern` type (which may contain generic parameter references) with
+    // a `target` type, recording bindings in `substitution`. Returns true if the pattern
+    // matches the target under some extension of the current substitution.
+    public static bool TryUnifyWith(this Type pattern, Type target, IDictionary<Type, Type> substitution)
+    {
+        if (pattern.IsGenericParameter)
+        {
+            if (substitution.TryGetValue(pattern, out Type? existing))
+            {
+                return existing == target;
+            }
+
+            substitution[pattern] = target;
+            return true;
+        }
+
+        if (pattern.IsArray)
+        {
+            if (!target.IsArray)
+            {
+                return false;
+            }
+
+            if (pattern.GetArrayRank() != target.GetArrayRank())
+            {
+                return false;
+            }
+
+            // Distinguish single-dim zero-based arrays (T[]) from non-SZ rank-1 arrays (T[*]).
+#if NET
+            if (pattern.IsSZArray != target.IsSZArray)
+            {
+                return false;
+            }
+#endif
+
+            return pattern.GetElementType()!.TryUnifyWith(target.GetElementType()!, substitution);
+        }
+
+        if (pattern.IsPointer)
+        {
+            return target.IsPointer
+                && pattern.GetElementType()!.TryUnifyWith(target.GetElementType()!, substitution);
+        }
+
+        if (pattern.IsByRef)
+        {
+            return target.IsByRef
+                && pattern.GetElementType()!.TryUnifyWith(target.GetElementType()!, substitution);
+        }
+
+        if (pattern.IsGenericType)
+        {
+            if (!target.IsGenericType || pattern.GetGenericTypeDefinition() != target.GetGenericTypeDefinition())
+            {
+                return false;
+            }
+
+            Type[] patternArgs = pattern.GetGenericArguments();
+            Type[] targetArgs = target.GetGenericArguments();
+            if (patternArgs.Length != targetArgs.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < patternArgs.Length; i++)
+            {
+                if (!patternArgs[i].TryUnifyWith(targetArgs[i], substitution))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return pattern == target;
+    }
+
+    // Adds every generic-parameter type referenced inside `pattern` (directly or through
+    // generic / array / pointer / byref wrappers) to `set`.
+    public static void CollectReferencedParameters(Type pattern, HashSet<Type> set)
+    {
+        if (pattern.IsGenericParameter)
+        {
+            set.Add(pattern);
+            return;
+        }
+
+        if (pattern.HasElementType)
+        {
+            CollectReferencedParameters(pattern.GetElementType()!, set);
+            return;
+        }
+
+        if (pattern.IsGenericType)
+        {
+            foreach (Type arg in pattern.GetGenericArguments())
+            {
+                CollectReferencedParameters(arg, set);
+            }
+        }
+    }
+
+    // Closes `openDerivedType` against the constructed `baseType` via structural unification.
+    //
+    // Mirrors the source-gen resolver in
+    // PolyType.SourceGenerator.Parser.TryResolveOpenGenericDerivedType. Both implementations --
+    // the structural unbound pre-check, the per-ancestor unification, and the ambiguity
+    // detection -- must be kept in lockstep so that reflection and source-gen produce the same
+    // closed type for the same registration.
+    //
+    // Known intentional asymmetry: source-gen rejects a managed value type (e.g. a struct
+    // containing reference fields) for a `where T : unmanaged` constraint because the generated
+    // C# would not compile. The reflection resolver delegates constraint validation to
+    // Type.MakeGenericType, which only enforces the underlying value-type part of the
+    // constraint at runtime.
+    [RequiresUnreferencedCode(ReflectionTypeShapeProvider.RequiresUnreferencedCodeMessage)]
+    [RequiresDynamicCode(ReflectionTypeShapeProvider.RequiresDynamicCodeMessage)]
+    public static bool TryResolveOpenGenericDerivedType(
+        Type openDerivedType,
+        Type baseType,
+        [NotNullWhen(true)] out Type? closedDerivedType,
+        [NotNullWhen(false)] out string? failureReason)
+    {
+        closedDerivedType = null;
+        failureReason = null;
+
+        if (!baseType.IsGenericType)
+        {
+            failureReason = "the derived type is not assignable to the base type";
+            return false;
+        }
+
+        Type baseTypeDefinition = baseType.GetGenericTypeDefinition();
+        Type[] baseTypeArgs = baseType.GetGenericArguments();
+
+        // Find every ancestor of the open derived type whose generic type definition matches
+        // the base type definition. For classes there is at most one such ancestor; for
+        // interfaces a derived type can implement the same interface definition multiple times
+        // with different type arguments (e.g. Derived<T> : IBase<T>, IBase<List<T>>).
+        List<Type> matchingBases = new();
+        foreach (Type match in openDerivedType.GetMatchingGenericBaseTypes(baseTypeDefinition))
+        {
+            matchingBases.Add(match);
+        }
+
+        if (matchingBases.Count == 0)
+        {
+            failureReason = "the derived type is not assignable to the base type";
+            return false;
+        }
+
+        // The full set of generic parameters we must bind includes the parameters of the
+        // derived type itself plus any parameters declared by enclosing generic types
+        // (e.g. Outer<T>.Derived needs T bound from the outer class).
+        Type[] requiredParams = openDerivedType.GetGenericArguments();
+
+        // Structural unbound pre-check: every required parameter must appear at least once
+        // somewhere in some matching ancestor's type arguments. If a parameter never appears
+        // at all, no closed base could ever bind it.
+        HashSet<Type> referencedParams = new();
+        foreach (Type mb in matchingBases)
+        {
+            foreach (Type arg in mb.GetGenericArguments())
+            {
+                CollectReferencedParameters(arg, referencedParams);
+            }
+        }
+
+        foreach (Type required in requiredParams)
+        {
+            if (!referencedParams.Contains(required))
+            {
+                failureReason = $"the type parameter '{required.Name}' of the derived type is not bound by the base type's arguments";
+                return false;
+            }
+        }
+
+        Type[]? successfulArgs = null;
+        int successCount = 0;
+
+        foreach (Type matchingBase in matchingBases)
+        {
+            Type[] matchingBaseArgs = matchingBase.GetGenericArguments();
+            Debug.Assert(
+                matchingBaseArgs.Length == baseTypeArgs.Length,
+                "matchingBase and baseTypeArgs share the same generic type definition, so arity must match.");
+
+            var substitution = new Dictionary<Type, Type>(requiredParams.Length);
+            bool unified = true;
+            for (int i = 0; i < matchingBaseArgs.Length; i++)
+            {
+                if (!matchingBaseArgs[i].TryUnifyWith(baseTypeArgs[i], substitution))
+                {
+                    unified = false;
+                    break;
+                }
+            }
+
+            if (!unified)
+            {
+                continue;
+            }
+
+            // Unification succeeded for every position. Every required parameter of the
+            // derived type definition must be bound by this ancestor; otherwise the
+            // resulting closed type would have unbound type arguments. A sibling ancestor
+            // may still bind this parameter, so failure here is not fatal.
+            Type[] closedArgs = new Type[requiredParams.Length];
+            bool allBound = true;
+            for (int i = 0; i < requiredParams.Length; i++)
+            {
+                if (!substitution.TryGetValue(requiredParams[i], out Type? boundArg))
+                {
+                    allBound = false;
+                    break;
+                }
+
+                closedArgs[i] = boundArg;
+            }
+
+            if (!allBound)
+            {
+                continue;
+            }
+
+            successCount++;
+            if (successCount == 1)
+            {
+                successfulArgs = closedArgs;
+            }
+            else
+            {
+                failureReason = "the derived type matches the base type through multiple ancestors";
+                return false;
+            }
+        }
+
+        if (successCount == 0 || successfulArgs is null)
+        {
+            failureReason = "the base type's arguments do not match the derived type's base specification";
+            return false;
+        }
+
+        try
+        {
+            closedDerivedType = openDerivedType.MakeGenericType(successfulArgs);
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or TypeLoadException)
+        {
+            failureReason = "the closed derived type would violate one of its declared generic constraints";
+            return false;
+        }
+    }
+}

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -321,28 +321,8 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
         List<DerivedTypeInfo> derivedTypeInfos = [];
         foreach (DerivedTypeShapeAttribute derivedTypeAttribute in derivedTypeAttributes)
         {
-            Type derivedType = derivedTypeAttribute.Type;
-
-            if (derivedType.IsGenericTypeDefinition)
-            {
-                if (!OpenGenericDerivedTypeResolver.TryResolveOpenGenericDerivedType(
-                        derivedType,
-                        unionType,
-                        out Type? closedDerivedType,
-                        out string? failureReason))
-                {
-                    throw new InvalidOperationException(
-                        $"The declared open generic derived type '{derivedType}' could not be resolved against the polymorphic base type '{unionType}': {failureReason}.");
-                }
-
-                derivedType = closedDerivedType;
-            }
-            else if (!unionType.IsAssignableFrom(derivedType))
-            {
-                throw new InvalidOperationException($"The declared derived type '{derivedType}' is not a valid subtype of '{unionType}'.");
-            }
-
             string name = derivedTypeAttribute.Name;
+            Type derivedType = ResolveAndValidateDerivedType(unionType, derivedTypeAttribute.Type);
             int index = derivedTypeInfos.Count;
             int tag = derivedTypeAttribute.Tag;
             bool isTagSpecified = true;
@@ -354,7 +334,7 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
 
             if (!types.Add(derivedType))
             {
-                throw new InvalidOperationException($"Polymorphic type '{unionType}' uses duplicate assignments for the derived type '{derivedTypeAttribute.Type}'.");
+                throw new InvalidOperationException($"Polymorphic type '{unionType}' uses duplicate assignments for the derived type '{derivedType}'.");
             }
 
             if (!tags.Add(tag))
@@ -372,6 +352,32 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
 
         Type unionTypeTy = typeof(ReflectionUnionTypeShape<>).MakeGenericType(unionType);
         return (IUnionTypeShape)Activator.CreateInstance(unionTypeTy, derivedTypeInfos.ToArray(), this, options)!;
+    }
+
+    private static Type ResolveAndValidateDerivedType(Type unionType, Type declaredDerivedType)
+    {
+        Type resolvedDerivedType = declaredDerivedType;
+        if (declaredDerivedType.IsGenericTypeDefinition)
+        {
+            if (!OpenGenericDerivedTypeResolver.TryResolveOpenGenericDerivedType(
+                    declaredDerivedType,
+                    unionType,
+                    out Type? closedDerivedType,
+                    out string? failureReason))
+            {
+                throw new InvalidOperationException(
+                    $"The declared open generic derived type '{declaredDerivedType}' could not be resolved against the polymorphic base type '{unionType}': {failureReason}.");
+            }
+
+            resolvedDerivedType = closedDerivedType;
+        }
+
+        if (!unionType.IsAssignableFrom(resolvedDerivedType))
+        {
+            throw new InvalidOperationException($"The declared derived type '{resolvedDerivedType}' is not a valid subtype of '{unionType}'.");
+        }
+
+        return resolvedDerivedType;
     }
 
     private IFunctionTypeShape CreateFunctionTypeShape(Type functionType, FSharpFuncInfo? fSharpFuncInfo, ReflectionTypeShapeOptions options)

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -324,21 +324,17 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
 
             if (derivedType.IsGenericTypeDefinition)
             {
-                try
+                if (!OpenGenericDerivedTypeResolver.TryResolveOpenGenericDerivedType(
+                        derivedType,
+                        unionType,
+                        out Type? closedDerivedType,
+                        out string? failureReason))
                 {
-                    // Accept generic derived types provided we can apply the type parameters for the base type.
-                    Type derivedWithBaseTypeParams = derivedType.MakeGenericType(unionType.GetGenericArguments());
-                    if (!unionType.IsAssignableFrom(derivedWithBaseTypeParams))
-                    {
-                        throw new InvalidOperationException();
-                    }
+                    throw new InvalidOperationException(
+                        $"The declared open generic derived type '{derivedType}' could not be resolved against the polymorphic base type '{unionType}': {failureReason}.");
+                }
 
-                    derivedType = derivedWithBaseTypeParams;
-                }
-                catch
-                {
-                    throw new InvalidOperationException($"The declared derived type '{derivedType}' introduces unsupported type parameters over '{unionType}'.");
-                }
+                derivedType = closedDerivedType;
             }
             else if (!unionType.IsAssignableFrom(derivedType))
             {

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -329,17 +329,8 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
                         derivedType,
                         unionType,
                         out Type? closedDerivedType,
-                        out string? failureReason,
-                        out OpenGenericResolutionFailureKind failureKind))
+                        out string? failureReason))
                 {
-                    if (failureKind.IsPerInstantiationFailure())
-                    {
-                        // The registration is valid in isolation but does not apply to this
-                        // particular closed base. A different closed instantiation of the
-                        // same base definition may still match it; silently skip.
-                        continue;
-                    }
-
                     throw new InvalidOperationException(
                         $"The declared open generic derived type '{derivedType}' could not be resolved against the polymorphic base type '{unionType}': {failureReason}.");
                 }
@@ -348,17 +339,6 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
             }
             else if (!unionType.IsAssignableFrom(derivedType))
             {
-                // The closed derived type does not fit this particular closed base. If the
-                // base is a generic instantiation AND the derived inherits from some other
-                // instantiation of the same base definition, silently skip -- the registration
-                // is targeted at a different closed base. Otherwise the registration is a
-                // hard misregistration.
-                if (unionType.IsGenericType &&
-                    derivedType.GetMatchingGenericBaseTypes(unionType.GetGenericTypeDefinition()).Any())
-                {
-                    continue;
-                }
-
                 throw new InvalidOperationException($"The declared derived type '{derivedType}' is not a valid subtype of '{unionType}'.");
             }
 

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
@@ -328,8 +329,17 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
                         derivedType,
                         unionType,
                         out Type? closedDerivedType,
-                        out string? failureReason))
+                        out string? failureReason,
+                        out OpenGenericResolutionFailureKind failureKind))
                 {
+                    if (failureKind.IsPerInstantiationFailure())
+                    {
+                        // The registration is valid in isolation but does not apply to this
+                        // particular closed base. A different closed instantiation of the
+                        // same base definition may still match it; silently skip.
+                        continue;
+                    }
+
                     throw new InvalidOperationException(
                         $"The declared open generic derived type '{derivedType}' could not be resolved against the polymorphic base type '{unionType}': {failureReason}.");
                 }
@@ -338,6 +348,17 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
             }
             else if (!unionType.IsAssignableFrom(derivedType))
             {
+                // The closed derived type does not fit this particular closed base. If the
+                // base is a generic instantiation AND the derived inherits from some other
+                // instantiation of the same base definition, silently skip -- the registration
+                // is targeted at a different closed base. Otherwise the registration is a
+                // hard misregistration.
+                if (unionType.IsGenericType &&
+                    derivedType.GetMatchingGenericBaseTypes(unionType.GetGenericTypeDefinition()).Any())
+                {
+                    continue;
+                }
+
                 throw new InvalidOperationException($"The declared derived type '{derivedType}' is not a valid subtype of '{unionType}'.");
             }
 

--- a/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
@@ -847,10 +847,10 @@ public static class DiagnosticTests
             [DerivedTypeShape(typeof(Derived<,>))]
             class Base<T>
             {
-                public class Inner;
+                public class Inner { }
             }
 
-            class Derived<T1, T2> : Base<T1>;
+            class Derived<T1, T2> : Base<T1> { }
 
             [GenerateShapeFor(typeof(Base<int>))]
             partial class Witness { }
@@ -898,7 +898,7 @@ public static class DiagnosticTests
             [DerivedTypeShape(typeof(Derived<>))]
             class Base<T> { }
 
-            class Derived<T> : Base<T> where T : struct;
+            class Derived<T> : Base<T> where T : struct { }
 
             [GenerateShapeFor(typeof(Base<string>))]
             partial class Witness { }
@@ -922,7 +922,7 @@ public static class DiagnosticTests
             [DerivedTypeShape(typeof(Derived<>))]
             class Base<T> { }
 
-            class Derived<T> : Base<T>;
+            class Derived<T> : Base<T> { }
 
             [GenerateShapeFor(typeof(Base<int>))]
             partial class Witness { }
@@ -941,7 +941,7 @@ public static class DiagnosticTests
             [DerivedTypeShape(typeof(Reordered<,>))]
             class Base<T1, T2> { }
 
-            class Reordered<U, V> : Base<V, U>;
+            class Reordered<U, V> : Base<V, U> { }
 
             [GenerateShapeFor(typeof(Base<int, string>))]
             partial class Witness { }
@@ -960,7 +960,7 @@ public static class DiagnosticTests
             [DerivedTypeShape(typeof(Partial<>))]
             class Base<T1, T2> { }
 
-            class Partial<T> : Base<T, int>;
+            class Partial<T> : Base<T, int> { }
 
             [GenerateShapeFor(typeof(Base<bool, int>))]
             partial class Witness { }
@@ -980,7 +980,7 @@ public static class DiagnosticTests
             [DerivedTypeShape(typeof(Wrapped<>))]
             class Base<T> { }
 
-            class Wrapped<T> : Base<List<T>>;
+            class Wrapped<T> : Base<List<T>> { }
 
             [GenerateShapeFor(typeof(Base<List<int>>))]
             partial class Witness { }

--- a/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
@@ -731,6 +731,153 @@ public static class DiagnosticTests
     }
 
     [Fact]
+    public static void ClosedAndOpenDerivedTypesResolvingToSameType_ErrorDiagnostic()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Derived<int>), Name = "closed", Tag = 1)]
+            [DerivedTypeShape(typeof(Derived<>), Name = "open", Tag = 2)]
+            class Base<T> { }
+
+            class Derived<T> : Base<T> { }
+
+            [GenerateShapeFor(typeof(Base<int>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0012", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("type 'Derived<int>'", diagnostic.GetMessage());
+    }
+
+    [Theory]
+    [MemberData(nameof(GetInvalidDerivedTypeMetadataCollisionCases))]
+    public static void InvalidDerivedType_StillReportsMetadataCollisions(string source, string primaryDiagnosticId)
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation(source);
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Assert.Single(result.Diagnostics, diagnostic => diagnostic.Id == primaryDiagnosticId);
+        Diagnostic[] duplicateDiagnostics = result.Diagnostics.Where(diagnostic => diagnostic.Id == "PT0012").ToArray();
+        Assert.Equal(2, duplicateDiagnostics.Length);
+        Assert.Contains(duplicateDiagnostics, diagnostic => diagnostic.GetMessage().Contains("tag '42'"));
+        Assert.Contains(duplicateDiagnostics, diagnostic => diagnostic.GetMessage().Contains("name 'collision'"));
+    }
+
+    public static IEnumerable<object[]> GetInvalidDerivedTypeMetadataCollisionCases()
+    {
+        yield return
+        [
+            """
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Unrelated), Name = "collision", Tag = 42)]
+            [DerivedTypeShape(typeof(Derived), Name = "collision", Tag = 42)]
+            class Base { }
+
+            class Unrelated { }
+            class Derived : Base { }
+
+            [GenerateShapeFor(typeof(Base))]
+            partial class Witness { }
+            """,
+            "PT0011",
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Unbound<,>), Name = "collision", Tag = 42)]
+            [DerivedTypeShape(typeof(Derived<>), Name = "collision", Tag = 42)]
+            class Base<T> { }
+
+            class Unbound<T, U> : Base<T> { }
+            class Derived<T> : Base<T> { }
+
+            [GenerateShapeFor(typeof(Base<int>))]
+            partial class Witness { }
+            """,
+            "PT0013",
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(GetUnsuppressibleDerivedTypeDiagnosticCases))]
+    public static void InvalidDerivedTypeDiagnostics_CannotBeSuppressed(string source, string diagnosticId)
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation(source);
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics, diagnostic => diagnostic.Id == diagnosticId);
+        Assert.False(diagnostic.IsSuppressed);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    public static IEnumerable<object[]> GetUnsuppressibleDerivedTypeDiagnosticCases()
+    {
+        yield return
+        [
+            """
+            using PolyType;
+
+            #pragma warning disable PT0011
+            [DerivedTypeShape(typeof(Unrelated))]
+            class Base { }
+            #pragma warning restore PT0011
+
+            class Unrelated { }
+
+            [GenerateShapeFor(typeof(Base))]
+            partial class Witness { }
+            """,
+            "PT0011",
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+
+            #pragma warning disable PT0012
+            [DerivedTypeShape(typeof(Derived), Name = "first")]
+            [DerivedTypeShape(typeof(Derived), Name = "second")]
+            class Base { }
+            #pragma warning restore PT0012
+
+            class Derived : Base { }
+
+            [GenerateShapeFor(typeof(Base))]
+            partial class Witness { }
+            """,
+            "PT0012",
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+
+            #pragma warning disable PT0013
+            [DerivedTypeShape(typeof(Derived<,>))]
+            class Base<T> { }
+            #pragma warning restore PT0013
+
+            class Derived<T, U> : Base<T> { }
+
+            [GenerateShapeFor(typeof(Base<int>))]
+            partial class Witness { }
+            """,
+            "PT0013",
+        ];
+    }
+
+    [Fact]
     public static void PolymorphicClassWithConflictingDerivedTypeNames_ErrorDiagnostic()
     {
         Compilation compilation = CompilationHelpers.CreateCompilation("""
@@ -1008,6 +1155,188 @@ public static class DiagnosticTests
         Assert.Empty(result.Diagnostics);
     }
 
+    [Theory]
+    [MemberData(nameof(GetAdvancedValidOpenGenericDerivedTypeCases))]
+    public static void OpenGenericDerivedType_AdvancedValidPattern_NoDiagnostic(string source)
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation(source);
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    public static IEnumerable<object[]> GetAdvancedValidOpenGenericDerivedTypeCases()
+    {
+        yield return
+        [
+            """
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Outer<>.Middle.Leaf<>))]
+            class Base<T> { }
+
+            class Outer<T>
+            {
+                public class Middle
+                {
+                    public class Leaf<U> : Base<(T, U)> { }
+                }
+            }
+
+            [GenerateShapeFor(typeof(Base<(int, string)>))]
+            partial class Witness { }
+            """,
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Derived<>))]
+            class Base<T> { }
+
+            class Outer<T>
+            {
+                public class Box<U> { }
+            }
+
+            class Derived<T> : Base<Outer<T>.Box<int>> { }
+
+            [GenerateShapeFor(typeof(Base<Outer<string>.Box<int>>))]
+            partial class Witness { }
+            """,
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Impl<>))]
+            interface IBase<T> { }
+
+            interface ILeft<T> : IBase<T> { }
+            interface IRight<T> : IBase<T> { }
+            interface IDiamond<T> : ILeft<T>, IRight<T> { }
+            class Impl<T> : IDiamond<T> { }
+
+            [GenerateShapeFor(typeof(IBase<int>))]
+            partial class Witness { }
+            """,
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Impl<>))]
+            interface IBase1<T> { }
+
+            [DerivedTypeShape(typeof(Impl<>))]
+            interface IBase2<T> { }
+
+            class Impl<T> : IBase1<T>, IBase2<T> { }
+
+            [GenerateShapeFor(typeof(IBase1<int>))]
+            [GenerateShapeFor(typeof(IBase2<string>))]
+            partial class Witness { }
+            """,
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+            using System.Collections.Generic;
+
+            [DerivedTypeShape(typeof(Impl<>))]
+            interface IBase<T> { }
+
+            class Impl<T> : IBase<T>, IBase<List<T>> { }
+
+            [GenerateShapeFor(typeof(IBase<int>))]
+            partial class Witness { }
+            """,
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+
+            [DerivedTypeShape(typeof(CovariantImpl<>))]
+            interface ICovariant<out T> { }
+            class CovariantImpl<T> : ICovariant<T> { }
+
+            [DerivedTypeShape(typeof(ContravariantImpl<>))]
+            interface IContravariant<in T> { }
+            class ContravariantImpl<T> : IContravariant<T> { }
+
+            [DerivedTypeShape(typeof(BivariantImpl<,>))]
+            interface IBivariant<in TIn, out TOut> { }
+            class BivariantImpl<TIn, TOut> : IBivariant<TIn, TOut> { }
+
+            [GenerateShapeFor(typeof(ICovariant<object>))]
+            [GenerateShapeFor(typeof(IContravariant<string>))]
+            [GenerateShapeFor(typeof(IBivariant<string, object>))]
+            partial class Witness { }
+            """,
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+            using System.Collections.Generic;
+
+            [DerivedTypeShape(typeof(Derived<>))]
+            class Base<T> { }
+
+            class Derived<T> : Base<T> where T : IEnumerable<object> { }
+
+            [GenerateShapeFor(typeof(Base<List<string>>))]
+            partial class Witness { }
+            """,
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+            using System.Collections.Generic;
+
+            [DerivedTypeShape(typeof(Derived<,>))]
+            class Base<T, U> { }
+
+            class Derived<T, U> : Base<T, U> where T : IEnumerable<U[]> { }
+
+            [GenerateShapeFor(typeof(Base<List<int[]>, int>))]
+            partial class Witness { }
+            """,
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+            using System.Collections.Generic;
+
+            [DerivedTypeShape(typeof(KeyValueDerived<>))]
+            class KeyValueBase<T> { }
+            class KeyValueDerived<T> : KeyValueBase<KeyValuePair<string, T>> { }
+
+            [DerivedTypeShape(typeof(TupleDerived<,>))]
+            class TupleBase<T> { }
+            class TupleDerived<T1, T2> : TupleBase<(T1, T2)> { }
+
+            [GenerateShapeFor(typeof(KeyValueBase<KeyValuePair<string, int>>))]
+            [GenerateShapeFor(typeof(TupleBase<(string, int)>))]
+            partial class Witness { }
+            """,
+        ];
+    }
+
     [Fact]
     public static void ClosedDerived_TargetingDifferentBaseInstantiation_ErrorDiagnostics()
     {
@@ -1249,6 +1578,29 @@ public static class DiagnosticTests
             """,
             "Silly<>",
             "Animal<System.Collections.Generic.List<int[][]>>",
+            "arguments do not match",
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Derived<>))]
+            class Base<T> { }
+
+            class Outer<T>
+            {
+                public class Box<U> { }
+            }
+
+            class Derived<T> : Base<Outer<int>.Box<T>> { }
+
+            [GenerateShapeFor(typeof(Base<Outer<string>.Box<int>>))]
+            partial class Witness { }
+            """,
+            "Derived<>",
+            "Base<Outer<string>.Box<int>>",
             "arguments do not match",
         ];
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
@@ -890,11 +890,8 @@ public static class DiagnosticTests
     }
 
     [Fact]
-    public static void OpenGenericDerivedType_ConstraintViolation_SilentlyFiltered_NoDiagnostic()
+    public static void OpenGenericDerivedType_ConstraintViolation_ErrorDiagnostic()
     {
-        // T = string violates `where T : struct`. The registration is silently filtered for
-        // this particular closed base; a different closed instantiation (e.g. Base<int>) may
-        // still match. No diagnostic should be produced.
         Compilation compilation = CompilationHelpers.CreateCompilation("""
             using PolyType;
 
@@ -908,7 +905,11 @@ public static class DiagnosticTests
             """);
 
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
-        Assert.Empty(result.Diagnostics);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0013", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("constraint", diagnostic.GetMessage());
     }
 
     [Fact]
@@ -1008,10 +1009,8 @@ public static class DiagnosticTests
     }
 
     [Fact]
-    public static void ClosedDerived_TargetingDifferentBaseInstantiation_SilentlyFiltered()
+    public static void ClosedDerived_TargetingDifferentBaseInstantiation_ErrorDiagnostics()
     {
-        // Cat targets Animal<int>; Dog targets Animal<string>. When the witness requests
-        // Animal<int>, Dog is silently filtered. No diagnostic should be produced.
         Compilation compilation = CompilationHelpers.CreateCompilation("""
             using PolyType;
 
@@ -1028,15 +1027,17 @@ public static class DiagnosticTests
             """);
 
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
-        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Diagnostics.Length);
+        Assert.All(result.Diagnostics, diagnostic =>
+        {
+            Assert.Equal("PT0011", diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        });
     }
 
     [Fact]
-    public static void ClosedDerived_TargetingDifferentBaseInstantiation_AllFiltered_NoDiagnostic()
+    public static void ClosedDerived_TargetingDifferentBaseInstantiation_AllInvalid_ErrorDiagnostics()
     {
-        // Animal<bool> matches neither Cat (Animal<int>) nor Dog (Animal<string>). Both
-        // registrations are silently filtered; the resulting union has no cases but no
-        // diagnostic is produced.
         Compilation compilation = CompilationHelpers.CreateCompilation("""
             using PolyType;
 
@@ -1052,7 +1053,12 @@ public static class DiagnosticTests
             """);
 
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
-        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Diagnostics.Length);
+        Assert.All(result.Diagnostics, diagnostic =>
+        {
+            Assert.Equal("PT0011", diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        });
     }
 
     [Fact]
@@ -1103,10 +1109,8 @@ public static class DiagnosticTests
     }
 
     [Fact]
-    public static void OpenGenericDerivedType_UnificationFailed_SilentlyFiltered_NoDiagnostic()
+    public static void OpenGenericDerivedType_UnificationFailed_ErrorDiagnostic()
     {
-        // Derived<T> : Base<List<T>>. For Base<int> there's no T such that List<T> = int,
-        // so unification fails per-instantiation. Silently filter rather than diagnose.
         Compilation compilation = CompilationHelpers.CreateCompilation("""
             using PolyType;
             using System.Collections.Generic;
@@ -1121,14 +1125,16 @@ public static class DiagnosticTests
             """);
 
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
-        Assert.Empty(result.Diagnostics);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0013", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("arguments do not match", diagnostic.GetMessage());
     }
 
     [Fact]
-    public static void OpenGenericDerivedType_InterfaceConstraint_FilteredAndResolvedPerInstantiation()
+    public static void OpenGenericDerivedType_InterfaceConstraint_InvalidSpecializationProducesError()
     {
-        // Derived<T> : Base<T> where T : IEnumerable<int>. For Base<List<int>> the constraint
-        // holds → resolved. For Base<string> the constraint fails → silently filtered.
         Compilation compilation = CompilationHelpers.CreateCompilation("""
             using PolyType;
             using System.Collections.Generic;
@@ -1144,7 +1150,107 @@ public static class DiagnosticTests
             """);
 
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
-        Assert.Empty(result.Diagnostics);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0013", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("constraint", diagnostic.GetMessage());
+        Assert.Contains("Base<string>", diagnostic.GetMessage());
+    }
+
+    [Theory]
+    [MemberData(nameof(GetInvalidOpenGenericSpecializationCases))]
+    public static void OpenGenericDerivedType_InvalidSpecialization_ErrorDiagnostic(
+        string source,
+        string expectedDerivedType,
+        string expectedBaseType,
+        string expectedReason)
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation(source);
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0013", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains(expectedDerivedType, diagnostic.GetMessage());
+        Assert.Contains(expectedBaseType, diagnostic.GetMessage());
+        Assert.Contains(expectedReason, diagnostic.GetMessage());
+    }
+
+    public static IEnumerable<object[]> GetInvalidOpenGenericSpecializationCases()
+    {
+        yield return
+        [
+            """
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Derived<>))]
+            class Base<T1, T2> { }
+            class Derived<T> : Base<T, T> { }
+
+            [GenerateShapeFor(typeof(Base<int, string>))]
+            partial class Witness { }
+            """,
+            "Derived<>",
+            "Base<int, string>",
+            "arguments do not match",
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Derived<>))]
+            class Base<T1, T2> { }
+            class Derived<T> : Base<T, int> { }
+
+            [GenerateShapeFor(typeof(Base<string, string>))]
+            partial class Witness { }
+            """,
+            "Derived<>",
+            "Base<string, string>",
+            "arguments do not match",
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Derived<>))]
+            class Base<T> { }
+            class Derived<T> : Base<T> where T : class, new() { }
+            class NoDefaultConstructorArgument
+            {
+                public NoDefaultConstructorArgument(int value) { }
+            }
+
+            [GenerateShapeFor(typeof(Base<NoDefaultConstructorArgument>))]
+            partial class Witness { }
+            """,
+            "Derived<>",
+            "Base<NoDefaultConstructorArgument>",
+            "constraint",
+        ];
+
+        yield return
+        [
+            """
+            using PolyType;
+            using System.Collections.Generic;
+
+            [DerivedTypeShape(typeof(Silly<>))]
+            class Animal<T> { }
+            class Silly<T> : Animal<List<T[][][]>> { }
+
+            [GenerateShapeFor(typeof(Animal<List<int[][]>>))]
+            partial class Witness { }
+            """,
+            "Silly<>",
+            "Animal<System.Collections.Generic.List<int[][]>>",
+            "arguments do not match",
+        ];
     }
 
     [Fact]
@@ -1202,11 +1308,8 @@ public static class DiagnosticTests
     }
 
     [Fact]
-    public static void MixedClosedAndOpenDerived_PerInstantiationFilteringWorks()
+    public static void MixedValidAndInvalidDerived_InvalidRegistrationProducesError()
     {
-        // Realistic mixed registration: a closed derived for one instantiation alongside an
-        // open generic derived covering others. Both registrations may apply or not depending
-        // on the requested base, and the source generator should never error.
         Compilation compilation = CompilationHelpers.CreateCompilation("""
             using PolyType;
 
@@ -1218,13 +1321,40 @@ public static class DiagnosticTests
             class General<T> : Base<T> where T : class { }
 
             [GenerateShapeFor(typeof(Base<int>))]
-            [GenerateShapeFor(typeof(Base<string>))]
-            [GenerateShapeFor(typeof(Base<bool>))]
             partial class Witness { }
             """);
 
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
-        Assert.Empty(result.Diagnostics);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0013", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("constraint", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_SameNameDifferentArities_ErrorDiagnostic()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Cat<>), Name = "cat")]
+            [DerivedTypeShape(typeof(Cat<,>), Name = "cat")]
+            class Animal<T1, T2> { }
+
+            class Cat<T> : Animal<T, T> { }
+            class Cat<T1, T2> : Animal<T1, T2> { }
+
+            [GenerateShapeFor(typeof(Animal<int, int>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0012", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("name 'cat'", diagnostic.GetMessage());
     }
 
     [Fact]

--- a/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
@@ -890,8 +890,11 @@ public static class DiagnosticTests
     }
 
     [Fact]
-    public static void OpenGenericDerivedType_ConstraintViolation_ErrorDiagnostic()
+    public static void OpenGenericDerivedType_ConstraintViolation_SilentlyFiltered_NoDiagnostic()
     {
+        // T = string violates `where T : struct`. The registration is silently filtered for
+        // this particular closed base; a different closed instantiation (e.g. Base<int>) may
+        // still match. No diagnostic should be produced.
         Compilation compilation = CompilationHelpers.CreateCompilation("""
             using PolyType;
 
@@ -905,12 +908,7 @@ public static class DiagnosticTests
             """);
 
         PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
-
-        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
-        Assert.Equal("PT0013", diagnostic.Id);
-        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
-        Assert.Contains("constraint on type parameter 'T'", diagnostic.GetMessage());
-        Assert.Contains("'string'", diagnostic.GetMessage());
+        Assert.Empty(result.Diagnostics);
     }
 
     [Fact]
@@ -1002,6 +1000,226 @@ public static class DiagnosticTests
             class Impl<T> : IBase<T> { }
 
             [GenerateShapeFor(typeof(IBase<int>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void ClosedDerived_TargetingDifferentBaseInstantiation_SilentlyFiltered()
+    {
+        // Cat targets Animal<int>; Dog targets Animal<string>. When the witness requests
+        // Animal<int>, Dog is silently filtered. No diagnostic should be produced.
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Cat))]
+            [DerivedTypeShape(typeof(Dog))]
+            class Animal<T> { }
+
+            class Cat : Animal<int> { }
+            class Dog : Animal<string> { }
+
+            [GenerateShapeFor(typeof(Animal<int>))]
+            [GenerateShapeFor(typeof(Animal<string>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void ClosedDerived_TargetingDifferentBaseInstantiation_AllFiltered_NoDiagnostic()
+    {
+        // Animal<bool> matches neither Cat (Animal<int>) nor Dog (Animal<string>). Both
+        // registrations are silently filtered; the resulting union has no cases but no
+        // diagnostic is produced.
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Cat))]
+            [DerivedTypeShape(typeof(Dog))]
+            class Animal<T> { }
+
+            class Cat : Animal<int> { }
+            class Dog : Animal<string> { }
+
+            [GenerateShapeFor(typeof(Animal<bool>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void ClosedDerived_NotAssignable_NonGenericBase_StillErrorDiagnostic()
+    {
+        // Non-generic base: there's no other instantiation to consider. Hard error preserved.
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Unrelated))]
+            class NonGenericBase { }
+
+            class Unrelated { }
+
+            [GenerateShapeFor(typeof(NonGenericBase))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0011", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public static void ClosedDerived_NoRelationToBaseDefinition_StillErrorDiagnostic()
+    {
+        // Even with a generic base, a derived type that has NO inheritance relation to any
+        // instantiation of the base is a hard misregistration.
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Unrelated))]
+            class GenericBase<T> { }
+
+            class Unrelated { }
+
+            [GenerateShapeFor(typeof(GenericBase<int>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0011", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_UnificationFailed_SilentlyFiltered_NoDiagnostic()
+    {
+        // Derived<T> : Base<List<T>>. For Base<int> there's no T such that List<T> = int,
+        // so unification fails per-instantiation. Silently filter rather than diagnose.
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+            using System.Collections.Generic;
+
+            [DerivedTypeShape(typeof(Wrapped<>))]
+            class Base<T> { }
+
+            class Wrapped<T> : Base<List<T>> { }
+
+            [GenerateShapeFor(typeof(Base<int>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_InterfaceConstraint_FilteredAndResolvedPerInstantiation()
+    {
+        // Derived<T> : Base<T> where T : IEnumerable<int>. For Base<List<int>> the constraint
+        // holds → resolved. For Base<string> the constraint fails → silently filtered.
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+            using System.Collections.Generic;
+
+            [DerivedTypeShape(typeof(Derived<>))]
+            class Base<T> { }
+
+            class Derived<T> : Base<T> where T : IEnumerable<int> { }
+
+            [GenerateShapeFor(typeof(Base<System.Collections.Generic.List<int>>))]
+            [GenerateShapeFor(typeof(Base<string>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_OverlappingArities_HigherArityIsHardError()
+    {
+        // Cat<T,U> : Animal<T> has an extra type parameter U that no base spec can bind.
+        // This is a fundamental misregistration (UnboundParameter) → hard error preserved.
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Cat<,>))]
+            class Animal<T> { }
+
+            class Cat<T, U> : Animal<T> { }
+
+            [GenerateShapeFor(typeof(Animal<int>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0013", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("'U'", diagnostic.GetMessage());
+        Assert.Contains("not bound", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_OverlappingArities_BothRegistered_HigherArityErrors()
+    {
+        // User registers both Cat<T> and Cat<T,U>. The first is valid, the second has an
+        // unbound parameter. The well-formed registration succeeds; the malformed one still
+        // produces a diagnostic.
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Cat<>))]
+            [DerivedTypeShape(typeof(Cat<,>))]
+            class Animal<T> { }
+
+            class Cat<T> : Animal<T> { }
+            class Cat<T, U> : Animal<T> { }
+
+            [GenerateShapeFor(typeof(Animal<int>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0013", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("'U'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public static void MixedClosedAndOpenDerived_PerInstantiationFilteringWorks()
+    {
+        // Realistic mixed registration: a closed derived for one instantiation alongside an
+        // open generic derived covering others. Both registrations may apply or not depending
+        // on the requested base, and the source generator should never error.
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(IntSpecial))]
+            [DerivedTypeShape(typeof(General<>))]
+            class Base<T> { }
+
+            class IntSpecial : Base<int> { }
+            class General<T> : Base<T> where T : class { }
+
+            [GenerateShapeFor(typeof(Base<int>))]
+            [GenerateShapeFor(typeof(Base<string>))]
+            [GenerateShapeFor(typeof(Base<bool>))]
             partial class Witness { }
             """);
 

--- a/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/DiagnosticTests.cs
@@ -803,7 +803,7 @@ public static class DiagnosticTests
         Diagnostic diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal("PT0013", diagnostic.Id);
         Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
-        Assert.Contains("introduces unsupported type parameters", diagnostic.GetMessage());
+        Assert.Contains("not assignable to the base type", diagnostic.GetMessage());
         Assert.Equal((2, 1), diagnostic.Location.GetStartPosition());
         Assert.Equal((2, 36), diagnostic.Location.GetEndPosition());
     }
@@ -830,9 +830,183 @@ public static class DiagnosticTests
         Diagnostic diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal("PT0013", diagnostic.Id);
         Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
-        Assert.Contains("introduces unsupported type parameters", diagnostic.GetMessage());
+        // The nested Derived<S> requires both the enclosing T and its own S; only S is bound by the
+        // matching ancestor's arguments, so T is reported as the unbound parameter.
+        Assert.Contains("'T'", diagnostic.GetMessage());
+        Assert.Contains("not bound by the base type's arguments", diagnostic.GetMessage());
         Assert.Equal((3, 1), diagnostic.Location.GetStartPosition());
         Assert.Equal((3, 36), diagnostic.Location.GetEndPosition());
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_UnboundParameter_ErrorDiagnostic()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Derived<,>))]
+            class Base<T>
+            {
+                public class Inner;
+            }
+
+            class Derived<T1, T2> : Base<T1>;
+
+            [GenerateShapeFor(typeof(Base<int>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0013", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("'T2'", diagnostic.GetMessage());
+        Assert.Contains("not bound by the base type's arguments", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_AmbiguousMatch_ErrorDiagnostic()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+            using System.Collections.Generic;
+
+            [DerivedTypeShape(typeof(Impl<>))]
+            interface IBase<T> { }
+
+            class Impl<T> : IBase<T>, IBase<List<T>> { }
+
+            [GenerateShapeFor(typeof(IBase<List<int>>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0013", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("matches the base type through multiple ancestors", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_ConstraintViolation_ErrorDiagnostic()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Derived<>))]
+            class Base<T> { }
+
+            class Derived<T> : Base<T> where T : struct;
+
+            [GenerateShapeFor(typeof(Base<string>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+        Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("PT0013", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("constraint on type parameter 'T'", diagnostic.GetMessage());
+        Assert.Contains("'string'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_Identity_NoDiagnostic()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Derived<>))]
+            class Base<T> { }
+
+            class Derived<T> : Base<T>;
+
+            [GenerateShapeFor(typeof(Base<int>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_ReorderedParameters_NoDiagnostic()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Reordered<,>))]
+            class Base<T1, T2> { }
+
+            class Reordered<U, V> : Base<V, U>;
+
+            [GenerateShapeFor(typeof(Base<int, string>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_PartialConcretization_NoDiagnostic()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Partial<>))]
+            class Base<T1, T2> { }
+
+            class Partial<T> : Base<T, int>;
+
+            [GenerateShapeFor(typeof(Base<bool, int>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_WrappedArgument_NoDiagnostic()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+            using System.Collections.Generic;
+
+            [DerivedTypeShape(typeof(Wrapped<>))]
+            class Base<T> { }
+
+            class Wrapped<T> : Base<List<T>>;
+
+            [GenerateShapeFor(typeof(Base<List<int>>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public static void OpenGenericDerivedType_InterfaceBase_NoDiagnostic()
+    {
+        Compilation compilation = CompilationHelpers.CreateCompilation("""
+            using PolyType;
+
+            [DerivedTypeShape(typeof(Impl<>))]
+            interface IBase<T> { }
+
+            class Impl<T> : IBase<T> { }
+
+            [GenerateShapeFor(typeof(IBase<int>))]
+            partial class Witness { }
+            """);
+
+        PolyTypeSourceGeneratorResult result = CompilationHelpers.RunPolyTypeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        Assert.Empty(result.Diagnostics);
     }
 
     [Fact]

--- a/tests/PolyType.Tests/ProviderUnderTest.cs
+++ b/tests/PolyType.Tests/ProviderUnderTest.cs
@@ -21,7 +21,12 @@ public abstract class ProviderUnderTest
     {
         if (testCase.IsUnion)
         {
-            return !testCase.IsAbstract || FSharpType.IsUnion(testCase.Type, null);
+            IUnionTypeShape unionShape = (IUnionTypeShape)ResolveShape(testCase);
+            return !testCase.IsAbstract ||
+                FSharpType.IsUnion(testCase.Type, null) ||
+                unionShape.UnionCases.Any(
+                    unionCase => !unionCase.UnionCaseType.Type.IsAbstract &&
+                        (testCase.Value is null || unionCase.UnionCaseType.Type.IsInstanceOfType(testCase.Value)));
         }
 
         return !(testCase.IsAbstract && !typeof(IEnumerable).IsAssignableFrom(testCase.Type)) &&

--- a/tests/PolyType.Tests/ReflectionTypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/ReflectionTypeShapeProviderTests.cs
@@ -111,6 +111,82 @@ public static class ReflectionTypeShapeProviderTests
         Assert.Equal(options1.GetHashCode(), options2.GetHashCode());
     }
 
+    [DerivedTypeShape(typeof(DuplicateClosedAndOpenDerived<int>), Name = "closed", Tag = 1)]
+    [DerivedTypeShape(typeof(DuplicateClosedAndOpenDerived<>), Name = "open", Tag = 2)]
+    private class DuplicateClosedAndOpenBase<T>;
+
+    private class DuplicateClosedAndOpenDerived<T> : DuplicateClosedAndOpenBase<T>;
+
+    [Fact]
+    public static void ClosedAndOpenDerivedTypesResolvingToSameType_ThrowsForResolvedType()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ReflectionTypeShapeProvider.Default.GetTypeShape(typeof(DuplicateClosedAndOpenBase<int>)));
+
+        Assert.Contains("duplicate assignments for the derived type", ex.Message);
+        Assert.Contains(typeof(DuplicateClosedAndOpenDerived<int>).ToString(), ex.Message);
+    }
+
+    private class EnclosingMismatchOuter<T>
+    {
+        public class Box<U>;
+    }
+
+    [DerivedTypeShape(typeof(EnclosingMismatchDerived<>))]
+    private class EnclosingMismatchBase<T>;
+
+    private class EnclosingMismatchDerived<T> : EnclosingMismatchBase<EnclosingMismatchOuter<int>.Box<T>>;
+
+    [Fact]
+    public static void OpenGenericDerivedType_EnclosingMismatch_ThrowsInvalidOperationException()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ReflectionTypeShapeProvider.Default.GetTypeShape(
+                typeof(EnclosingMismatchBase<EnclosingMismatchOuter<string>.Box<int>>)));
+
+        Assert.Contains("arguments do not match", ex.Message);
+    }
+
+    [DerivedTypeShape(typeof(MultipleBaseImpl<>))]
+    private interface IMultipleBase1<T>;
+
+    [DerivedTypeShape(typeof(MultipleBaseImpl<>))]
+    private interface IMultipleBase2<T>;
+
+    private class MultipleBaseImpl<T> : IMultipleBase1<T>, IMultipleBase2<T>;
+
+    [Theory]
+    [InlineData(typeof(IMultipleBase1<int>))]
+    [InlineData(typeof(IMultipleBase2<string>))]
+    public static void OpenGenericDerivedType_MultipleGenericInterfaceBases_ResolveIndependently(Type baseType)
+    {
+        var union = Assert.IsAssignableFrom<IUnionTypeShape>(ReflectionTypeShapeProvider.Default.GetTypeShape(baseType));
+        Type expectedDerivedType = typeof(MultipleBaseImpl<>).MakeGenericType(baseType.GetGenericArguments());
+        Assert.Contains(union.UnionCases, unionCase => unionCase.UnionCaseType.Type == expectedDerivedType);
+    }
+
+    [DerivedTypeShape(typeof(CovariantImpl<>))]
+    private interface ICovariant<out T>;
+    private class CovariantImpl<T> : ICovariant<T>;
+
+    [DerivedTypeShape(typeof(ContravariantImpl<>))]
+    private interface IContravariant<in T>;
+    private class ContravariantImpl<T> : IContravariant<T>;
+
+    [DerivedTypeShape(typeof(BivariantImpl<,>))]
+    private interface IBivariant<in TIn, out TOut>;
+    private class BivariantImpl<TIn, TOut> : IBivariant<TIn, TOut>;
+
+    [Theory]
+    [InlineData(typeof(ICovariant<object>), typeof(CovariantImpl<object>))]
+    [InlineData(typeof(IContravariant<string>), typeof(ContravariantImpl<string>))]
+    [InlineData(typeof(IBivariant<string, object>), typeof(BivariantImpl<string, object>))]
+    public static void OpenGenericDerivedType_VariantInterface_Resolves(Type baseType, Type expectedDerivedType)
+    {
+        var union = Assert.IsAssignableFrom<IUnionTypeShape>(ReflectionTypeShapeProvider.Default.GetTypeShape(baseType));
+        Assert.Contains(union.UnionCases, unionCase => unionCase.UnionCaseType.Type == expectedDerivedType);
+    }
+
 #if NET
     [Fact]
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -1681,6 +1681,9 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
     [Theory]
     [InlineData(typeof(PolymorphicClassWithGenericDerivedType), "Derived")]
     [InlineData(typeof(GenericPolymorphicClassWithMismatchingGenericDerivedType<int>), "Derived")]
+    [InlineData(typeof(OpenGenericPolymorphicClassUnboundParameter<int>), "Derived")]
+    [InlineData(typeof(OpenGenericPolymorphicClassAmbiguousMatch<List<int>>), "Impl")]
+    [InlineData(typeof(OpenGenericPolymorphicClassConstraintViolation<string>), "Derived")]
     public void PolymorphicClassWithGenericDerivedType_ThrowsInvalidOperationException(Type type, string derivedTypeName)
     {
         var ex = Assert.Throws<InvalidOperationException>(() => Provider.GetTypeShape(type));
@@ -1697,6 +1700,43 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
     private class GenericPolymorphicClassWithMismatchingGenericDerivedType<T>
     {
         public class Derived<S> : GenericPolymorphicClassWithMismatchingGenericDerivedType<List<S>>;
+    }
+
+    [DerivedTypeShape(typeof(OpenGenericPolymorphicClassUnboundParameterDerived<,>))]
+    private class OpenGenericPolymorphicClassUnboundParameter<T>;
+
+    private class OpenGenericPolymorphicClassUnboundParameterDerived<T1, T2> : OpenGenericPolymorphicClassUnboundParameter<T1>;
+
+    [DerivedTypeShape(typeof(OpenGenericPolymorphicClassAmbiguousMatchImpl<>))]
+    private interface OpenGenericPolymorphicClassAmbiguousMatch<T>;
+
+    private class OpenGenericPolymorphicClassAmbiguousMatchImpl<T> :
+        OpenGenericPolymorphicClassAmbiguousMatch<T>,
+        OpenGenericPolymorphicClassAmbiguousMatch<List<T>>;
+
+    [DerivedTypeShape(typeof(OpenGenericPolymorphicClassConstraintViolationDerived<>))]
+    private class OpenGenericPolymorphicClassConstraintViolation<T>;
+
+    private class OpenGenericPolymorphicClassConstraintViolationDerived<T> : OpenGenericPolymorphicClassConstraintViolation<T>
+        where T : struct;
+
+    [Theory]
+    [MemberData(nameof(GetOpenGenericResolutionSuccessCases))]
+    public void OpenGenericDerivedType_SupportedPatterns_ResolvesToExpectedClosedType(Type baseType, Type expectedClosedDerived)
+    {
+        ITypeShape shape = Provider.GetTypeShape(baseType)!;
+        var union = Assert.IsAssignableFrom<IUnionTypeShape>(shape);
+        Assert.Contains(union.UnionCases, c => c.UnionCaseType.Type == expectedClosedDerived);
+    }
+
+    public static IEnumerable<object[]> GetOpenGenericResolutionSuccessCases()
+    {
+        yield return new object[] { typeof(OpenGenericReorderedBase<int, string>), typeof(OpenGenericReorderedDerived<string, int>) };
+        yield return new object[] { typeof(OpenGenericPartialBase<string, int>), typeof(OpenGenericPartialDerived<string>) };
+        yield return new object[] { typeof(OpenGenericWrappedBase<List<string>>), typeof(OpenGenericWrappedDerived<string>) };
+        yield return new object[] { typeof(OpenGenericArrayBase<int[]>), typeof(OpenGenericArrayDerived<int>) };
+        yield return new object[] { typeof(IOpenGenericInterfaceBase<int>), typeof(OpenGenericInterfaceImpl<int>) };
+        yield return new object[] { typeof(OpenGenericMultiLevelBase<List<int>>), typeof(OpenGenericMultiLevelLeaf<int>) };
     }
 
     [Fact]

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -1720,13 +1720,12 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
         where T : struct;
 
     [Fact]
-    public void OpenGenericDerivedType_ConstraintViolation_SilentlyFiltered()
+    public void OpenGenericDerivedType_ConstraintViolation_ThrowsInvalidOperationException()
     {
-        // T = string violates `where T : struct` -- the registration cannot apply to
-        // OpenGenericPolymorphicClassConstraintViolation<string> so it is silently filtered.
-        ITypeShape shape = Provider.GetTypeShape(typeof(OpenGenericPolymorphicClassConstraintViolation<string>))!;
-        var union = Assert.IsAssignableFrom<IUnionTypeShape>(shape);
-        Assert.Empty(union.UnionCases);
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => Provider.GetTypeShape(typeof(OpenGenericPolymorphicClassConstraintViolation<string>)));
+
+        Assert.Contains("generic constraints", ex.Message);
     }
 
     [Fact]
@@ -1744,25 +1743,14 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
     private class GenericFilter_Cat : GenericFilter_Animal<int>;
     private class GenericFilter_Dog : GenericFilter_Animal<string>;
 
-    [Fact]
-    public void ClosedDerived_FilterByInstantiation_OnlyAssignableSurvives()
+    [Theory]
+    [InlineData(typeof(GenericFilter_Animal<int>))]
+    [InlineData(typeof(GenericFilter_Animal<string>))]
+    [InlineData(typeof(GenericFilter_Animal<bool>))]
+    public void ClosedDerived_TargetingDifferentBaseInstantiation_ThrowsInvalidOperationException(Type baseType)
     {
-        // Animal<int>: Cat applies, Dog (declared against Animal<string>) is silently filtered.
-        ITypeShape catShape = Provider.GetTypeShape(typeof(GenericFilter_Animal<int>))!;
-        var catUnion = Assert.IsAssignableFrom<IUnionTypeShape>(catShape);
-        IUnionCaseShape onlyCase = Assert.Single(catUnion.UnionCases);
-        Assert.Equal(typeof(GenericFilter_Cat), onlyCase.UnionCaseType.Type);
-
-        // Animal<string>: Dog applies, Cat is silently filtered.
-        ITypeShape dogShape = Provider.GetTypeShape(typeof(GenericFilter_Animal<string>))!;
-        var dogUnion = Assert.IsAssignableFrom<IUnionTypeShape>(dogShape);
-        IUnionCaseShape onlyDog = Assert.Single(dogUnion.UnionCases);
-        Assert.Equal(typeof(GenericFilter_Dog), onlyDog.UnionCaseType.Type);
-
-        // Animal<bool>: neither applies. Empty union.
-        ITypeShape boolShape = Provider.GetTypeShape(typeof(GenericFilter_Animal<bool>))!;
-        var boolUnion = Assert.IsAssignableFrom<IUnionTypeShape>(boolShape);
-        Assert.Empty(boolUnion.UnionCases);
+        var ex = Assert.Throws<InvalidOperationException>(() => Provider.GetTypeShape(baseType));
+        Assert.Contains("not a valid subtype", ex.Message);
     }
 
     [DerivedTypeShape(typeof(OpenGenericFilter_Derived<>))]
@@ -1771,17 +1759,20 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
         where T : System.Collections.Generic.IEnumerable<int>;
 
     [Fact]
-    public void OpenGenericDerived_ConstraintFilter_AppliesPerInstantiation()
+    public void OpenGenericDerived_InterfaceConstraintCompatibleSpecialization_Resolves()
     {
-        // Base<List<int>>: List<int> : IEnumerable<int>. Constraint satisfied → resolved.
-        ITypeShape okShape = Provider.GetTypeShape(typeof(OpenGenericFilter_Base<List<int>>))!;
-        var okUnion = Assert.IsAssignableFrom<IUnionTypeShape>(okShape);
-        Assert.Contains(okUnion.UnionCases, c => c.UnionCaseType.Type == typeof(OpenGenericFilter_Derived<List<int>>));
+        ITypeShape shape = Provider.GetTypeShape(typeof(OpenGenericFilter_Base<List<int>>))!;
+        var union = Assert.IsAssignableFrom<IUnionTypeShape>(shape);
+        Assert.Contains(union.UnionCases, c => c.UnionCaseType.Type == typeof(OpenGenericFilter_Derived<List<int>>));
+    }
 
-        // Base<string>: string does not implement IEnumerable<int>. Silently filtered.
-        ITypeShape badShape = Provider.GetTypeShape(typeof(OpenGenericFilter_Base<string>))!;
-        var badUnion = Assert.IsAssignableFrom<IUnionTypeShape>(badShape);
-        Assert.Empty(badUnion.UnionCases);
+    [Fact]
+    public void OpenGenericDerived_InterfaceConstraintIncompatibleSpecialization_ThrowsInvalidOperationException()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => Provider.GetTypeShape(typeof(OpenGenericFilter_Base<string>)));
+
+        Assert.Contains("generic constraints", ex.Message);
     }
 
     [DerivedTypeShape(typeof(MultiClosedDerived_A))]
@@ -1790,20 +1781,13 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
     private class MultiClosedDerived_A : MultiClosedFilter_Base<int>;
     private class MultiClosedDerived_B<T> : MultiClosedFilter_Base<T> where T : class;
 
-    [Fact]
-    public void MixedClosedAndOpenDerived_FilterRespectsInstantiation()
+    [Theory]
+    [InlineData(typeof(MultiClosedFilter_Base<int>))]
+    [InlineData(typeof(MultiClosedFilter_Base<string>))]
+    [InlineData(typeof(MultiClosedFilter_Base<bool>))]
+    public void MixedClosedAndOpenDerived_InvalidRegistrationInvalidatesConfiguration(Type baseType)
     {
-        // Base<int>: A applies (closed-instance match). B<int> would violate `class` constraint → filtered.
-        ITypeShape intShape = Provider.GetTypeShape(typeof(MultiClosedFilter_Base<int>))!;
-        var intUnion = Assert.IsAssignableFrom<IUnionTypeShape>(intShape);
-        IUnionCaseShape intOnly = Assert.Single(intUnion.UnionCases);
-        Assert.Equal(typeof(MultiClosedDerived_A), intOnly.UnionCaseType.Type);
-
-        // Base<string>: A targets Base<int> → filtered. B<string> satisfies `class` → resolved.
-        ITypeShape strShape = Provider.GetTypeShape(typeof(MultiClosedFilter_Base<string>))!;
-        var strUnion = Assert.IsAssignableFrom<IUnionTypeShape>(strShape);
-        IUnionCaseShape strOnly = Assert.Single(strUnion.UnionCases);
-        Assert.Equal(typeof(MultiClosedDerived_B<string>), strOnly.UnionCaseType.Type);
+        Assert.Throws<InvalidOperationException>(() => Provider.GetTypeShape(baseType));
     }
 
     [DerivedTypeShape(typeof(UnrelatedDerivedType))]
@@ -1816,6 +1800,44 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
         // Hard error preserved: derived has no inheritance relation to the base at all.
         var ex = Assert.Throws<InvalidOperationException>(() => Provider.GetTypeShape(typeof(TotallyUnrelatedBase)));
         Assert.Contains("UnrelatedDerivedType", ex.Message);
+    }
+
+    private class OpenGenericNoDefaultConstructorArgument(int value)
+    {
+        public int Value { get; } = value;
+    }
+
+    [Theory]
+    [MemberData(nameof(GetOpenGenericResolutionFailureCases))]
+    public void OpenGenericDerivedType_InvalidSpecialization_ThrowsInvalidOperationException(Type baseType, string expectedMessage)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => Provider.GetTypeShape(baseType));
+        Assert.Contains(expectedMessage, ex.Message);
+    }
+
+    public static IEnumerable<object[]> GetOpenGenericResolutionFailureCases()
+    {
+        yield return [typeof(OpenGenericRepeatedBase<int, string>), "arguments do not match"];
+        yield return [typeof(OpenGenericPartialBase<string, string>), "arguments do not match"];
+        yield return [typeof(OpenGenericInterfaceConstraintBase<List<string>>), "generic constraints"];
+        yield return [typeof(OpenGenericNewConstraintBase<OpenGenericNoDefaultConstructorArgument>), "generic constraints"];
+        yield return [typeof(OpenGenericDeepJaggedBase<List<int[][]>>), "arguments do not match"];
+    }
+
+    [DerivedTypeShape(typeof(OpenGenericNameCollisionDerived<>), Name = "derived")]
+    [DerivedTypeShape(typeof(OpenGenericNameCollisionDerived<,>), Name = "derived")]
+    private class OpenGenericNameCollisionBase<T1, T2>;
+
+    private class OpenGenericNameCollisionDerived<T> : OpenGenericNameCollisionBase<T, T>;
+    private class OpenGenericNameCollisionDerived<T1, T2> : OpenGenericNameCollisionBase<T1, T2>;
+
+    [Fact]
+    public void OpenGenericDerivedType_SameNameDifferentArities_ThrowsOnNameCollision()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => Provider.GetTypeShape(typeof(OpenGenericNameCollisionBase<int, int>)));
+
+        Assert.Contains("duplicate assignments for the name 'derived'", ex.Message);
     }
 
     [Theory]
@@ -1835,6 +1857,10 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
         yield return new object[] { typeof(OpenGenericArrayBase<int[]>), typeof(OpenGenericArrayDerived<int>) };
         yield return new object[] { typeof(IOpenGenericInterfaceBase<int>), typeof(OpenGenericInterfaceImpl<int>) };
         yield return new object[] { typeof(OpenGenericMultiLevelBase<List<int>>), typeof(OpenGenericMultiLevelLeaf<int>) };
+        yield return new object[] { typeof(OpenGenericRepeatedBase<int, int>), typeof(OpenGenericRepeatedDerived<int>) };
+        yield return new object[] { typeof(OpenGenericInterfaceConstraintBase<List<int>>), typeof(OpenGenericInterfaceConstraintDerived<List<int>>) };
+        yield return new object[] { typeof(OpenGenericNewConstraintBase<OpenGenericNewConstraintArgument>), typeof(OpenGenericNewConstraintDerived<OpenGenericNewConstraintArgument>) };
+        yield return new object[] { typeof(OpenGenericDeepJaggedBase<List<int[][][]>>), typeof(OpenGenericDeepJaggedDerived<int>) };
     }
 
     [Fact]

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -1737,54 +1737,54 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
         Assert.Contains(union.UnionCases, c => c.UnionCaseType.Type == typeof(OpenGenericPolymorphicClassConstraintViolationDerived<int>));
     }
 
-    [DerivedTypeShape(typeof(GenericFilter_Cat))]
-    [DerivedTypeShape(typeof(GenericFilter_Dog))]
-    private class GenericFilter_Animal<T>;
-    private class GenericFilter_Cat : GenericFilter_Animal<int>;
-    private class GenericFilter_Dog : GenericFilter_Animal<string>;
+    [DerivedTypeShape(typeof(GenericSpecialization_Cat))]
+    [DerivedTypeShape(typeof(GenericSpecialization_Dog))]
+    private class GenericSpecialization_Animal<T>;
+    private class GenericSpecialization_Cat : GenericSpecialization_Animal<int>;
+    private class GenericSpecialization_Dog : GenericSpecialization_Animal<string>;
 
     [Theory]
-    [InlineData(typeof(GenericFilter_Animal<int>))]
-    [InlineData(typeof(GenericFilter_Animal<string>))]
-    [InlineData(typeof(GenericFilter_Animal<bool>))]
+    [InlineData(typeof(GenericSpecialization_Animal<int>))]
+    [InlineData(typeof(GenericSpecialization_Animal<string>))]
+    [InlineData(typeof(GenericSpecialization_Animal<bool>))]
     public void ClosedDerived_TargetingDifferentBaseInstantiation_ThrowsInvalidOperationException(Type baseType)
     {
         var ex = Assert.Throws<InvalidOperationException>(() => Provider.GetTypeShape(baseType));
         Assert.Contains("not a valid subtype", ex.Message);
     }
 
-    [DerivedTypeShape(typeof(OpenGenericFilter_Derived<>))]
-    private class OpenGenericFilter_Base<T>;
-    private class OpenGenericFilter_Derived<T> : OpenGenericFilter_Base<T>
+    [DerivedTypeShape(typeof(OpenGenericConstraint_Derived<>))]
+    private class OpenGenericConstraint_Base<T>;
+    private class OpenGenericConstraint_Derived<T> : OpenGenericConstraint_Base<T>
         where T : System.Collections.Generic.IEnumerable<int>;
 
     [Fact]
     public void OpenGenericDerived_InterfaceConstraintCompatibleSpecialization_Resolves()
     {
-        ITypeShape shape = Provider.GetTypeShape(typeof(OpenGenericFilter_Base<List<int>>))!;
+        ITypeShape shape = Provider.GetTypeShape(typeof(OpenGenericConstraint_Base<List<int>>))!;
         var union = Assert.IsAssignableFrom<IUnionTypeShape>(shape);
-        Assert.Contains(union.UnionCases, c => c.UnionCaseType.Type == typeof(OpenGenericFilter_Derived<List<int>>));
+        Assert.Contains(union.UnionCases, c => c.UnionCaseType.Type == typeof(OpenGenericConstraint_Derived<List<int>>));
     }
 
     [Fact]
     public void OpenGenericDerived_InterfaceConstraintIncompatibleSpecialization_ThrowsInvalidOperationException()
     {
         var ex = Assert.Throws<InvalidOperationException>(
-            () => Provider.GetTypeShape(typeof(OpenGenericFilter_Base<string>)));
+            () => Provider.GetTypeShape(typeof(OpenGenericConstraint_Base<string>)));
 
         Assert.Contains("generic constraints", ex.Message);
     }
 
     [DerivedTypeShape(typeof(MultiClosedDerived_A))]
     [DerivedTypeShape(typeof(MultiClosedDerived_B<>))]
-    private class MultiClosedFilter_Base<T>;
-    private class MultiClosedDerived_A : MultiClosedFilter_Base<int>;
-    private class MultiClosedDerived_B<T> : MultiClosedFilter_Base<T> where T : class;
+    private class MixedSpecialization_Base<T>;
+    private class MultiClosedDerived_A : MixedSpecialization_Base<int>;
+    private class MultiClosedDerived_B<T> : MixedSpecialization_Base<T> where T : class;
 
     [Theory]
-    [InlineData(typeof(MultiClosedFilter_Base<int>))]
-    [InlineData(typeof(MultiClosedFilter_Base<string>))]
-    [InlineData(typeof(MultiClosedFilter_Base<bool>))]
+    [InlineData(typeof(MixedSpecialization_Base<int>))]
+    [InlineData(typeof(MixedSpecialization_Base<string>))]
+    [InlineData(typeof(MixedSpecialization_Base<bool>))]
     public void MixedClosedAndOpenDerived_InvalidRegistrationInvalidatesConfiguration(Type baseType)
     {
         Assert.Throws<InvalidOperationException>(() => Provider.GetTypeShape(baseType));
@@ -1840,6 +1840,15 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
         Assert.Contains("duplicate assignments for the name 'derived'", ex.Message);
     }
 
+    [Fact]
+    public void OpenGenericDerivedType_DefaultNameUsesDeclaredType()
+    {
+        ITypeShape shape = Provider.GetTypeShape(typeof(OpenGenericDefaultNameBase<int>))!;
+        var union = Assert.IsAssignableFrom<IUnionTypeShape>(shape);
+        IUnionCaseShape unionCase = Assert.Single(union.UnionCases);
+        Assert.Equal("OpenGenericDefaultNameDerived_T", unionCase.Name);
+    }
+
     [Theory]
     [MemberData(nameof(GetOpenGenericResolutionSuccessCases))]
     public void OpenGenericDerivedType_SupportedPatterns_ResolvesToExpectedClosedType(Type baseType, Type expectedClosedDerived)
@@ -1856,9 +1865,13 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
         yield return new object[] { typeof(OpenGenericWrappedBase<List<string>>), typeof(OpenGenericWrappedDerived<string>) };
         yield return new object[] { typeof(OpenGenericArrayBase<int[]>), typeof(OpenGenericArrayDerived<int>) };
         yield return new object[] { typeof(IOpenGenericInterfaceBase<int>), typeof(OpenGenericInterfaceImpl<int>) };
+        yield return new object[] { typeof(OpenGenericNestedBase<(string, int)>), typeof(OpenGenericOuter<string>.Middle.Leaf<int>) };
+        yield return new object[] { typeof(IOpenGenericHierarchyBase<int>), typeof(OpenGenericHierarchyImpl<int>) };
+        yield return new object[] { typeof(IOpenGenericMultipleInterfaceBase<int>), typeof(OpenGenericMultipleInterfaceImpl<int>) };
         yield return new object[] { typeof(OpenGenericMultiLevelBase<List<int>>), typeof(OpenGenericMultiLevelLeaf<int>) };
         yield return new object[] { typeof(OpenGenericRepeatedBase<int, int>), typeof(OpenGenericRepeatedDerived<int>) };
         yield return new object[] { typeof(OpenGenericInterfaceConstraintBase<List<int>>), typeof(OpenGenericInterfaceConstraintDerived<List<int>>) };
+        yield return new object[] { typeof(OpenGenericCovariantConstraintBase<List<string>>), typeof(OpenGenericCovariantConstraintDerived<List<string>>) };
         yield return new object[] { typeof(OpenGenericNewConstraintBase<OpenGenericNewConstraintArgument>), typeof(OpenGenericNewConstraintDerived<OpenGenericNewConstraintArgument>) };
         yield return new object[] { typeof(OpenGenericDeepJaggedBase<List<int[][][]>>), typeof(OpenGenericDeepJaggedDerived<int>) };
     }

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -1683,7 +1683,6 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
     [InlineData(typeof(GenericPolymorphicClassWithMismatchingGenericDerivedType<int>), "Derived")]
     [InlineData(typeof(OpenGenericPolymorphicClassUnboundParameter<int>), "Derived")]
     [InlineData(typeof(OpenGenericPolymorphicClassAmbiguousMatch<List<int>>), "Impl")]
-    [InlineData(typeof(OpenGenericPolymorphicClassConstraintViolation<string>), "Derived")]
     public void PolymorphicClassWithGenericDerivedType_ThrowsInvalidOperationException(Type type, string derivedTypeName)
     {
         var ex = Assert.Throws<InvalidOperationException>(() => Provider.GetTypeShape(type));
@@ -1719,6 +1718,105 @@ public sealed class TypeShapeProviderTests_ReflectionEmit() : TypeShapeProviderT
 
     private class OpenGenericPolymorphicClassConstraintViolationDerived<T> : OpenGenericPolymorphicClassConstraintViolation<T>
         where T : struct;
+
+    [Fact]
+    public void OpenGenericDerivedType_ConstraintViolation_SilentlyFiltered()
+    {
+        // T = string violates `where T : struct` -- the registration cannot apply to
+        // OpenGenericPolymorphicClassConstraintViolation<string> so it is silently filtered.
+        ITypeShape shape = Provider.GetTypeShape(typeof(OpenGenericPolymorphicClassConstraintViolation<string>))!;
+        var union = Assert.IsAssignableFrom<IUnionTypeShape>(shape);
+        Assert.Empty(union.UnionCases);
+    }
+
+    [Fact]
+    public void OpenGenericDerivedType_ConstraintSatisfied_Resolved()
+    {
+        // T = int satisfies `where T : struct` so the registration applies.
+        ITypeShape shape = Provider.GetTypeShape(typeof(OpenGenericPolymorphicClassConstraintViolation<int>))!;
+        var union = Assert.IsAssignableFrom<IUnionTypeShape>(shape);
+        Assert.Contains(union.UnionCases, c => c.UnionCaseType.Type == typeof(OpenGenericPolymorphicClassConstraintViolationDerived<int>));
+    }
+
+    [DerivedTypeShape(typeof(GenericFilter_Cat))]
+    [DerivedTypeShape(typeof(GenericFilter_Dog))]
+    private class GenericFilter_Animal<T>;
+    private class GenericFilter_Cat : GenericFilter_Animal<int>;
+    private class GenericFilter_Dog : GenericFilter_Animal<string>;
+
+    [Fact]
+    public void ClosedDerived_FilterByInstantiation_OnlyAssignableSurvives()
+    {
+        // Animal<int>: Cat applies, Dog (declared against Animal<string>) is silently filtered.
+        ITypeShape catShape = Provider.GetTypeShape(typeof(GenericFilter_Animal<int>))!;
+        var catUnion = Assert.IsAssignableFrom<IUnionTypeShape>(catShape);
+        IUnionCaseShape onlyCase = Assert.Single(catUnion.UnionCases);
+        Assert.Equal(typeof(GenericFilter_Cat), onlyCase.UnionCaseType.Type);
+
+        // Animal<string>: Dog applies, Cat is silently filtered.
+        ITypeShape dogShape = Provider.GetTypeShape(typeof(GenericFilter_Animal<string>))!;
+        var dogUnion = Assert.IsAssignableFrom<IUnionTypeShape>(dogShape);
+        IUnionCaseShape onlyDog = Assert.Single(dogUnion.UnionCases);
+        Assert.Equal(typeof(GenericFilter_Dog), onlyDog.UnionCaseType.Type);
+
+        // Animal<bool>: neither applies. Empty union.
+        ITypeShape boolShape = Provider.GetTypeShape(typeof(GenericFilter_Animal<bool>))!;
+        var boolUnion = Assert.IsAssignableFrom<IUnionTypeShape>(boolShape);
+        Assert.Empty(boolUnion.UnionCases);
+    }
+
+    [DerivedTypeShape(typeof(OpenGenericFilter_Derived<>))]
+    private class OpenGenericFilter_Base<T>;
+    private class OpenGenericFilter_Derived<T> : OpenGenericFilter_Base<T>
+        where T : System.Collections.Generic.IEnumerable<int>;
+
+    [Fact]
+    public void OpenGenericDerived_ConstraintFilter_AppliesPerInstantiation()
+    {
+        // Base<List<int>>: List<int> : IEnumerable<int>. Constraint satisfied → resolved.
+        ITypeShape okShape = Provider.GetTypeShape(typeof(OpenGenericFilter_Base<List<int>>))!;
+        var okUnion = Assert.IsAssignableFrom<IUnionTypeShape>(okShape);
+        Assert.Contains(okUnion.UnionCases, c => c.UnionCaseType.Type == typeof(OpenGenericFilter_Derived<List<int>>));
+
+        // Base<string>: string does not implement IEnumerable<int>. Silently filtered.
+        ITypeShape badShape = Provider.GetTypeShape(typeof(OpenGenericFilter_Base<string>))!;
+        var badUnion = Assert.IsAssignableFrom<IUnionTypeShape>(badShape);
+        Assert.Empty(badUnion.UnionCases);
+    }
+
+    [DerivedTypeShape(typeof(MultiClosedDerived_A))]
+    [DerivedTypeShape(typeof(MultiClosedDerived_B<>))]
+    private class MultiClosedFilter_Base<T>;
+    private class MultiClosedDerived_A : MultiClosedFilter_Base<int>;
+    private class MultiClosedDerived_B<T> : MultiClosedFilter_Base<T> where T : class;
+
+    [Fact]
+    public void MixedClosedAndOpenDerived_FilterRespectsInstantiation()
+    {
+        // Base<int>: A applies (closed-instance match). B<int> would violate `class` constraint → filtered.
+        ITypeShape intShape = Provider.GetTypeShape(typeof(MultiClosedFilter_Base<int>))!;
+        var intUnion = Assert.IsAssignableFrom<IUnionTypeShape>(intShape);
+        IUnionCaseShape intOnly = Assert.Single(intUnion.UnionCases);
+        Assert.Equal(typeof(MultiClosedDerived_A), intOnly.UnionCaseType.Type);
+
+        // Base<string>: A targets Base<int> → filtered. B<string> satisfies `class` → resolved.
+        ITypeShape strShape = Provider.GetTypeShape(typeof(MultiClosedFilter_Base<string>))!;
+        var strUnion = Assert.IsAssignableFrom<IUnionTypeShape>(strShape);
+        IUnionCaseShape strOnly = Assert.Single(strUnion.UnionCases);
+        Assert.Equal(typeof(MultiClosedDerived_B<string>), strOnly.UnionCaseType.Type);
+    }
+
+    [DerivedTypeShape(typeof(UnrelatedDerivedType))]
+    private class TotallyUnrelatedBase;
+    private class UnrelatedDerivedType;  // doesn't inherit from anything related
+
+    [Fact]
+    public void ClosedDerivedNotAssignable_NonGenericBase_StillThrows()
+    {
+        // Hard error preserved: derived has no inheritance relation to the base at all.
+        var ex = Assert.Throws<InvalidOperationException>(() => Provider.GetTypeShape(typeof(TotallyUnrelatedBase)));
+        Assert.Contains("UnrelatedDerivedType", ex.Message);
+    }
 
     [Theory]
     [MemberData(nameof(GetOpenGenericResolutionSuccessCases))]


### PR DESCRIPTION
Ports [dotnet/runtime#127318](https://github.com/dotnet/runtime/pull/127318) (open generics support in System.Text.Json `[JsonDerivedType]`) to PolyType's `[DerivedTypeShape]` polymorphism feature.

Previously the resolver only handled the identity-binding case (`Derived<T> : Base<T>`); it now performs structural unification of the derived's base specification against the closed base, mirroring STJ's algorithm in both the **source generator** and **reflection** providers.

## Supported patterns

1. **Identity binding** — `Derived<T> : Base<T>` against `Base<int>` → `Derived<int>`
2. **Reordered/remapped parameters** — `Derived<U, V> : Base<V, U>` against `Base<int, string>` → `Derived<string, int>`
3. **Partial concretization** — `Derived<T> : Base<T, int>` against `Base<bool, int>` → `Derived<bool>`
4. **Wrapped / nested type arguments** — `Derived<T> : Base<List<T>>` against `Base<List<int>>` → `Derived<int>`
5. **Interface bases** (with ambiguity detection across multiple matching instantiations)
6. **Multi-level / enclosing-type parameters** — substitution flows through intermediate generic ancestors

## Failure cases

The source generator emits `PT0013` (and the reflection provider throws `InvalidOperationException`) when:

* The derived type is not assignable to the base.
* The derived's base specification cannot be unified with the closed base.
* Derived parameters are left unbound by the resolved substitution.
* The unified substitution does not satisfy generic constraints on the derived type.
* The derived type matches more than one ancestor instantiation of the base.

## Test coverage

* 6 new test types in `PolyType.TestCases/TestTypes.cs` (one per pattern above), wired into the round-trip test enumeration.
* 7 new positive/negative source-gen diagnostic tests in `DiagnosticTests.cs` covering identity, reordered, partial, wrapped, interface, unbound, ambiguous, and constraint-violation scenarios.
* 6 reflection success cases + 3 new reflection failure cases in `TypeShapeProviderTests.cs`.
* Existing `PT0013` test updated to the richer diagnostic format.

All tests pass against net10.0/net9.0/net8.0 of the main test suite plus net9.0/net8.0 of the source-gen unit tests and net10.0 of the Roslyn tests.

## Documentation

Added a "Generic polymorphism" subsection to `docs/docs/shape-providers.md` enumerating supported patterns and failure modes.