### PR TITLE
Fix constructor-shape duplication for required-by-attribute properties

### DIFF
--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -693,19 +693,10 @@ public sealed partial class Parser
         string name = parameter.Parameter.Name;
         bool isRequired = !parameter.HasDefaultValue;
 
-        PropertyDataModel? matchingProperty = FindMatchingProperty(declaringObjectForConstructor, parameter);
-
         AttributeData? parameterAttr = parameter.Parameter.GetAttribute(_knownSymbols.ParameterShapeAttribute);
         if (parameterAttr?.TryGetNamedArgument("IsRequired", out bool? isRequiredValue) is true && isRequiredValue is not null)
         {
-            // An explicit [ParameterShape] override takes precedence.
             isRequired = isRequiredValue.Value;
-        }
-        else if (matchingProperty?.IsRequiredByPolicy is bool requiredByPolicy)
-        {
-            // Otherwise inherit the IsRequired value of the matching property (e.g. set via
-            // [PropertyShape] or [DataMember]).
-            isRequired = requiredByPolicy;
         }
 
         if (parameterAttr != null &&
@@ -720,10 +711,19 @@ public sealed partial class Parser
         {
             name = name[1..];
         }
-        else if (matchingProperty is { } namedProperty)
+        else if (declaringObjectForConstructor is not null)
         {
-            // We have a matching property, use its name in the parameter.
-            name = namedProperty.LogicalName ?? namedProperty.Name;
+            foreach (PropertyDataModel property in declaringObjectForConstructor.Properties)
+            {
+                // Match property names to parameters up to Pascal/camel case conversion.
+                if (SymbolEqualityComparer.Default.Equals(property.PropertyType, parameter.Parameter.Type) &&
+                    CommonHelpers.CamelCaseInvariantComparer.Instance.Equals(parameter.Parameter.Name, property.Name))
+                {
+                    // We have a matching property, use its name in the parameter.
+                    name = property.LogicalName ?? property.Name;
+                    break;
+                }
+            }
         }
 
         return new ParameterShapeModel
@@ -748,26 +748,6 @@ public sealed partial class Parser
             DefaultValueExpr = parameter.DefaultValueExpr,
             Attributes = CollectAttributes(parameter.Parameter),
         };
