### PR TITLE
Dedup ctor/method reflection-info signature lookups in generated shapes

### DIFF
--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Constructors.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Constructors.cs
@@ -17,6 +17,7 @@ internal sealed partial class SourceFormatter
         string constructorArgumentStateFQN = FormatConstructorArgumentStateFQN(type, constructor);
         string? constructorParameterFactoryName = constructor.TotalArity > 0 ? $"__CreateConstructorParameters_{type.SourceIdentifier}" : null;
         string? attributeFactoryName = constructor.Attributes.Length > 0 ? $"__CreateConstructorAttributes_{type.SourceIdentifier}" : null;
+        string? constructorInfoResolverName = GetConstructorInfoResolverName(type, constructor);
 
         writer.WriteLine($"private global::PolyType.Abstractions.IConstructorShape {methodName}()");
         writer.WriteLine('{');
@@ -30,7 +31,7 @@ internal sealed partial class SourceFormatter
                 DefaultConstructor = {{FormatDefaultCtor(type, constructor)}},
                 ArgumentStateConstructor = {{FormatArgumentStateCtor(type, constructor, constructorArgumentStateFQN)}},
                 ParameterizedConstructor = {{FormatParameterizedCtor(type, constructor, constructorArgumentStateFQN)}},
-                MethodBaseFactory = {{FormatConstructorInfoResolver(type, constructor)}},
+                MethodBaseFactory = {{FormatMethodBaseFactory(type, constructor, constructorInfoResolverName)}},
                 AttributeFactory = {{FormatNull(attributeFactoryName)}},
                 IsPublic = {{FormatBool(constructor.IsPublic)}},
             };
@@ -42,7 +43,13 @@ internal sealed partial class SourceFormatter
         if (constructorParameterFactoryName != null)
         {
             writer.WriteLine();
-            FormatParameterFactory(writer, type, constructorParameterFactoryName, constructor, constructorArgumentStateFQN);
+            FormatParameterFactory(writer, type, constructorParameterFactoryName, constructor, constructorArgumentStateFQN, constructorInfoResolverName);
+        }
+
+        if (constructorInfoResolverName is not null)
+        {
+            writer.WriteLine();
+            writer.WriteLine($"private static global::System.Reflection.MethodBase? {constructorInfoResolverName}() => {FormatConstructorInfoExpr(constructor)};");
         }
 
         if (attributeFactoryName is not null)
@@ -63,28 +70,29 @@ internal sealed partial class SourceFormatter
                 constructor.GetAllParameters());
         }
         
-        static string FormatConstructorInfoResolver(ObjectShapeModel type, ConstructorShapeModel constructor)
+        static string FormatMethodBaseFactory(ObjectShapeModel type, ConstructorShapeModel constructor, string? constructorInfoResolverName)
         {
             if (type.IsTupleType || constructor.IsStaticFactory || constructor.IsFSharpUnitConstructor)
             {
                 return "null";
             }
 
-            string parameterTypes;
-            if (constructor.Parameters.Length == 0)
-            {
-                parameterTypes = "global::System.Type.EmptyTypes";
-            }
-            else
-            {
-                string FormatType(ParameterShapeModel p) => p.RefKind is RefKind.Out
-                    ? $"typeof({p.ParameterType.FullyQualifiedName}).MakeByRefType()"
-                    : FormatParameterTypeExpr(p);
+            // Reference the shared resolver method group when one is emitted; otherwise inline the lookup.
+            return constructorInfoResolverName ?? $"static () => {FormatConstructorInfoExpr(constructor)}";
+        }
 
-                parameterTypes = $$"""new global::System.Type[] { {{string.Join(", ", constructor.Parameters.Select(FormatType))}} }""";
-            }
+        static string? GetConstructorInfoResolverName(ObjectShapeModel type, ConstructorShapeModel constructor)
+        {
+            // The ConstructorInfo lookup is otherwise emitted inline once for the MethodBaseFactory and once per
+            // method-parameter ReflectionInfoFactory. Lift it into a shared helper only when at least two call sites
+            // would reference it, so the indirection actually removes duplicated code (and IL).
+            bool methodBaseUsesResolver = !(type.IsTupleType || constructor.IsStaticFactory || constructor.IsFSharpUnitConstructor);
+            int parameterRefs = type.IsTupleType || constructor.IsStaticFactory
+                ? 0
+                : constructor.ShapedParameters.Count(p => p.Kind is ParameterKind.MethodParameter);
 
-            return $"static () => typeof({constructor.DeclaringType.FullyQualifiedName}).GetConstructor({InstanceBindingFlagsConstMember}, null, {parameterTypes}, null)";
+            int callSites = (methodBaseUsesResolver ? 1 : 0) + parameterRefs;
+            return callSites >= 2 ? $"__ConstructorInfo_{type.SourceIdentifier}" : null;
         }
 
         static string FormatArgumentStateCtor(ObjectShapeModel type, ConstructorShapeModel constructor, string constructorArgumentStateFQN)
@@ -298,7 +306,7 @@ internal sealed partial class SourceFormatter
         }
     }
 
