### PR TITLE
Avoid representing the same required parameter twice

### DIFF
--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Object.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.Object.cs
@@ -359,26 +359,27 @@ public partial class TypeDataModelGenerator
                 property = property with { IsRequiredBySyntax = false };
             }
 
-            if (!property.IsRequiredBySyntax && MatchesConstructorParameter(property))
+            if (GetMatchingConstructorParameter(property) is not null && !property.IsRequiredBySyntax)
             {
-                // Deduplicate any optional properties whose signature matches a constructor parameter.
+                // Deduplicate properties whose signature matches a constructor parameter unless
+                // an object initializer slot is required to satisfy C# required members.
                 continue;
             }
 
             (memberInitializers ??= []).Add(property);
 
-            bool MatchesConstructorParameter(PropertyDataModel settableProperty)
+            IParameterSymbol? GetMatchingConstructorParameter(PropertyDataModel settableProperty)
             {
                 foreach (IParameterSymbol p in constructor.Parameters)
                 {
                     if (SymbolEqualityComparer.Default.Equals(p.Type, settableProperty.PropertyType) &&
                         CommonHelpers.CamelCaseInvariantComparer.Instance.Equals(p.Name, settableProperty.Name))
                     {
-                        return true;
+                        return p;
                     }
                 }
 
-                return false;
+                return null;
             }
         }
 

--- a/src/PolyType.SourceGenerator/Model/ConstructorShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/ConstructorShapeModel.cs
@@ -19,7 +19,7 @@ public sealed record ConstructorShapeModel
     public required bool IsFSharpUnitConstructor { get; init; }
     public required ImmutableEquatableArray<AttributeDataModel> Attributes { get; init; }
 
-    public int TotalArity => Parameters.Count(p => p.RefKind is not RefKind.Out) + RequiredMembers.Length + OptionalMembers.Length;
+    public int TotalArity => Parameters.Count(p => p.RefKind is not RefKind.Out) + RequiredMembers.Count(p => !p.IsObjectInitializerOnly) + OptionalMembers.Count(p => !p.IsObjectInitializerOnly);
     public bool IsStaticFactory => StaticFactoryName != null;
     public bool HasOutParameters => Parameters.Any(p => p.RefKind is RefKind.Out);
 
@@ -34,11 +34,17 @@ public sealed record ConstructorShapeModel
         }
         foreach (var member in RequiredMembers)
         {
-            yield return member;
+            if (!member.IsObjectInitializerOnly)
+            {
+                yield return member;
+            }
         }
         foreach (var member in OptionalMembers)
         {
-            yield return member;
+            if (!member.IsObjectInitializerOnly)
+            {
+                yield return member;
+            }
         }
     }
 }

--- a/src/PolyType.SourceGenerator/Model/ParameterShapeModel.cs
+++ b/src/PolyType.SourceGenerator/Model/ParameterShapeModel.cs
@@ -12,6 +12,7 @@ public sealed record ParameterShapeModel
     public required ParameterKind Kind { get; init; }
     public required RefKind RefKind { get; init; }
     public required int Position { get; init; }