-    }
-
-    private static PropertyDataModel? FindMatchingProperty(ObjectDataModel? declaringObjectForConstructor, ParameterDataModel parameter)
-    {
-        if (declaringObjectForConstructor is null)
-        {
-            return null;
-        }
-
-        foreach (PropertyDataModel property in declaringObjectForConstructor.Properties)
-        {
-            // Match property names to parameters up to Pascal/camel case conversion.
-            if (SymbolEqualityComparer.Default.Equals(property.PropertyType, parameter.Parameter.Type) &&
-                CommonHelpers.CamelCaseInvariantComparer.Instance.Equals(parameter.Parameter.Name, property.Name))
-            {
-                return property;
-            }
-        }
-
-        return null;
     }
 
     private ImmutableEquatableArray<ParameterShapeModel> MapFSharpFunctionParameters(FSharpFunctionDataModel fsharpFunc, TypeId declaringTypeId, out int effectiveParameterCount)

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -691,21 +691,26 @@ public sealed partial class Parser
     private ParameterShapeModel MapParameter(ObjectDataModel? declaringObjectForConstructor, TypeId declaringTypeId, ParameterDataModel parameter, bool isFSharpUnionCase)
     {
         string name = parameter.Parameter.Name;
-        bool isRequired = !parameter.HasDefaultValue;
 
         PropertyDataModel? matchingProperty = FindMatchingProperty(declaringObjectForConstructor, parameter);
+
+        // Resolve requiredness using a "strictest wins" policy. Start from the intrinsic requiredness
+        // (a parameter without a default value is required), apply an explicit
+        // [ParameterShape(IsRequired)] override, then let a matching property marked required tighten
+        // the result. A required assertion always wins: a matching property marked required via
+        // [PropertyShape(IsRequired = true)] / [DataMember(IsRequired = true)] forces the parameter to
+        // be required, even over a default value or an opposing [ParameterShape(IsRequired = false)].
+        // A property marked not-required never relaxes the parameter.
+        bool isRequired = !parameter.HasDefaultValue;
 
         AttributeData? parameterAttr = parameter.Parameter.GetAttribute(_knownSymbols.ParameterShapeAttribute);
         if (parameterAttr?.TryGetNamedArgument("IsRequired", out bool? isRequiredValue) is true && isRequiredValue is not null)
         {
-            // An explicit [ParameterShape(IsRequired)] override takes precedence.
             isRequired = isRequiredValue.Value;
         }
-        else if (matchingProperty?.IsRequiredByPolicy is true)
+
+        if (matchingProperty?.IsRequiredByPolicy is true)
         {
-            // "Strictest wins": a matching property marked required via [PropertyShape(IsRequired = true)]
-            // or [DataMember(IsRequired = true)] forces the parameter to be required, even if it declares
-            // a default value. A property marked not-required never relaxes an otherwise-required parameter.
             isRequired = true;
         }
 

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -693,10 +693,19 @@ public sealed partial class Parser
         string name = parameter.Parameter.Name;
         bool isRequired = !parameter.HasDefaultValue;
 
+        PropertyDataModel? matchingProperty = FindMatchingProperty(declaringObjectForConstructor, parameter);
+
         AttributeData? parameterAttr = parameter.Parameter.GetAttribute(_knownSymbols.ParameterShapeAttribute);
         if (parameterAttr?.TryGetNamedArgument("IsRequired", out bool? isRequiredValue) is true && isRequiredValue is not null)
         {
+            // An explicit [ParameterShape] override takes precedence.
             isRequired = isRequiredValue.Value;
+        }
+        else if (matchingProperty?.IsRequiredByPolicy is bool requiredByPolicy)
+        {
+            // Otherwise inherit the IsRequired value of the matching property (e.g. set via
+            // [PropertyShape] or [DataMember]).
+            isRequired = requiredByPolicy;
         }
 
         if (parameterAttr != null &&
@@ -711,19 +720,10 @@ public sealed partial class Parser
         {
             name = name[1..];
         }
-        else if (declaringObjectForConstructor is not null)
+        else if (matchingProperty is { } namedProperty)
         {
-            foreach (PropertyDataModel property in declaringObjectForConstructor.Properties)
-            {
-                // Match property names to parameters up to Pascal/camel case conversion.
-                if (SymbolEqualityComparer.Default.Equals(property.PropertyType, parameter.Parameter.Type) &&
-                    CommonHelpers.CamelCaseInvariantComparer.Instance.Equals(parameter.Parameter.Name, property.Name))
-                {
-                    // We have a matching property, use its name in the parameter.
-                    name = property.LogicalName ?? property.Name;
-                    break;
-                }
-            }
+            // We have a matching property, use its name in the parameter.
+            name = namedProperty.LogicalName ?? namedProperty.Name;
         }
 
         return new ParameterShapeModel
@@ -748,6 +748,26 @@ public sealed partial class Parser
             DefaultValueExpr = parameter.DefaultValueExpr,
             Attributes = CollectAttributes(parameter.Parameter),
         };
+    }
+
+    private static PropertyDataModel? FindMatchingProperty(ObjectDataModel? declaringObjectForConstructor, ParameterDataModel parameter)
+    {
+        if (declaringObjectForConstructor is null)
+        {
+            return null;
+        }
+
+        foreach (PropertyDataModel property in declaringObjectForConstructor.Properties)
+        {
+            // Match property names to parameters up to Pascal/camel case conversion.
+            if (SymbolEqualityComparer.Default.Equals(property.PropertyType, parameter.Parameter.Type) &&
+                CommonHelpers.CamelCaseInvariantComparer.Instance.Equals(parameter.Parameter.Name, property.Name))
+            {
+                return property;
+            }
+        }
+
+        return null;
     }
 
     private ImmutableEquatableArray<ParameterShapeModel> MapFSharpFunctionParameters(FSharpFunctionDataModel fsharpFunc, TypeId declaringTypeId, out int effectiveParameterCount)

--- a/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.ModelMapper.cs
@@ -693,10 +693,20 @@ public sealed partial class Parser
         string name = parameter.Parameter.Name;
         bool isRequired = !parameter.HasDefaultValue;
 