-    private void FormatParameterFactory(SourceWriter writer, ObjectShapeModel type, string methodName, ConstructorShapeModel constructor, string constructorArgumentStateFQN)
+    private void FormatParameterFactory(SourceWriter writer, ObjectShapeModel type, string methodName, ConstructorShapeModel constructor, string constructorArgumentStateFQN, string? constructorInfoResolverName)
     {
         writer.WriteLine($"private global::PolyType.Abstractions.IParameterShape[] {methodName}() => new global::PolyType.Abstractions.IParameterShape[]");
         writer.WriteLine('{');
@@ -331,13 +339,13 @@ internal sealed partial class SourceFormatter
                     Getter = static (ref {{constructorArgumentStateFQN}} state) => {{FormatGetterBody(constructor, parameter)}},
                     Setter = static (ref {{constructorArgumentStateFQN}} state, {{parameter.ParameterType.FullyQualifiedName}} value) => {{FormatSetterBody(constructor, parameter)}},
                     AttributeFactory = {{FormatNull(attributeFactoryName)}},
-                    ReflectionInfoFactory = {{FormatAttributeProviderFunc(type, constructor, parameter)}},
+                    ReflectionInfoFactory = {{FormatAttributeProviderFunc(type, constructor, parameter, constructorInfoResolverName)}},
                 },
                 """, trimDefaultAssignmentLines: true);
 
             i++;
 
-            static string FormatAttributeProviderFunc(ObjectShapeModel type, ConstructorShapeModel constructor, ParameterShapeModel parameter)
+            static string FormatAttributeProviderFunc(ObjectShapeModel type, ConstructorShapeModel constructor, ParameterShapeModel parameter, string? constructorInfoResolverName)
             {
                 if (type.IsTupleType || constructor.IsStaticFactory)
                 {
@@ -351,11 +359,12 @@ internal sealed partial class SourceFormatter
                         : $$"""static () => typeof({{parameter.DeclaringType.FullyQualifiedName}}).GetProperty({{FormatStringLiteral(parameter.UnderlyingMemberName)}}, {{InstanceBindingFlagsConstMember}}, null, typeof({{parameter.ParameterType}}), global::System.Type.EmptyTypes, null)""";
                 }
 
-                string parameterTypes = constructor.Parameters.Length == 0
-                    ? "global::System.Type.EmptyTypes"
-                    : $$"""new global::System.Type[] { {{string.Join(", ", constructor.Parameters.Select(FormatParameterTypeExpr))}} }""";
+                // Resolve the owning ConstructorInfo via the shared resolver when available; otherwise inline it.
+                string constructorInfo = constructorInfoResolverName is not null
+                    ? $"{constructorInfoResolverName}()"
+                    : FormatConstructorInfoExpr(constructor);
 
-                return $"static () => typeof({constructor.DeclaringType.FullyQualifiedName}).GetConstructor({InstanceBindingFlagsConstMember}, null, {parameterTypes}, null)?.GetParameters()[{parameter.Position}]";
+                return $"static () => {constructorInfo}?.GetParameters()[{parameter.Position}]";
             }
 
             static string FormatGetterBody(ConstructorShapeModel constructor, ParameterShapeModel parameter)
@@ -584,6 +593,15 @@ internal sealed partial class SourceFormatter
         return parameter.RefKind is RefKind.None
             ? $"typeof({parameter.ParameterType.FullyQualifiedName})"
             : $"typeof({parameter.ParameterType.FullyQualifiedName}).MakeByRefType()";
+    }
+
+    private static string FormatConstructorInfoExpr(ConstructorShapeModel constructor)
+    {
+        string parameterTypes = constructor.Parameters.Length == 0
+            ? "global::System.Type.EmptyTypes"
+            : $$"""new global::System.Type[] { {{string.Join(", ", constructor.Parameters.Select(FormatParameterTypeExpr))}} }""";
+
+        return $"typeof({constructor.DeclaringType.FullyQualifiedName}).GetConstructor({InstanceBindingFlagsConstMember}, null, {parameterTypes}, null)";
     }
 
 }

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Methods.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Methods.cs
@@ -57,6 +57,7 @@ internal sealed partial class SourceFormatter
         string methodArgumentStateFQN = FormatMethodArgumentStateFQN(method);
         string? methodParameterFactoryName = method.ShapedParameterCount > 0 ? $"__CreateMethodParameters_{declaringType.SourceIdentifier}_{method.Position}" : null;
         string? methodAttributeFactory = method.Attributes.Length > 0 ? $"__CreateAttributes_{declaringType.SourceIdentifier}_{method.Position}" : null;
+        string? methodInfoResolverName = GetMethodInfoResolverName(declaringType, method);
 
         writer.WriteLine($"private global::PolyType.Abstractions.IMethodShape {methodName}()");
         writer.WriteLine('{');
@@ -73,7 +74,7 @@ internal sealed partial class SourceFormatter
                 DeclaringType = {{declaringType.SourceIdentifier}},
                 ReturnType = {{GetShapeModel(method.ReturnType).SourceIdentifier}},
                 ParametersFactory = {{FormatNull(methodParameterFactoryName)}},
-                MethodBaseFactory = {{FormatAttributeProviderFunc(declaringType, method)}},
+                MethodBaseFactory = {{FormatMethodBaseFactory(method, methodInfoResolverName)}},
                 AttributeFactory = {{FormatNull(methodAttributeFactory)}},
                 ArgumentStateConstructor = {{FormatArgumentStateConstructor(declaringType, method, methodArgumentStateFQN)}},
                 MethodInvoker = {{FormatMethodInvoker(declaringType, method, methodArgumentStateFQN)}},
@@ -86,7 +87,13 @@ internal sealed partial class SourceFormatter
         if (methodParameterFactoryName != null)
         {
             writer.WriteLine();
-            FormatMethodParameterFactory(writer, declaringType, methodParameterFactoryName, method, methodArgumentStateFQN);
+            FormatMethodParameterFactory(writer, declaringType, methodParameterFactoryName, method, methodArgumentStateFQN, methodInfoResolverName);
+        }
+
+        if (methodInfoResolverName is not null)
+        {
+            writer.WriteLine();
+            writer.WriteLine($"private static global::System.Reflection.MethodBase? {methodInfoResolverName}() => {FormatMethodInfoExpr(method)};");
         }
 
         if (FormatRequiredParametersMaskFieldName(declaringType, method) is { } requiredParametersMaskFieldName)
@@ -120,10 +127,19 @@ internal sealed partial class SourceFormatter
                 or MethodReturnTypeKind.ValueTaskOfT;
         }
 
-        static string FormatAttributeProviderFunc(TypeShapeModel declaringType, MethodShapeModel method)
+        static string FormatMethodBaseFactory(MethodShapeModel method, string? methodInfoResolverName)
         {
-            string parameterTypes = FormatAllMethodParameterTypes(method);
-            return $"static () => typeof({method.DeclaringType.FullyQualifiedName}).GetMethod({FormatStringLiteral(method.UnderlyingMethodName)}, {AllBindingFlagsConstMember}, null, {parameterTypes}, null)";
+            // Reference the shared resolver method group when one is emitted; otherwise inline the lookup.
+            return methodInfoResolverName ?? $"static () => {FormatMethodInfoExpr(method)}";
+        }
+
+        static string? GetMethodInfoResolverName(TypeShapeModel declaringType, MethodShapeModel method)
+        {
+            // The MethodBaseFactory and each method-parameter ReflectionInfoFactory resolve the same MethodInfo.
+            // Lift it into a shared helper only when at least two call sites would reference it, so the indirection
+            // actually removes duplicated code (and IL).
+            int callSites = 1 + method.ShapedParameterCount;
+            return callSites >= 2 ? $"__MethodInfo_{declaringType.SourceIdentifier}_{method.Position}" : null;
         }
 
         static string FormatArgumentStateConstructor(TypeShapeModel declaringType, MethodShapeModel method, string methodArgumentStateFQN)
@@ -225,7 +241,7 @@ internal sealed partial class SourceFormatter
         }
     }
 
-    private void FormatMethodParameterFactory(SourceWriter writer, TypeShapeModel declaringType, string methodName, MethodShapeModel method, string methodArgumentStateFQN)
+    private void FormatMethodParameterFactory(SourceWriter writer, TypeShapeModel declaringType, string methodName, MethodShapeModel method, string methodArgumentStateFQN, string? methodInfoResolverName)
     {
         writer.WriteLine($"private global::PolyType.Abstractions.IParameterShape[] {methodName}() => new global::PolyType.Abstractions.IParameterShape[]");
         writer.WriteLine('{');
@@ -255,15 +271,18 @@ internal sealed partial class SourceFormatter
                     Getter = static (ref {{methodArgumentStateFQN}} state) => {{FormatGetterBody(method, parameter)}},
                     Setter = static (ref {{methodArgumentStateFQN}} state, {{parameter.ParameterType.FullyQualifiedName}} value) => {{FormatSetterBody(method, parameter)}},
                     AttributeFactory = {{FormatNull(attributeFactoryName)}},
-                    ReflectionInfoFactory = {{FormatAttributeProviderFunc(declaringType, method, parameter)}},
+                    ReflectionInfoFactory = {{FormatAttributeProviderFunc(method, parameter, methodInfoResolverName)}},
                 },
                 """, trimDefaultAssignmentLines: true);
 