+    public required bool IsObjectInitializerOnly { get; init; }
     public required bool IsRequired { get; init; }
     public required bool IsInitOnlyProperty { get; init; }
     public required bool IsNonNullable { get; init; }

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -454,7 +454,12 @@ public sealed partial class Parser
 
     private ConstructorShapeModel MapConstructor(ObjectDataModel objectModel, TypeId declaringTypeId, ConstructorDataModel constructor, bool isFSharpUnionCase)
     {
-        int position = constructor.Parameters.Length;
+        var mappedParameters = MapParametersWithOutDiscards(
+            constructor.Constructor.Parameters,
+            constructor.Parameters,
+            p => MapParameter(objectModel, declaringTypeId, p, isFSharpUnionCase, constructor.Constructor.HasSetsRequiredMembersAttribute()));
+
+        int position = mappedParameters.Count(p => p.RefKind is not RefKind.Out);
         List<ParameterShapeModel>? requiredMembers = null;
         List<ParameterShapeModel>? optionalMembers = null;
 
@@ -468,6 +473,7 @@ public sealed partial class Parser
 
         foreach (PropertyDataModel propertyModel in memberInitializers)
         {
+            int? objectInitializerParameterPosition = GetMatchingConstructorParameterPosition(propertyModel);
             var memberInitializer = new ParameterShapeModel
             {
                 ParameterType = CreateTypeId(propertyModel.PropertyType),
@@ -477,7 +483,8 @@ public sealed partial class Parser
 
                 Name = propertyModel.LogicalName ?? propertyModel.Name,
                 UnderlyingMemberName = propertyModel.Name,
-                Position = position++,
+                Position = objectInitializerParameterPosition ?? position++,
+                IsObjectInitializerOnly = objectInitializerParameterPosition.HasValue,
                 IsRequired = propertyModel.IsRequiredByPolicy ?? propertyModel.IsRequiredBySyntax,
                 IsAccessible = propertyModel.IsSetterAccessible,
                 CanUseUnsafeAccessors = _knownSymbols.TargetFramework switch
@@ -509,12 +516,34 @@ public sealed partial class Parser
                 // Member can be set optionally post construction
                 (optionalMembers ??= []).Add(memberInitializer);
             }
-        }
 
-        var mappedParameters = MapParametersWithOutDiscards(
-            constructor.Constructor.Parameters,
-            constructor.Parameters,
-            p => MapParameter(objectModel, declaringTypeId, p, isFSharpUnionCase));
+            int? GetMatchingConstructorParameterPosition(PropertyDataModel property)
+            {
+                if (!property.IsRequiredBySyntax)
+                {
+                    return null;
+                }
+
+                int parameterPosition = 0;
+                foreach (IParameterSymbol parameter in constructor.Constructor.Parameters)
+                {
+                    if (parameter.RefKind is RefKind.Out)
+                    {
+                        continue;
+                    }
+
+                    if (SymbolEqualityComparer.Default.Equals(parameter.Type, property.PropertyType) &&
+                        CommonHelpers.CamelCaseInvariantComparer.Instance.Equals(parameter.Name, property.Name))
+                    {
+                        return parameterPosition;
+                    }
+
+                    parameterPosition++;
+                }
+
+                return null;
+            }
+        }
 
         return new ConstructorShapeModel
         {
@@ -525,7 +554,7 @@ public sealed partial class Parser
             Parameters = mappedParameters,
             RequiredMembers = requiredMembers?.ToImmutableEquatableArray() ?? [],
             OptionalMembers = optionalMembers?.ToImmutableEquatableArray() ?? [],
-            ArgumentStateType = (constructor.Parameters.Length + (requiredMembers?.Count ?? 0) + (optionalMembers?.Count ?? 0)) switch
+            ArgumentStateType = (mappedParameters.Count(p => p.RefKind is not RefKind.Out) + (requiredMembers?.Count(p => !p.IsObjectInitializerOnly) ?? 0) + (optionalMembers?.Count(p => !p.IsObjectInitializerOnly) ?? 0)) switch
             {
                 0 => ArgumentStateType.EmptyArgumentState,
                 <= 64 => ArgumentStateType.SmallArgumentState,
@@ -638,6 +667,7 @@ public sealed partial class Parser
                     DeclaringType = CreateTypeId(symbol.ContainingType),
                     Kind = ParameterKind.MethodParameter,
                     RefKind = RefKind.Out,
+                    IsObjectInitializerOnly = false,
                     IsRequired = false,
                     IsAccessible = true,
                     CanUseUnsafeAccessors = false,
@@ -688,15 +718,42 @@ public sealed partial class Parser
             .ToImmutableEquatableArray();
     }
 
-    private ParameterShapeModel MapParameter(ObjectDataModel? declaringObjectForConstructor, TypeId declaringTypeId, ParameterDataModel parameter, bool isFSharpUnionCase)
+    private ParameterShapeModel MapParameter(
+        ObjectDataModel? declaringObjectForConstructor,
+        TypeId declaringTypeId,
+        ParameterDataModel parameter,
+        bool isFSharpUnionCase,
+        bool constructorSetsRequiredMembers = false)
     {
         string name = parameter.Parameter.Name;
         bool isRequired = !parameter.HasDefaultValue;
+        PropertyDataModel? matchingProperty = null;
+
+        if (declaringObjectForConstructor is not null)
+        {
+            foreach (PropertyDataModel property in declaringObjectForConstructor.Properties)
+            {
+                if (SymbolEqualityComparer.Default.Equals(property.PropertyType, parameter.Parameter.Type) &&
+                    CommonHelpers.CamelCaseInvariantComparer.Instance.Equals(parameter.Parameter.Name, property.Name))
+                {
+                    matchingProperty = property;
+                    break;
+                }
+            }
+        }
 
         AttributeData? parameterAttr = parameter.Parameter.GetAttribute(_knownSymbols.ParameterShapeAttribute);
         if (parameterAttr?.TryGetNamedArgument("IsRequired", out bool? isRequiredValue) is true && isRequiredValue is not null)
         {
             isRequired = isRequiredValue.Value;
+        }
+        else if (matchingProperty?.IsRequiredByPolicy is bool isRequiredByPolicy)
+        {
+            isRequired = isRequiredByPolicy;
+        }
+        else if (!parameter.HasDefaultValue && !constructorSetsRequiredMembers && matchingProperty?.IsRequiredBySyntax is true)
+        {
+            isRequired = true;
         }
 
         if (parameterAttr != null &&
@@ -713,16 +770,10 @@ public sealed partial class Parser
         }
         else if (declaringObjectForConstructor is not null)
         {
-            foreach (PropertyDataModel property in declaringObjectForConstructor.Properties)
+            if (matchingProperty is { } property)
             {
-                // Match property names to parameters up to Pascal/camel case conversion.
-                if (SymbolEqualityComparer.Default.Equals(property.PropertyType, parameter.Parameter.Type) &&
-                    CommonHelpers.CamelCaseInvariantComparer.Instance.Equals(parameter.Parameter.Name, property.Name))
-                {
-                    // We have a matching property, use its name in the parameter.
-                    name = property.LogicalName ?? property.Name;
-                    break;
-                }
+                // We have a matching property, use its name in the parameter.
+                name = property.LogicalName ?? property.Name;
             }
         }
 
@@ -736,6 +787,7 @@ public sealed partial class Parser
             Kind = ParameterKind.MethodParameter,
             RefKind = parameter.Parameter.RefKind,
             IsRequired = isRequired,
+            IsObjectInitializerOnly = false,
             IsAccessible = true,
             CanUseUnsafeAccessors = false,
             IsInitOnlyProperty = false,
@@ -772,6 +824,7 @@ public sealed partial class Parser
                     ParameterType = CreateTypeId(argType),
                     Kind = ParameterKind.MethodParameter,
                     RefKind = RefKind.None,
+                    IsObjectInitializerOnly = false,
                     IsRequired = true,
                     IsAccessible = true,
                     CanUseUnsafeAccessors = false,
@@ -834,6 +887,7 @@ public sealed partial class Parser
                 Kind = ParameterKind.MethodParameter,
                 RefKind = RefKind.None,
                 IsRequired = true,
+                IsObjectInitializerOnly = false,
                 IsAccessible = true,
                 CanUseUnsafeAccessors = false,
                 IsInitOnlyProperty = false,

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Constructors.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Constructors.cs
@@ -171,7 +171,7 @@ internal sealed partial class SourceFormatter
                     _ when !constructor.HasOutParameters && shapedParamCount == 0 && constructor.StaticFactoryIsProperty => castPrefix + constructorName,
                     _ when !constructor.HasOutParameters && shapedParamCount == 0 && memberInitializerBlock is null => $"{castPrefix}{constructorName}()",
                     _ when !constructor.HasOutParameters && shapedParamCount == 0 => $"{castPrefix}{constructorName}{memberInitializerBlock}",
-                    _ when !constructor.HasOutParameters && shapedParamCount == 1 && constructor.TotalArity == 1 => $"{castPrefix}{constructorName}({FormatCtorParameterExpr(constructor.ShapedParameters.First(), isSingleParameter: true)})",
+                    _ when !constructor.HasOutParameters && shapedParamCount == 1 && constructor.TotalArity == 1 && memberInitializerBlock is null => $"{castPrefix}{constructorName}({FormatCtorParameterExpr(constructor.ShapedParameters.First(), isSingleParameter: true)})",
                     _ => $"{castPrefix}{constructorName}({FormatCtorArgumentsBody()}){memberInitializerBlock}",
                 };
 
@@ -304,7 +304,9 @@ internal sealed partial class SourceFormatter
         writer.WriteLine('{');
         writer.Indentation++;
 
-        var allParams = constructor.ShapedParameters.Concat(constructor.RequiredMembers).Concat(constructor.OptionalMembers);
+        var allParams = constructor.ShapedParameters
+            .Concat(constructor.RequiredMembers.Where(p => !p.IsObjectInitializerOnly))
+            .Concat(constructor.OptionalMembers.Where(p => !p.IsObjectInitializerOnly));
 
         int i = 0;
         foreach (ParameterShapeModel parameter in allParams)

--- a/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
@@ -163,6 +163,7 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
                 .FirstOrDefault();
         }
 