+        PropertyDataModel? matchingProperty = FindMatchingProperty(declaringObjectForConstructor, parameter);
+
         AttributeData? parameterAttr = parameter.Parameter.GetAttribute(_knownSymbols.ParameterShapeAttribute);
         if (parameterAttr?.TryGetNamedArgument("IsRequired", out bool? isRequiredValue) is true && isRequiredValue is not null)
         {
+            // An explicit [ParameterShape(IsRequired)] override takes precedence.
             isRequired = isRequiredValue.Value;
+        }
+        else if (matchingProperty?.IsRequiredByPolicy is true)
+        {
+            // "Strictest wins": a matching property marked required via [PropertyShape(IsRequired = true)]
+            // or [DataMember(IsRequired = true)] forces the parameter to be required, even if it declares
+            // a default value. A property marked not-required never relaxes an otherwise-required parameter.
+            isRequired = true;
         }
 
         if (parameterAttr != null &&
@@ -711,19 +721,10 @@ public sealed partial class Parser
         {
             name = name[1..];
         }
-        else if (declaringObjectForConstructor is not null)
+        else if (matchingProperty is { } namedProperty)
         {
-            foreach (PropertyDataModel property in declaringObjectForConstructor.Properties)
-            {
-                // Match property names to parameters up to Pascal/camel case conversion.
-                if (SymbolEqualityComparer.Default.Equals(property.PropertyType, parameter.Parameter.Type) &&
-                    CommonHelpers.CamelCaseInvariantComparer.Instance.Equals(parameter.Parameter.Name, property.Name))
-                {
-                    // We have a matching property, use its name in the parameter.
-                    name = property.LogicalName ?? property.Name;
-                    break;
-                }
-            }
+            // We have a matching property, use its name in the parameter.
+            name = namedProperty.LogicalName ?? namedProperty.Name;
         }
 
         return new ParameterShapeModel
@@ -748,6 +749,26 @@ public sealed partial class Parser
             DefaultValueExpr = parameter.DefaultValueExpr,
             Attributes = CollectAttributes(parameter.Parameter),
         };
+    }
+
+    private static PropertyDataModel? FindMatchingProperty(ObjectDataModel? declaringObjectForConstructor, ParameterDataModel parameter)
+    {
+        if (declaringObjectForConstructor is null)
+        {
+            return null;
+        }
+
+        foreach (PropertyDataModel property in declaringObjectForConstructor.Properties)
+        {
+            // Match property names to parameters up to Pascal/camel case conversion.
+            if (SymbolEqualityComparer.Default.Equals(property.PropertyType, parameter.Parameter.Type) &&
+                CommonHelpers.CamelCaseInvariantComparer.Instance.Equals(parameter.Parameter.Name, property.Name))
+            {
+                return property;
+            }
+        }
+
+        return null;
     }
 
     private ImmutableEquatableArray<ParameterShapeModel> MapFSharpFunctionParameters(FSharpFunctionDataModel fsharpFunc, TypeId declaringTypeId, out int effectiveParameterCount)

--- a/src/PolyType/Abstractions/IParameterShape.cs
+++ b/src/PolyType/Abstractions/IParameterShape.cs
@@ -48,8 +48,11 @@ public interface IParameterShape
     /// A parameter is reported as required if it is either a
     /// parameter without a default value or related to a property declared with the <see langword="required" /> modifier
     /// where the constructor is not annotated with <see cref="SetsRequiredMembersAttribute"/>.
-    /// This value will switch to the value set by <see cref="PropertyShapeAttribute.IsRequired"/>
-    /// or <see cref="ParameterShapeAttribute.IsRequired"/> (successively) if they are set.
+    /// When <see cref="PropertyShapeAttribute.IsRequired"/> or <see cref="ParameterShapeAttribute.IsRequired"/> are set,
+    /// the strictest setting wins: the parameter is reported as required if either attribute marks it as required,
+    /// even if it declares a default value. An explicit <see cref="ParameterShapeAttribute.IsRequired"/> of
+    /// <see langword="false"/> relaxes a parameter that would otherwise be required only for lacking a default value,
+    /// but a matching <see cref="PropertyShapeAttribute.IsRequired"/> of <see langword="true"/> still takes precedence.
     /// </remarks>
     bool IsRequired { get; }
 

--- a/src/PolyType/ReflectionProvider/IParameterShapeInfo.cs
+++ b/src/PolyType/ReflectionProvider/IParameterShapeInfo.cs
@@ -64,7 +64,8 @@ internal sealed class MemberInitializerShapeInfo : IParameterShapeInfo
         Type = memberInfo.MemberType();
         Name = logicalName ?? memberInfo.Name;
         MemberInfo = memberInfo;