-            static string FormatAttributeProviderFunc(TypeShapeModel declaringType, MethodShapeModel method, ParameterShapeModel parameter)
+            static string FormatAttributeProviderFunc(MethodShapeModel method, ParameterShapeModel parameter, string? methodInfoResolverName)
             {
-                string parameterTypes = FormatAllMethodParameterTypes(method);
+                // Resolve the owning MethodInfo via the shared resolver when available; otherwise inline it.
+                string methodInfo = methodInfoResolverName is not null
+                    ? $"{methodInfoResolverName}()"
+                    : FormatMethodInfoExpr(method);
 
-                return $"static () => typeof({method.DeclaringType.FullyQualifiedName}).GetMethod({FormatStringLiteral(method.UnderlyingMethodName)}, {AllBindingFlagsConstMember}, null, {parameterTypes}, null)?.GetParameters()[{parameter.Position}]";
+                return $"static () => {methodInfo}?.GetParameters()[{parameter.Position}]";
             }
 
             static string FormatGetterBody(MethodShapeModel method, ParameterShapeModel parameter)
@@ -435,4 +454,7 @@ internal sealed partial class SourceFormatter
 
         return $$"""new global::System.Type[] { {{string.Join(", ", method.Parameters.Select(FormatType))}} }""";
     }
+
+    private static string FormatMethodInfoExpr(MethodShapeModel method)
+        => $"typeof({method.DeclaringType.FullyQualifiedName}).GetMethod({FormatStringLiteral(method.UnderlyingMethodName)}, {AllBindingFlagsConstMember}, null, {FormatAllMethodParameterTypes(method)}, null)";
 }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
@@ -59,7 +59,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Pair_Int32_String,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Pair_Int32_String),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.Pair<int, string>(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Pair_Int32_String,
                 IsPublic = true,
             };
         }
@@ -77,7 +77,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -91,9 +91,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Pair_Int32_String() => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Pair_Int32_String = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Address,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Address),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => new global::TestNamespace.Address(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Address,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Address() => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Address = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Person,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Person),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => new global::TestNamespace.Person(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Person,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int)>, int>
@@ -93,9 +93,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Person() => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private const ulong __RequiredMembersMask_Person = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
@@ -97,7 +97,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Secrets,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_Secrets),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => { var obj = __CtorAccessor_Secrets(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.Label = state.Arguments.Item3; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Secrets,
                 AttributeFactory = __CreateConstructorAttributes_Secrets,
             };
         }
@@ -116,7 +116,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, int>
@@ -130,7 +130,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, string>
@@ -147,6 +147,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetProperty("Label", __BindingFlags_Instance_All, null, typeof(string), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Secrets() => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private static global::PolyType.SourceGenModel.SourceGenAttributeInfo[] __CreateConstructorAttributes_Secrets() => new global::PolyType.SourceGenModel.SourceGenAttributeInfo[]
         {

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
@@ -61,7 +61,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_RefParamDemo,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.RefParamDemo(ref state.Arguments.Item1, in state.Arguments.Item2, out _),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null),
+                MethodBaseFactory = __ConstructorInfo_RefParamDemo,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_RefParamDemo() => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo = 0x3UL;
 
@@ -116,7 +118,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Unit,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_0,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_0,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>((default, default!), count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_0_Update),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => { target!.Update(ref state.Arguments.Item1, in state.Arguments.Item2); return new(global::PolyType.Abstractions.Unit.Value); },
             };