+        bool setsRequiredMembers = constructorInfo.SetsRequiredMembers();
         var parameterShapeInfos = new MethodParameterShapeInfo[parameters.Length];
         int i = 0;
 
@@ -189,12 +190,14 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
                 logicalName = matchingMember.LogicalName ?? matchingMember.BaseMemberInfo.Name;
             }
 
-            bool? isRequired = parameterShapeAttribute?.IsRequiredSpecified is true ? parameterShapeAttribute.IsRequired : null;
+            bool? isRequired = parameterShapeAttribute?.IsRequiredSpecified is true
+                ? parameterShapeAttribute.IsRequired
+                : matchingMember?.IsRequiredByAttribute ??
+                    (!parameter.HasDefaultValue && !setsRequiredMembers && matchingMember?.BaseMemberInfo.IsRequired() is true ? true : null);
 
             parameterShapeInfos[i++] = new(parameter, isNonNullable, matchingMember?.BaseMemberInfo, logicalName, isRequired);
         }
 
-        bool setsRequiredMembers = constructorInfo.SetsRequiredMembers();
         settableMembers = GetSettableMembers(allMembers, setsRequiredMembers);
         List<MemberInitializerShapeInfo>? memberInitializers = null;
 
@@ -205,7 +208,8 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
             // members in the shape signature.
             foreach (MemberInitializerShapeInfo memberInitializer in settableMembers)
             {
-                if (!memberInitializer.IsRequired && parameterShapeInfos.Any(p => p.MatchingMember == memberInitializer.MemberInfo))
+                MethodParameterShapeInfo? matchingParameter = parameterShapeInfos.FirstOrDefault(p => p.MatchingMember == memberInitializer.MemberInfo);
+                if (matchingParameter is not null)
                 {
                     // Deduplicate any properties whose signature matches a constructor parameter.
                     continue;

--- a/tests/PolyType.Tests/IsRequiredTests.cs
+++ b/tests/PolyType.Tests/IsRequiredTests.cs
@@ -161,10 +161,10 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
         var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasNonDefaultConstructorWithDefaultAndRequiredProperty));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