-        IsRequired = isRequiredByAttribute ?? (!ctorSetsRequiredMembers && memberInfo.IsRequired());
+        IsRequiredBySyntax = !ctorSetsRequiredMembers && memberInfo.IsRequired();
+        IsRequired = isRequiredByAttribute ?? IsRequiredBySyntax;
         IsInitOnly = memberInfo.IsInitOnly();
         IsPublic = memberInfo is FieldInfo { IsPublic: true } or PropertyInfo { GetMethod.IsPublic: true };
         IsNonNullable = isSetterNonNullable;
@@ -74,6 +75,13 @@ internal sealed class MemberInitializerShapeInfo : IParameterShapeInfo
     public MemberInfo MemberInfo { get; }
     public bool IsByRef => false;
     public bool IsRequired { get; }
+
+    /// <summary>
+    /// Whether the underlying member is declared with the <see langword="required" /> keyword
+    /// (and the constructor is not annotated with <see cref="System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute" />),
+    /// independent of any <see cref="PropertyShapeAttribute.IsRequired" /> override.
+    /// </summary>
+    public bool IsRequiredBySyntax { get; }
     public bool IsInitOnly { get; }
     public bool IsNonNullable { get; }
     public bool IsPublic { get; }

--- a/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
@@ -189,14 +189,18 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
                 logicalName = matchingMember.LogicalName ?? matchingMember.BaseMemberInfo.Name;
             }
 
-            // Resolve the parameter's required flag using a "strictest wins" policy: an explicit
-            // [ParameterShape(IsRequired)] override takes precedence; otherwise the parameter is
-            // required if it has no default value OR the matching property is marked required via
-            // [PropertyShape(IsRequired = true)] / [DataMember(IsRequired = true)]. A property marked
-            // not-required never relaxes an otherwise-required parameter.
+            // Resolve the parameter's required flag using a "strictest wins" policy across every
+            // applicable source. A required assertion always wins: the parameter is required if it
+            // is marked required via [ParameterShape(IsRequired = true)] or if the matching property
+            // is marked required via [PropertyShape(IsRequired = true)] / [DataMember(IsRequired = true)],
+            // even when the parameter declares a default value and even over an opposing
+            // [ParameterShape(IsRequired = false)]. Absent any required assertion, an explicit
+            // [ParameterShape(IsRequired = false)] relaxes a parameter that would otherwise be
+            // required only for lacking a default value, while a property marked not-required never
+            // relaxes the parameter (its requiredness is intrinsic to the construction contract).
             bool? isRequired =
-                parameterShapeAttribute?.IsRequiredSpecified is true ? parameterShapeAttribute.IsRequired :
-                matchingMember?.IsRequiredByAttribute is true ? true :
+                matchingMember?.IsRequiredByAttribute is true || parameterShapeAttribute is { IsRequiredSpecified: true, IsRequired: true } ? true :
+                parameterShapeAttribute?.IsRequiredSpecified is true ? false :
                 null;
 
             parameterShapeInfos[i++] = new(parameter, isNonNullable, matchingMember?.BaseMemberInfo, logicalName, isRequired);

--- a/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
@@ -189,13 +189,15 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
                 logicalName = matchingMember.LogicalName ?? matchingMember.BaseMemberInfo.Name;
             }
 
-            // An explicit [ParameterShape] override takes precedence, otherwise fall back to the
-            // presence of a default value. A matching property's [PropertyShape(IsRequired)] is
-            // intentionally not propagated here: a constructor parameter's requiredness is intrinsic
-            // to the constructor contract and cannot be relaxed by a property annotation.
-            bool? isRequired = parameterShapeAttribute?.IsRequiredSpecified is true
-                ? parameterShapeAttribute.IsRequired
-                : null;
+            // Resolve the parameter's required flag using a "strictest wins" policy: an explicit
+            // [ParameterShape(IsRequired)] override takes precedence; otherwise the parameter is
+            // required if it has no default value OR the matching property is marked required via
+            // [PropertyShape(IsRequired = true)] / [DataMember(IsRequired = true)]. A property marked
+            // not-required never relaxes an otherwise-required parameter.
+            bool? isRequired =
+                parameterShapeAttribute?.IsRequiredSpecified is true ? parameterShapeAttribute.IsRequired :
+                matchingMember?.IsRequiredByAttribute is true ? true :
+                null;
 
             parameterShapeInfos[i++] = new(parameter, isNonNullable, matchingMember?.BaseMemberInfo, logicalName, isRequired);
         }

--- a/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
@@ -189,12 +189,13 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
                 logicalName = matchingMember.LogicalName ?? matchingMember.BaseMemberInfo.Name;
             }
 