@@ -135,7 +137,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -150,9 +152,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_0() => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_0_Update = 0x3UL;
 
@@ -165,7 +169,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Boolean,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_1,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_1,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<string>(default!, count: 1, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_1_TryGet),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => { var result = target!.TryGet(state.Arguments, out _); return new(result); },
             };
@@ -185,9 +189,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => state.Arguments,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state, string value) => { state.Arguments = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_1()?.GetParameters()[0],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_1() => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_1_TryGet = 0x1UL;
 

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimplePoco,
                 ArgumentStateConstructor = static () => new((default, "default", default), count: 3, requiredArgumentsMask: __RequiredMembersMask_SimplePoco),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => { var obj = new global::TestNamespace.SimplePoco(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.IsActive = state.Arguments.Item3!; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimplePoco,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = "default",
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, bool?>
@@ -120,6 +120,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetProperty("IsActive", __BindingFlags_Instance_All, null, typeof(bool?), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimplePoco() => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_SimplePoco = 0x1UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Debug/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimpleRecord,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_SimpleRecord),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => new global::TestNamespace.SimpleRecord(state.Arguments.Item1, state.Arguments.Item2, state.Arguments.Item3),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimpleRecord,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, bool>
@@ -119,9 +119,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item3,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, bool value) => { state.Arguments.Item3 = value; state.MarkArgumentSet(2); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[2],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[2],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimpleRecord() => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null);
 
         private const ulong __RequiredMembersMask_SimpleRecord = 0x7UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
@@ -59,7 +59,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Pair_Int32_String,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Pair_Int32_String),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.Pair<int, string>(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Pair_Int32_String,
                 IsPublic = true,
             };
         }
@@ -77,7 +77,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -91,9 +91,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Pair_Int32_String() => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Pair_Int32_String = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Address,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Address),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => new global::TestNamespace.Address(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Address,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Address() => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Address = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Person,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Person),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => new global::TestNamespace.Person(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Person,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int)>, int>
@@ -93,9 +93,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Person() => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private const ulong __RequiredMembersMask_Person = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
@@ -97,7 +97,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Secrets,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_Secrets),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => { var obj = __CtorAccessor_Secrets(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.Label = state.Arguments.Item3; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Secrets,
                 AttributeFactory = __CreateConstructorAttributes_Secrets,
             };
         }
@@ -116,7 +116,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, int>
@@ -130,7 +130,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, string>
@@ -147,6 +147,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetProperty("Label", __BindingFlags_Instance_All, null, typeof(string), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Secrets() => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private static global::PolyType.SourceGenModel.SourceGenAttributeInfo[] __CreateConstructorAttributes_Secrets() => new global::PolyType.SourceGenModel.SourceGenAttributeInfo[]
         {

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
@@ -61,7 +61,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_RefParamDemo,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.RefParamDemo(ref state.Arguments.Item1, in state.Arguments.Item2, out _),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null),
+                MethodBaseFactory = __ConstructorInfo_RefParamDemo,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_RefParamDemo() => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo = 0x3UL;
 
@@ -116,7 +118,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Unit,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_0,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_0,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>((default, default!), count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_0_Update),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => { target!.Update(ref state.Arguments.Item1, in state.Arguments.Item2); return new(global::PolyType.Abstractions.Unit.Value); },
             };
@@ -135,7 +137,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -150,9 +152,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_0() => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_0_Update = 0x3UL;
 
@@ -165,7 +169,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Boolean,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_1,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_1,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<string>(default!, count: 1, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_1_TryGet),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => { var result = target!.TryGet(state.Arguments, out _); return new(result); },
             };
@@ -185,9 +189,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => state.Arguments,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state, string value) => { state.Arguments = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_1()?.GetParameters()[0],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_1() => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_1_TryGet = 0x1UL;
 

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimplePoco,
                 ArgumentStateConstructor = static () => new((default, "default", default), count: 3, requiredArgumentsMask: __RequiredMembersMask_SimplePoco),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => { var obj = new global::TestNamespace.SimplePoco(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.IsActive = state.Arguments.Item3!; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimplePoco,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = "default",
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, bool?>
@@ -120,6 +120,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetProperty("IsActive", __BindingFlags_Instance_All, null, typeof(bool?), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimplePoco() => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_SimplePoco = 0x1UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net472-Release/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimpleRecord,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_SimpleRecord),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => new global::TestNamespace.SimpleRecord(state.Arguments.Item1, state.Arguments.Item2, state.Arguments.Item3),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimpleRecord,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, bool>
@@ -119,9 +119,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item3,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, bool value) => { state.Arguments.Item3 = value; state.MarkArgumentSet(2); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[2],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[2],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimpleRecord() => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null);
 
         private const ulong __RequiredMembersMask_SimpleRecord = 0x7UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
@@ -59,7 +59,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Pair_Int32_String,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Pair_Int32_String),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.Pair<int, string>(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Pair_Int32_String,
                 IsPublic = true,
             };
         }
@@ -77,7 +77,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -91,9 +91,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Pair_Int32_String() => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Pair_Int32_String = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Address,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Address),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => new global::TestNamespace.Address(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Address,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Address() => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Address = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Person,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Person),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => new global::TestNamespace.Person(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Person,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int)>, int>
@@ -93,9 +93,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Person() => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private const ulong __RequiredMembersMask_Person = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
@@ -97,7 +97,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Secrets,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_Secrets),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => { var obj = __CtorAccessor_Secrets(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.Label = state.Arguments.Item3; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Secrets,
                 AttributeFactory = __CreateConstructorAttributes_Secrets,
             };
         }