-        var parameter = shape.Constructor.Parameters.Single(p => p.Name == nameof(HasNonDefaultConstructorWithDefaultAndRequiredProperty.MyProperty) && p.Kind == ParameterKind.MethodParameter);
-        var member = shape.Constructor.Parameters.Single(p => p.Name == nameof(HasNonDefaultConstructorWithDefaultAndRequiredProperty.MyProperty) && p.Kind == ParameterKind.MemberInitializer);
+        IParameterShape parameter = Assert.Single(shape.Constructor.Parameters, p => p.Name == nameof(HasNonDefaultConstructorWithDefaultAndRequiredProperty.MyProperty));
+        Assert.Equal(ParameterKind.MethodParameter, parameter.Kind);
         Assert.False(parameter.IsRequired);
-        Assert.True(member.IsRequired);
+        Assert.True(parameter.HasDefaultValue);
     }
 
     [GenerateShape]
@@ -176,6 +176,139 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
         }
 
         public required int MyProperty { get; set; }
+    }
+
+    [Fact]
+    public void RequiredPropertyAndRequiredConstructorParameter()
+    {
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasRequiredPropertyAndRequiredConstructorParameter));
+        Assert.NotNull(shape);
+        Assert.NotNull(shape.Constructor);
+
+        Assert.Equal(1, shape.Constructor.Parameters.Count(p => p.Name == nameof(HasRequiredPropertyAndRequiredConstructorParameter.RequiredString)));
+        Assert.Contains(shape.Constructor.Parameters, p =>
+            p.Name == nameof(HasRequiredPropertyAndRequiredConstructorParameter.RequiredString) &&
+            p.Kind == ParameterKind.MethodParameter &&
+            p.IsRequired);
+    }
+
+    [GenerateShape]
+    public partial class HasRequiredPropertyAndRequiredConstructorParameter
+    {
+        public HasRequiredPropertyAndRequiredConstructorParameter(string requiredString)
+        {
+            RequiredString = requiredString;
+        }
+
+        public required string RequiredString { get; set; }
+    }
+
+    [Theory]
+    [MemberData(nameof(GetConstructorParameterRequirednessCases))]
+    public void ConstructorParameterRequirednessMatrix(Type type, string parameterName, bool isRequired, bool hasDefaultValue)
+    {
+        IObjectTypeShape shape = Assert.IsAssignableFrom<IObjectTypeShape>(providerUnderTest.Provider.GetTypeShape(type));
+        Assert.NotNull(shape.Constructor);
+
+        IParameterShape parameter = Assert.Single(shape.Constructor.Parameters, p => p.Name == parameterName);
+        Assert.Equal(ParameterKind.MethodParameter, parameter.Kind);
+
+        if (isRequired)
+        {
+            Assert.True(parameter.IsRequired);
+        }
+        else
+        {
+            Assert.False(parameter.IsRequired);
+        }
+
+        if (hasDefaultValue)
+        {
+            Assert.True(parameter.HasDefaultValue);
+        }
+        else
+        {
+            Assert.False(parameter.HasDefaultValue);
+        }
+    }
+
+    public static TheoryData<Type, string, bool, bool> GetConstructorParameterRequirednessCases()
+        => new()
+        {
+            { typeof(OptionalPropertyWithRequiredParameter), nameof(OptionalPropertyWithRequiredParameter.Value), true, false },
+            { typeof(OptionalPropertyWithDefaultParameter), nameof(OptionalPropertyWithDefaultParameter.Value), false, true },
+            { typeof(RequiredPropertyWithRequiredParameter), nameof(RequiredPropertyWithRequiredParameter.Value), true, false },
+            { typeof(RequiredPropertyWithDefaultParameter), nameof(RequiredPropertyWithDefaultParameter.Value), false, true },
+            { typeof(PropertyShapeRequiredWithDefaultParameter), nameof(PropertyShapeRequiredWithDefaultParameter.Value), true, true },
+            { typeof(RequiredPropertyShapeFalseWithRequiredParameter), nameof(RequiredPropertyShapeFalseWithRequiredParameter.Value), false, false },
+        };
+
+    [GenerateShape]
+    public partial class OptionalPropertyWithRequiredParameter
+    {
+        public OptionalPropertyWithRequiredParameter(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; set; }
+    }
+
+    [GenerateShape]
+    public partial class OptionalPropertyWithDefaultParameter
+    {
+        public OptionalPropertyWithDefaultParameter(string? value = null)
+        {
+            Value = value;
+        }
+
+        public string? Value { get; set; }
+    }
+
+    [GenerateShape]
+    public partial class RequiredPropertyWithRequiredParameter
+    {
+        public RequiredPropertyWithRequiredParameter(string value)
+        {
+            Value = value;
+        }
+
+        public required string Value { get; set; }
+    }
+
+    [GenerateShape]
+    public partial class RequiredPropertyWithDefaultParameter
+    {
+        public RequiredPropertyWithDefaultParameter(string? value = null)
+        {
+            Value = value;
+        }
+
+        public required string? Value { get; set; }
+    }
+
+    [GenerateShape]
+    public partial class PropertyShapeRequiredWithDefaultParameter
+    {
+        public PropertyShapeRequiredWithDefaultParameter(string? value = null)
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = true)]
+        public string? Value { get; set; }
+    }
+
+    [GenerateShape]
+    public partial class RequiredPropertyShapeFalseWithRequiredParameter
+    {
+        public RequiredPropertyShapeFalseWithRequiredParameter(string value)
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = false)]
+        public required string Value { get; set; }
     }
 
     [Fact]


### PR DESCRIPTION
Consider a type has a `required` property and a constructor that takes that property as a parameter _without_ a `[SetsRequiredMembers]` attribute on the ctor:

```cs
public class SomeType
{
	public Base(string requiredString)
	{
		RequiredString = requiredString;
	}

	public required string RequiredString { get; set; }
}
```

PolyType was creating two parameter shapes: one for the parameter and one for the member initializer. Both were set as Required. As a result, middleware like Nerdbank.MessagePack failing to deserialize such types because the type shape reported not all required properties were initialized.

This change adds a test for this scenario and asserts that only one parameter shape is created, and that its `IsRequired` and `HasDefaultValue` properties have defensible values given the various test cases thrown at it.

Fixes eiriktsarpalis/PolyType#450