-            // Resolve the required flag: an explicit [ParameterShape] override takes precedence,
-            // otherwise inherit the IsRequired value of the matching property (e.g. set via
-            // [PropertyShape] or [DataMember]); fall back to the presence of a default value.
+            // An explicit [ParameterShape] override takes precedence, otherwise fall back to the
+            // presence of a default value. A matching property's [PropertyShape(IsRequired)] is
+            // intentionally not propagated here: a constructor parameter's requiredness is intrinsic
+            // to the constructor contract and cannot be relaxed by a property annotation.
             bool? isRequired = parameterShapeAttribute?.IsRequiredSpecified is true
                 ? parameterShapeAttribute.IsRequired
-                : matchingMember?.IsRequiredByAttribute;
+                : null;
 
             parameterShapeInfos[i++] = new(parameter, isNonNullable, matchingMember?.BaseMemberInfo, logicalName, isRequired);
         }

--- a/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
@@ -189,7 +189,12 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
                 logicalName = matchingMember.LogicalName ?? matchingMember.BaseMemberInfo.Name;
             }
 
-            bool? isRequired = parameterShapeAttribute?.IsRequiredSpecified is true ? parameterShapeAttribute.IsRequired : null;
+            // Resolve the required flag: an explicit [ParameterShape] override takes precedence,
+            // otherwise inherit the IsRequired value of the matching property (e.g. set via
+            // [PropertyShape] or [DataMember]); fall back to the presence of a default value.
+            bool? isRequired = parameterShapeAttribute?.IsRequiredSpecified is true
+                ? parameterShapeAttribute.IsRequired
+                : matchingMember?.IsRequiredByAttribute;
 
             parameterShapeInfos[i++] = new(parameter, isNonNullable, matchingMember?.BaseMemberInfo, logicalName, isRequired);
         }
@@ -205,9 +210,11 @@ internal sealed class DefaultReflectionObjectTypeShape<T>(ReflectionTypeShapePro
             // members in the shape signature.
             foreach (MemberInitializerShapeInfo memberInitializer in settableMembers)
             {
-                if (!memberInitializer.IsRequired && parameterShapeInfos.Any(p => p.MatchingMember == memberInitializer.MemberInfo))
+                if (!memberInitializer.IsRequiredBySyntax && parameterShapeInfos.Any(p => p.MatchingMember == memberInitializer.MemberInfo))
                 {
                     // Deduplicate any properties whose signature matches a constructor parameter.
+                    // Members declared with the 'required' keyword are exempt since they must be set
+                    // using an object initializer; their required-ness can't be satisfied by the parameter alone.
                     continue;
                 }
 

--- a/tests/PolyType.Tests/IsRequiredTests.cs
+++ b/tests/PolyType.Tests/IsRequiredTests.cs
@@ -270,7 +270,7 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     }
 
     [Fact]
-    public void RequiredByAttributeProperty_MatchingOptionalCtorParameter_ParameterStaysOptional()
+    public void RequiredByAttributeProperty_MatchingOptionalCtorParameter_BecomesRequired()
     {
         var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasRequiredByAttributePropertyAndMatchingOptionalCtorParameter));
         Assert.NotNull(shape);
@@ -278,10 +278,10 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
         var parameter = shape.Constructor.Parameters.Single(p => p.Name == nameof(HasRequiredByAttributePropertyAndMatchingOptionalCtorParameter.Value));
         Assert.Equal(ParameterKind.MethodParameter, parameter.Kind);
 
-        // The matching property is [PropertyShape(IsRequired = true)], but it is deduplicated
-        // against the constructor parameter, which has a default value. The property annotation does
-        // not propagate to the parameter, so the parameter remains optional per the constructor.
-        Assert.False(parameter.IsRequired);
+        // The matching property is [PropertyShape(IsRequired = true)] and is deduplicated against the
+        // constructor parameter, which has a default value. Under the "strictest wins" policy the
+        // required property forces the parameter to be required despite its default.
+        Assert.True(parameter.IsRequired);
     }
 
     [GenerateShape]
@@ -293,6 +293,32 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
         }
 
         [PropertyShape(IsRequired = true)]