@@ -116,7 +116,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, int>
@@ -130,7 +130,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, string>
@@ -147,6 +147,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetProperty("Label", __BindingFlags_Instance_All, null, typeof(string), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Secrets() => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private static global::PolyType.SourceGenModel.SourceGenAttributeInfo[] __CreateConstructorAttributes_Secrets() => new global::PolyType.SourceGenModel.SourceGenAttributeInfo[]
         {

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
@@ -61,7 +61,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_RefParamDemo,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.RefParamDemo(ref state.Arguments.Item1, in state.Arguments.Item2, out _),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null),
+                MethodBaseFactory = __ConstructorInfo_RefParamDemo,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_RefParamDemo() => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo = 0x3UL;
 
@@ -116,7 +118,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Unit,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_0,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_0,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>((default, default!), count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_0_Update),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => { target!.Update(ref state.Arguments.Item1, in state.Arguments.Item2); return new(global::PolyType.Abstractions.Unit.Value); },
             };
@@ -135,7 +137,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -150,9 +152,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_0() => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_0_Update = 0x3UL;
 
@@ -165,7 +169,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Boolean,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_1,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_1,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<string>(default!, count: 1, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_1_TryGet),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => { var result = target!.TryGet(state.Arguments, out _); return new(result); },
             };
@@ -185,9 +189,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => state.Arguments,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state, string value) => { state.Arguments = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_1()?.GetParameters()[0],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_1() => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_1_TryGet = 0x1UL;
 

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimplePoco,
                 ArgumentStateConstructor = static () => new((default, "default", default), count: 3, requiredArgumentsMask: __RequiredMembersMask_SimplePoco),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => { var obj = new global::TestNamespace.SimplePoco(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.IsActive = state.Arguments.Item3!; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimplePoco,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = "default",
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, bool?>
@@ -120,6 +120,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetProperty("IsActive", __BindingFlags_Instance_All, null, typeof(bool?), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimplePoco() => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_SimplePoco = 0x1UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Debug/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimpleRecord,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_SimpleRecord),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => new global::TestNamespace.SimpleRecord(state.Arguments.Item1, state.Arguments.Item2, state.Arguments.Item3),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimpleRecord,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, bool>
@@ -119,9 +119,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item3,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, bool value) => { state.Arguments.Item3 = value; state.MarkArgumentSet(2); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[2],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[2],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimpleRecord() => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null);
 
         private const ulong __RequiredMembersMask_SimpleRecord = 0x7UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
@@ -59,7 +59,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Pair_Int32_String,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Pair_Int32_String),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.Pair<int, string>(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Pair_Int32_String,
                 IsPublic = true,
             };
         }
@@ -77,7 +77,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -91,9 +91,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Pair_Int32_String() => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Pair_Int32_String = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Address,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Address),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => new global::TestNamespace.Address(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Address,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Address() => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Address = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Person,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Person),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => new global::TestNamespace.Person(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Person,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int)>, int>
@@ -93,9 +93,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Person() => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private const ulong __RequiredMembersMask_Person = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
@@ -97,7 +97,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Secrets,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_Secrets),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => { var obj = __CtorAccessor_Secrets(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.Label = state.Arguments.Item3; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Secrets,
                 AttributeFactory = __CreateConstructorAttributes_Secrets,
             };
         }
@@ -116,7 +116,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, int>
@@ -130,7 +130,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, string>
@@ -147,6 +147,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetProperty("Label", __BindingFlags_Instance_All, null, typeof(string), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Secrets() => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private static global::PolyType.SourceGenModel.SourceGenAttributeInfo[] __CreateConstructorAttributes_Secrets() => new global::PolyType.SourceGenModel.SourceGenAttributeInfo[]
         {

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
@@ -61,7 +61,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_RefParamDemo,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.RefParamDemo(ref state.Arguments.Item1, in state.Arguments.Item2, out _),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null),
+                MethodBaseFactory = __ConstructorInfo_RefParamDemo,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_RefParamDemo() => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo = 0x3UL;
 
@@ -116,7 +118,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Unit,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_0,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_0,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>((default, default!), count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_0_Update),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => { target!.Update(ref state.Arguments.Item1, in state.Arguments.Item2); return new(global::PolyType.Abstractions.Unit.Value); },
             };
@@ -135,7 +137,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -150,9 +152,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_0() => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_0_Update = 0x3UL;
 
@@ -165,7 +169,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Boolean,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_1,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_1,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<string>(default!, count: 1, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_1_TryGet),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => { var result = target!.TryGet(state.Arguments, out _); return new(result); },
             };
@@ -185,9 +189,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => state.Arguments,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state, string value) => { state.Arguments = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_1()?.GetParameters()[0],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_1() => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_1_TryGet = 0x1UL;
 

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimplePoco,
                 ArgumentStateConstructor = static () => new((default, "default", default), count: 3, requiredArgumentsMask: __RequiredMembersMask_SimplePoco),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => { var obj = new global::TestNamespace.SimplePoco(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.IsActive = state.Arguments.Item3!; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimplePoco,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = "default",
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, bool?>
@@ -120,6 +120,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetProperty("IsActive", __BindingFlags_Instance_All, null, typeof(bool?), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimplePoco() => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_SimplePoco = 0x1UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net8.0-Release/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimpleRecord,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_SimpleRecord),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => new global::TestNamespace.SimpleRecord(state.Arguments.Item1, state.Arguments.Item2, state.Arguments.Item3),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimpleRecord,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, bool>
@@ -119,9 +119,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item3,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, bool value) => { state.Arguments.Item3 = value; state.MarkArgumentSet(2); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[2],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[2],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimpleRecord() => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null);
 
         private const ulong __RequiredMembersMask_SimpleRecord = 0x7UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
@@ -59,7 +59,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Pair_Int32_String,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Pair_Int32_String),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.Pair<int, string>(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Pair_Int32_String,
                 IsPublic = true,
             };
         }