+        public string Value { get; set; }
+    }
+
+    [Fact]
+    public void NotRequiredByAttributeProperty_MatchingOptionalCtorParameter_StaysOptional()
+    {
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasNotRequiredByAttributePropertyAndMatchingOptionalCtorParameter));
+        Assert.NotNull(shape);
+        Assert.NotNull(shape.Constructor);
+        var parameter = shape.Constructor.Parameters.Single(p => p.Name == nameof(HasNotRequiredByAttributePropertyAndMatchingOptionalCtorParameter.Value));
+        Assert.Equal(ParameterKind.MethodParameter, parameter.Kind);
+
+        // Neither the constructor parameter (which has a default value) nor the matching property
+        // (which is [PropertyShape(IsRequired = false)]) is required, so the parameter stays optional.
+        Assert.False(parameter.IsRequired);
+    }
+
+    [GenerateShape]
+    public partial class HasNotRequiredByAttributePropertyAndMatchingOptionalCtorParameter
+    {
+        public HasNotRequiredByAttributePropertyAndMatchingOptionalCtorParameter(string value = "")
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = false)]
         public string Value { get; set; }
     }
 

--- a/tests/PolyType.Tests/IsRequiredTests.cs
+++ b/tests/PolyType.Tests/IsRequiredTests.cs
@@ -217,6 +217,76 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
         public required bool RequiredProperty { get; set; }
     }
 
+    [Fact]
+    public void RequiredByAttributeProperty_MatchingCtorParameter_NotDuplicated()
+    {
+        // Regression test for https://github.com/eiriktsarpalis/PolyType/issues/450
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasRequiredByAttributePropertyAndMatchingCtorParameter));
+        Assert.NotNull(shape);
+        Assert.NotNull(shape.Constructor);
+        var parameter = shape.Constructor.Parameters.Single(p => p.Name == nameof(HasRequiredByAttributePropertyAndMatchingCtorParameter.Value));
+        Assert.Equal(ParameterKind.MethodParameter, parameter.Kind);
+        Assert.True(parameter.IsRequired);
+    }
+
+    [GenerateShape]
+    public partial class HasRequiredByAttributePropertyAndMatchingCtorParameter
+    {
+        public HasRequiredByAttributePropertyAndMatchingCtorParameter(string value)
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = true)]
+        public string Value { get; set; }
+    }
+
+    [Fact]
+    public void NotRequiredByAttributeProperty_MatchingCtorParameter_NotDuplicated()
+    {
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasNotRequiredByAttributePropertyAndMatchingCtorParameter));
+        Assert.NotNull(shape);
+        Assert.NotNull(shape.Constructor);
+        var parameter = shape.Constructor.Parameters.Single(p => p.Name == nameof(HasNotRequiredByAttributePropertyAndMatchingCtorParameter.Value));
+        Assert.Equal(ParameterKind.MethodParameter, parameter.Kind);
+        Assert.False(parameter.IsRequired);
+    }
+
+    [GenerateShape]
+    public partial class HasNotRequiredByAttributePropertyAndMatchingCtorParameter
+    {
+        public HasNotRequiredByAttributePropertyAndMatchingCtorParameter(string value)
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = false)]
+        public string Value { get; set; }
+    }
+
+    [Fact]
+    public void RequiredByAttributeProperty_MatchingOptionalCtorParameter_PreservesRequired()
+    {
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasRequiredByAttributePropertyAndMatchingOptionalCtorParameter));
+        Assert.NotNull(shape);
+        Assert.NotNull(shape.Constructor);
+        var parameter = shape.Constructor.Parameters.Single(p => p.Name == nameof(HasRequiredByAttributePropertyAndMatchingOptionalCtorParameter.Value));
+        Assert.Equal(ParameterKind.MethodParameter, parameter.Kind);
+        Assert.True(parameter.IsRequired);
+    }
+
+    [GenerateShape]
+    public partial class HasRequiredByAttributePropertyAndMatchingOptionalCtorParameter
+    {
+        public HasRequiredByAttributePropertyAndMatchingOptionalCtorParameter(string value = "")
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = true)]
+        public string Value { get; set; }
+    }
+
     [GenerateShapeFor<HasRequiredProperty>]
     internal partial class Witness;
 

--- a/tests/PolyType.Tests/IsRequiredTests.cs
+++ b/tests/PolyType.Tests/IsRequiredTests.cs
@@ -249,7 +249,12 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
         Assert.NotNull(shape.Constructor);
         var parameter = shape.Constructor.Parameters.Single(p => p.Name == nameof(HasNotRequiredByAttributePropertyAndMatchingCtorParameter.Value));
         Assert.Equal(ParameterKind.MethodParameter, parameter.Kind);
-        Assert.False(parameter.IsRequired);
+
+        // The matching property is [PropertyShape(IsRequired = false)], but it is deduplicated
+        // against the constructor parameter. The parameter has no default value, so it remains
+        // required: a constructor parameter's requiredness is intrinsic to the constructor contract
+        // and a property annotation cannot relax it.
+        Assert.True(parameter.IsRequired);
     }
 
     [GenerateShape]
@@ -265,14 +270,18 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
     }
 
     [Fact]
-    public void RequiredByAttributeProperty_MatchingOptionalCtorParameter_PreservesRequired()
+    public void RequiredByAttributeProperty_MatchingOptionalCtorParameter_ParameterStaysOptional()
     {
         var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(typeof(HasRequiredByAttributePropertyAndMatchingOptionalCtorParameter));
         Assert.NotNull(shape);
         Assert.NotNull(shape.Constructor);
         var parameter = shape.Constructor.Parameters.Single(p => p.Name == nameof(HasRequiredByAttributePropertyAndMatchingOptionalCtorParameter.Value));
         Assert.Equal(ParameterKind.MethodParameter, parameter.Kind);
-        Assert.True(parameter.IsRequired);
+
+        // The matching property is [PropertyShape(IsRequired = true)], but it is deduplicated
+        // against the constructor parameter, which has a default value. The property annotation does
+        // not propagate to the parameter, so the parameter remains optional per the constructor.
+        Assert.False(parameter.IsRequired);
     }
 
     [GenerateShape]

--- a/tests/PolyType.Tests/IsRequiredTests.cs
+++ b/tests/PolyType.Tests/IsRequiredTests.cs
@@ -322,6 +322,100 @@ public abstract partial class IsRequiredTests(ProviderUnderTest providerUnderTes
         public string Value { get; set; }
     }
 
+    [Theory]
+    [InlineData(typeof(ParamNotRequiredPropRequiredOptionalParam), true)]
+    [InlineData(typeof(ParamNotRequiredPropRequiredRequiredParam), true)]
+    [InlineData(typeof(ParamRequiredPropNotRequiredOptionalParam), true)]
+    [InlineData(typeof(ParamRequiredPropNotRequiredRequiredParam), true)]
+    [InlineData(typeof(ParamNotRequiredPropNotRequiredRequiredParam), false)]
+    [InlineData(typeof(ParamRequiredPropRequiredOptionalParam), true)]
+    public void ParameterShapeAndPropertyShapeIsRequired_StrictestWins(Type type, bool expectedIsRequired)
+    {
+        // [ParameterShape(IsRequired)] and a matching [PropertyShape(IsRequired)] combine following a
+        // "most strict policy wins" principle: a required assertion from either attribute forces the
+        // parameter to be required (winning over a default value or an opposing not-required setting),
+        // and the parameter is only optional when neither attribute, nor an intrinsic lack of default
+        // value, marks it as required.
+        var shape = (IObjectTypeShape?)providerUnderTest.Provider.GetTypeShape(type);
+        Assert.NotNull(shape);
+        Assert.NotNull(shape.Constructor);
+        var parameter = shape.Constructor.Parameters.Single(p => p.Name == "Value");
+        Assert.Equal(ParameterKind.MethodParameter, parameter.Kind);
+        Assert.Equal(expectedIsRequired, parameter.IsRequired);
+    }
+
+    [GenerateShape]
+    public partial class ParamNotRequiredPropRequiredOptionalParam
+    {
+        public ParamNotRequiredPropRequiredOptionalParam([ParameterShape(IsRequired = false)] string value = "")
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = true)]
+        public string Value { get; set; }
+    }
+
+    [GenerateShape]
+    public partial class ParamNotRequiredPropRequiredRequiredParam
+    {
+        public ParamNotRequiredPropRequiredRequiredParam([ParameterShape(IsRequired = false)] string value)
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = true)]
+        public string Value { get; set; }
+    }
+
+    [GenerateShape]
+    public partial class ParamRequiredPropNotRequiredOptionalParam
+    {
+        public ParamRequiredPropNotRequiredOptionalParam([ParameterShape(IsRequired = true)] string value = "")
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = false)]
+        public string Value { get; set; }
+    }
+
+    [GenerateShape]
+    public partial class ParamRequiredPropNotRequiredRequiredParam
+    {
+        public ParamRequiredPropNotRequiredRequiredParam([ParameterShape(IsRequired = true)] string value)
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = false)]
+        public string Value { get; set; }
+    }
+
+    [GenerateShape]
+    public partial class ParamNotRequiredPropNotRequiredRequiredParam
+    {
+        public ParamNotRequiredPropNotRequiredRequiredParam([ParameterShape(IsRequired = false)] string value)
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = false)]
+        public string Value { get; set; }
+    }
+
+    [GenerateShape]
+    public partial class ParamRequiredPropRequiredOptionalParam
+    {
+        public ParamRequiredPropRequiredOptionalParam([ParameterShape(IsRequired = true)] string value = "")
+        {
+            Value = value;
+        }
+
+        [PropertyShape(IsRequired = true)]
+        public string Value { get; set; }
+    }
+
     [GenerateShapeFor<HasRequiredProperty>]
     internal partial class Witness;
 