@@ -77,7 +77,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -91,9 +91,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Pair_Int32_String() => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Pair_Int32_String = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Address,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Address),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => new global::TestNamespace.Address(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Address,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Address() => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Address = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Person,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Person),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => new global::TestNamespace.Person(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Person,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int)>, int>
@@ -93,9 +93,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Person() => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private const ulong __RequiredMembersMask_Person = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
@@ -97,7 +97,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Secrets,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_Secrets),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => { var obj = __CtorAccessor_Secrets(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.Label = state.Arguments.Item3; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Secrets,
                 AttributeFactory = __CreateConstructorAttributes_Secrets,
             };
         }
@@ -116,7 +116,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, int>
@@ -130,7 +130,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, string>
@@ -147,6 +147,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetProperty("Label", __BindingFlags_Instance_All, null, typeof(string), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Secrets() => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private static global::PolyType.SourceGenModel.SourceGenAttributeInfo[] __CreateConstructorAttributes_Secrets() => new global::PolyType.SourceGenModel.SourceGenAttributeInfo[]
         {

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
@@ -61,7 +61,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_RefParamDemo,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.RefParamDemo(ref state.Arguments.Item1, in state.Arguments.Item2, out _),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null),
+                MethodBaseFactory = __ConstructorInfo_RefParamDemo,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_RefParamDemo() => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo = 0x3UL;
 
@@ -116,7 +118,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Unit,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_0,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_0,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>((default, default!), count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_0_Update),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => { target!.Update(ref state.Arguments.Item1, in state.Arguments.Item2); return new(global::PolyType.Abstractions.Unit.Value); },
             };
@@ -135,7 +137,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -150,9 +152,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_0() => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_0_Update = 0x3UL;
 
@@ -165,7 +169,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Boolean,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_1,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_1,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<string>(default!, count: 1, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_1_TryGet),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => { var result = target!.TryGet(state.Arguments, out _); return new(result); },
             };
@@ -185,9 +189,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => state.Arguments,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state, string value) => { state.Arguments = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_1()?.GetParameters()[0],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_1() => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_1_TryGet = 0x1UL;
 

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimplePoco,
                 ArgumentStateConstructor = static () => new((default, "default", default), count: 3, requiredArgumentsMask: __RequiredMembersMask_SimplePoco),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => { var obj = new global::TestNamespace.SimplePoco(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.IsActive = state.Arguments.Item3!; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimplePoco,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = "default",
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, bool?>
@@ -120,6 +120,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetProperty("IsActive", __BindingFlags_Instance_All, null, typeof(bool?), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimplePoco() => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_SimplePoco = 0x1UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Debug/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimpleRecord,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_SimpleRecord),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => new global::TestNamespace.SimpleRecord(state.Arguments.Item1, state.Arguments.Item2, state.Arguments.Item3),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimpleRecord,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, bool>
@@ -119,9 +119,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item3,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, bool value) => { state.Arguments.Item3 = value; state.MarkArgumentSet(2); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[2],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[2],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimpleRecord() => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null);
 
         private const ulong __RequiredMembersMask_SimpleRecord = 0x7UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/GenericRecord/PolyType.SourceGenerator.TypeShapeProvider.Pair_Int32_String.g.cs.txt
@@ -59,7 +59,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Pair_Int32_String,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Pair_Int32_String),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.Pair<int, string>(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Pair_Int32_String,
                 IsPublic = true,
             };
         }
@@ -77,7 +77,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -91,9 +91,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Pair_Int32_String()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Pair_Int32_String() => typeof(global::TestNamespace.Pair<int, string>).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Pair_Int32_String = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Address.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Address,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Address),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => new global::TestNamespace.Address(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_Address,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Address()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Address() => typeof(global::TestNamespace.Address).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_Address = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/MultiTypeProvider/PolyType.SourceGenerator.TypeShapeProvider.Person.g.cs.txt
@@ -60,7 +60,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Person,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_Person),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => new global::TestNamespace.Person(state.Arguments.Item1, state.Arguments.Item2),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Person,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int)>, int>
@@ -93,9 +93,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Person()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Person() => typeof(global::TestNamespace.Person).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private const ulong __RequiredMembersMask_Person = 0x3UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/PrivateMembers/PolyType.SourceGenerator.TypeShapeProvider.Secrets.g.cs.txt
@@ -97,7 +97,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_Secrets,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_Secrets),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => { var obj = __CtorAccessor_Secrets(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.Label = state.Arguments.Item3; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null),
+                MethodBaseFactory = __ConstructorInfo_Secrets,
                 AttributeFactory = __CreateConstructorAttributes_Secrets,
             };
         }
@@ -116,7 +116,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, string value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, int>
@@ -130,7 +130,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)> state, int value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_Secrets()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(string, int, string)>, string>
@@ -147,6 +147,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.Secrets).GetProperty("Label", __BindingFlags_Instance_All, null, typeof(string), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_Secrets() => typeof(global::TestNamespace.Secrets).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(string), typeof(int) }, null);
 
         private static global::PolyType.SourceGenModel.SourceGenAttributeInfo[] __CreateConstructorAttributes_Secrets() => new global::PolyType.SourceGenModel.SourceGenAttributeInfo[]
         {

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/RefParameters/PolyType.SourceGenerator.TypeShapeProvider.RefParamDemo.g.cs.txt
@@ -61,7 +61,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_RefParamDemo,
                 ArgumentStateConstructor = static () => new(default!, count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => new global::TestNamespace.RefParamDemo(ref state.Arguments.Item1, in state.Arguments.Item2, out _),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null),
+                MethodBaseFactory = __ConstructorInfo_RefParamDemo,
                 IsPublic = true,
             };
         }
@@ -79,7 +79,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -94,9 +94,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_RefParamDemo()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_RefParamDemo() => typeof(global::TestNamespace.RefParamDemo).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType(), typeof(bool).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo = 0x3UL;
 
@@ -116,7 +118,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Unit,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_0,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_0,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>((default, default!), count: 2, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_0_Update),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => { target!.Update(ref state.Arguments.Item1, in state.Arguments.Item2); return new(global::PolyType.Abstractions.Unit.Value); },
             };
@@ -135,7 +137,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string)>, string>
@@ -150,9 +152,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_0()?.GetParameters()[1],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_0() => typeof(global::TestNamespace.RefParamDemo).GetMethod("Update", __BindingFlags_All, null, new global::System.Type[] { typeof(int).MakeByRefType(), typeof(string).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_0_Update = 0x3UL;
 
@@ -165,7 +169,7 @@ namespace PolyType.SourceGenerator
                 DeclaringType = RefParamDemo,
                 ReturnType = Boolean,
                 ParametersFactory = __CreateMethodParameters_RefParamDemo_1,
-                MethodBaseFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null),
+                MethodBaseFactory = __MethodInfo_RefParamDemo_1,
                 ArgumentStateConstructor = static () => new global::PolyType.SourceGenModel.SmallArgumentState<string>(default!, count: 1, requiredArgumentsMask: __RequiredMembersMask_RefParamDemo_1_TryGet),
                 MethodInvoker = static (ref global::TestNamespace.RefParamDemo? target, ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => { var result = target!.TryGet(state.Arguments, out _); return new(result); },
             };
@@ -185,9 +189,11 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state) => state.Arguments,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<string> state, string value) => { state.Arguments = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __MethodInfo_RefParamDemo_1()?.GetParameters()[0],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __MethodInfo_RefParamDemo_1() => typeof(global::TestNamespace.RefParamDemo).GetMethod("TryGet", __BindingFlags_All, null, new global::System.Type[] { typeof(string), typeof(int).MakeByRefType() }, null);
 
         private const ulong __RequiredMembersMask_RefParamDemo_1_TryGet = 0x1UL;
 

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/SimplePoco/PolyType.SourceGenerator.TypeShapeProvider.SimplePoco.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimplePoco,
                 ArgumentStateConstructor = static () => new((default, "default", default), count: 3, requiredArgumentsMask: __RequiredMembersMask_SimplePoco),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => { var obj = new global::TestNamespace.SimplePoco(state.Arguments.Item1, state.Arguments.Item2); if (state.IsArgumentSet(2)) obj.IsActive = state.Arguments.Item3!; return obj; },
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimplePoco,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = "default",
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimplePoco()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool?)>, bool?>
@@ -120,6 +120,8 @@ namespace PolyType.SourceGenerator
                 ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimplePoco).GetProperty("IsActive", __BindingFlags_Instance_All, null, typeof(bool?), global::System.Type.EmptyTypes, null),
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimplePoco() => typeof(global::TestNamespace.SimplePoco).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string) }, null);
 
         private const ulong __RequiredMembersMask_SimplePoco = 0x1UL;
     }

--- a/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
+++ b/tests/PolyType.SourceGenerator.UnitTests/Snapshots/net9.0-Release/SimpleRecord/PolyType.SourceGenerator.TypeShapeProvider.SimpleRecord.g.cs.txt
@@ -72,7 +72,7 @@ namespace PolyType.SourceGenerator
                 ParametersFactory = __CreateConstructorParameters_SimpleRecord,
                 ArgumentStateConstructor = static () => new(default!, count: 3, requiredArgumentsMask: __RequiredMembersMask_SimpleRecord),
                 ParameterizedConstructor = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => new global::TestNamespace.SimpleRecord(state.Arguments.Item1, state.Arguments.Item2, state.Arguments.Item3),
-                MethodBaseFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null),
+                MethodBaseFactory = __ConstructorInfo_SimpleRecord,
                 IsPublic = true,
             };
         }
@@ -90,7 +90,7 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item1,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, int value) => { state.Arguments.Item1 = value; state.MarkArgumentSet(0); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[0],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[0],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, string>
@@ -105,7 +105,7 @@ namespace PolyType.SourceGenerator
                 DefaultValue = default!,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item2,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, string value) => { state.Arguments.Item2 = value; state.MarkArgumentSet(1); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[1],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[1],
             },
 
             new global::PolyType.SourceGenModel.SourceGenParameterShape<global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)>, bool>
@@ -119,9 +119,11 @@ namespace PolyType.SourceGenerator
                 IsPublic = true,
                 Getter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state) => state.Arguments.Item3,
                 Setter = static (ref global::PolyType.SourceGenModel.SmallArgumentState<(int, string, bool)> state, bool value) => { state.Arguments.Item3 = value; state.MarkArgumentSet(2); },
-                ReflectionInfoFactory = static () => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null)?.GetParameters()[2],
+                ReflectionInfoFactory = static () => __ConstructorInfo_SimpleRecord()?.GetParameters()[2],
             },
         };
+
+        private static global::System.Reflection.MethodBase? __ConstructorInfo_SimpleRecord() => typeof(global::TestNamespace.SimpleRecord).GetConstructor(__BindingFlags_Instance_All, null, new global::System.Type[] { typeof(int), typeof(string), typeof(bool) }, null);
 
         private const ulong __RequiredMembersMask_SimpleRecord = 0x7UL;
     }