### PR DESCRIPTION
## Why

Fixes: #450

When a settable property marked `[PropertyShape(IsRequired = true)]` matched a constructor parameter, the reflection provider duplicated the member: it emitted both a method parameter and a member initializer with the same logical name, so `Constructor.Parameters.Count` was 3 instead of 2. The source generator emitted only one. Consumers such as Nerdbank.MessagePack saw an extra parameter and inconsistent behaviour across providers.

## Root cause

The reflection provider deduplicated settable members against constructor parameters using the attribute-inclusive `IsRequired` flag. A property marked required by attribute therefore looked "required" and was never deduplicated, even when it clearly matched a constructor parameter. The source generator already deduplicated on syntactic requiredness (the `required` keyword) only.

## Approach

Both providers now follow one consistent set of rules:

1. **Deduplicate on syntax, not attributes.** A settable member matching a constructor parameter is kept as a separate member initializer only when it is required by *syntax* (the `required` keyword, and the constructor is not `[SetsRequiredMembers]`). Otherwise it is deduplicated. The reflection provider now gates on a new `IsRequiredBySyntax` flag instead of the attribute-inclusive `IsRequired`, matching the source generator.

2. **Resolve the matched parameter's requiredness with a "most strict policy wins" rule.** A required assertion from any applicable source wins:
   - The parameter is required if it has no default value, **or** the matching property is marked required via `[PropertyShape(IsRequired = true)]` / `[DataMember(IsRequired = true)]`, **or** it is marked required via `[ParameterShape(IsRequired = true)]`.
   - An explicit `[ParameterShape(IsRequired = false)]` only relaxes a parameter that would otherwise be required for lacking a default value; it loses to a matching `[PropertyShape(IsRequired = true)]`.
   - A property marked not-required never relaxes the parameter, since a constructor parameter's requiredness is intrinsic to the construction contract.

   This also updates the documented `IParameterShape.IsRequired` contract: the previous wording said `[PropertyShape]` then `[ParameterShape]` were applied "successively" (parameter wins unconditionally); it now describes the strictest-wins behaviour.

## Resulting behaviour (reflection == reflection-emit == source gen)

| property annotation | parameter annotation | ctor parameter | parameter `IsRequired` |
|---|---|---|---|
| `[PropertyShape(IsRequired = true)]` | - | required (no default) | `true` |
| `[PropertyShape(IsRequired = true)]` | - | optional (default) | `true` (property tightens) |
| `[PropertyShape(IsRequired = false)]` | - | required (no default) | `true` (cannot relax) |
| `[PropertyShape(IsRequired = false)]` | - | optional (default) | `false` |
| `[PropertyShape(IsRequired = true)]` | `[ParameterShape(IsRequired = false)]` | any | `true` (strictest wins) |
| `[PropertyShape(IsRequired = false)]` | `[ParameterShape(IsRequired = true)]` | any | `true` (strictest wins) |
| `[PropertyShape(IsRequired = false)]` | `[ParameterShape(IsRequired = false)]` | required (no default) | `false` |
| - | `[ParameterShape(IsRequired = false)]` | required (no default) | `false` (explicit relax) |
| `required` keyword | - | required | method param + required member init (member kept) |

Members declared with the `required` keyword stay exempt from deduplication and are kept as separate member initializers, since they must be satisfied through an object initializer; their requiredness is preserved on the member rather than the parameter.

## Tests

Added regression tests in `IsRequiredTests.cs` covering required/not-required attribute properties against required and optional constructor parameters, plus a theory matrix exercising the `[ParameterShape(IsRequired)]` x `[PropertyShape(IsRequired)]` combinations. All cases run across the reflection, reflection-emit, and source-generated providers. Full `PolyType.Tests` suite and source-generator unit tests pass.