--- a/tests/PolyType.Tests.NativeAOT/ReflectionInfoTests.cs
+++ b/tests/PolyType.Tests.NativeAOT/ReflectionInfoTests.cs
@@ -1,0 +1,61 @@
+using PolyType.Abstractions;
+using System.Reflection;
+
+namespace PolyType.Tests.NativeAOT;
+
+/// <summary>
+/// Verifies that the reflection metadata exposed by source-generated shapes
+/// (<see cref="IConstructorShape.MethodBase"/>, <see cref="IMethodShape.MethodBase"/> and
+/// <see cref="IParameterShape.ParameterInfo"/>) resolves correctly under Native AOT.
+/// These accessors are backed by <c>typeof(T).GetConstructor(...)</c> / <c>GetMethod(...)</c>
+/// lookups in the generated code, so this doubles as a guard that reading them roots the
+/// necessary member metadata and it is not trimmed away.
+/// </summary>
+public class ReflectionInfoTests
+{
+    [Test]
+    public async Task ConstructorMethodBaseResolves()
+    {
+        var objectShape = TypeShapeResolver.Resolve<SimpleTestData>() as IObjectTypeShape<SimpleTestData>;
+        await Assert.That(objectShape).IsNotNull();
+
+        IConstructorShape? ctor = objectShape!.Constructor;
+        await Assert.That(ctor).IsNotNull();
+
+        MethodBase? methodBase = ctor!.MethodBase;
+        await Assert.That(methodBase).IsNotNull();
+        await Assert.That(methodBase is ConstructorInfo).IsTrue();
+        await Assert.That(methodBase!.GetParameters().Length).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task ConstructorParameterInfoResolves()
+    {
+        var objectShape = (IObjectTypeShape<SimpleTestData>)TypeShapeResolver.Resolve<SimpleTestData>();
+        IConstructorShape ctor = objectShape.Constructor!;
+
+        IParameterShape parameter = ctor.Parameters.First(p => p.Position == 0);
+        ParameterInfo? parameterInfo = parameter.ParameterInfo;
+
+        await Assert.That(parameterInfo).IsNotNull();
+        await Assert.That(parameterInfo!.Name).IsEqualTo(nameof(SimpleTestData.IntValue));
+        await Assert.That(parameterInfo.Position).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task MethodBaseAndParameterInfoResolve()
+    {
+        var serviceShape = TypeShapeResolver.Resolve<TestRpcService>();
+        IMethodShape method = serviceShape.Methods.First(m => m.Name == nameof(TestRpcService.AddPersonAsync));
+
+        MethodBase? methodBase = method.MethodBase;
+        await Assert.That(methodBase).IsNotNull();
+        await Assert.That(methodBase is MethodInfo).IsTrue();
+        await Assert.That(methodBase!.Name).IsEqualTo(nameof(TestRpcService.AddPersonAsync));
+
+        IParameterShape parameter = method.Parameters.First(p => p.Name == "person");
+        ParameterInfo? parameterInfo = parameter.ParameterInfo;
+        await Assert.That(parameterInfo).IsNotNull();
+        await Assert.That(parameterInfo!.Name).IsEqualTo("person");
+    }
+}


### PR DESCRIPTION
## Summary

Reduces duplicated reflection-resolution code in source-generated `ITypeShape` implementations by lifting the per-shape `MethodBase`/`ConstructorInfo`/`MethodInfo` lookup into a shared helper that every parameter shape calls into.

For a constructor or method with **M** shaped parameters, the generator previously emitted the identical `typeof(T).GetConstructor(...)` / `GetMethod(...)` signature lookup **M+1** times — once on `MethodBaseFactory` and once per parameter's `ReflectionInfoFactory`. This consolidates that into a single shared:

- `private static MethodBase? __ConstructorInfo_{id}()` (constructors)
- `private static MethodBase? __MethodInfo_{id}_{pos}()` (methods)

referenced as a method group by `MethodBaseFactory` and called as `…()?.GetParameters()[i]` by each parameter.

## Details

- **Gated on ≥2 call sites** — parameterless constructors and zero-argument methods stay inline and byte-identical to before, so the indirection is only introduced where it actually removes duplication.
- **Signatures preserved exactly**, including `out` parameters lowered to `MakeByRefType()` (verified against the `RefParamDemo` snapshot).
- **Pay-for-play trimming unchanged** — when the reflection-info accessors are never read, the shared helper is unreferenced and trimmed away under Native AOT, exactly as the inline lookups were.

## Native AOT coverage (new)

There was previously no AOT test exercising `IConstructorShape.MethodBase`, `IMethodShape.MethodBase`, or `IParameterShape.ParameterInfo` — so nothing rooted these lookups under trimming. This adds `ReflectionInfoTests` to `PolyType.Tests.NativeAOT` that reads that metadata and asserts it resolves correctly. It doubles as a guard that reading these accessors roots the member metadata and it is not trimmed. Verified against a real `dotnet publish` AOT build: links with **no IL trim/AOT warnings** and all tests pass from the native binary.

## Measured size impact

Clean same-machine A/B on the `SizeTrackingApp.AOT` canary (win-x64, .NET 10):

| Build | Native exe size | Delta |
|---|---|---|
| Pre-change | 2,543,104 B | baseline |
| This PR | 2,541,056 B | **−2,048 B (−0.081%)** |

The pre-change build reproduced the committed CI baseline exactly to the byte, confirming determinism, so the reduction is attributable to this change. The saving is small on a serialization-only app (most reflection-info is trimmed) but scales for apps that actively consume reflection-info, where the M+1 duplication is most present. Well within the committed AOT-size tolerance, so no baseline update.

## Validation

- Generator builds clean (0 warnings).
- Snapshot suite: **834 tests pass without the update flag** across net472/net8.0/net9.0 (baselines match emission).
- Full `PolyType.Tests` runtime suite: **69,970 passed / 0 failed** — including `AttributeProviderTests`/`TypeShapeProviderTests` that read `.MethodBase`/`.ParameterInfo`/`.MemberInfo`/`.AttributeProvider` through the new shared-resolver path.
- Native AOT suite: **29 passed / 0 failed** (26 existing + 3 new) from the published native binary.

No public API changes; generated-code and tests only.