### PR TITLE
Fix ReflectionProvider bug on inheritance

### DIFF
--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -615,6 +615,12 @@ public sealed partial class Parser : TypeDataModelGenerator
                 }
 
                 derivedType = dt;
+
+                // Only consider derived types, KnownTypeAttribute can be used for AssociatedTypes purposes
+                if (!type.IsAssignableFrom(derivedType))
+                {
+                    continue;
+                }
             }
             else
             {

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -615,12 +615,6 @@ public sealed partial class Parser : TypeDataModelGenerator
                 }
 
                 derivedType = dt;
-
-                // Only consider derived types, KnownTypeAttribute can be used for AssociatedTypes purposes
-                if (!type.IsAssignableFrom(derivedType))
-                {
-                    continue;
-                }
             }
             else
             {

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -310,8 +310,6 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
 
                     return attr.Type;
                 })
-                // Only consider derived types, KnownTypeAttribute can be used for AssociatedTypes purposes
-                .Where(type => unionType.IsAssignableFrom(type))
                 .Select(t => new DerivedTypeShapeAttribute(t));
 
             derivedTypeAttributes.AddRange(mappedKnownTypeAttributes);

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -294,13 +294,13 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
             return (IUnionTypeShape)Activator.CreateInstance(fsharpUnionTypeTy, fSharpUnionInfo, this, options)!;
         }
 
-        List<DerivedTypeShapeAttribute> derivedTypeAttributes = unionType.GetCustomAttributes<DerivedTypeShapeAttribute>().ToList();
+        List<DerivedTypeShapeAttribute> derivedTypeAttributes = unionType.GetCustomAttributes<DerivedTypeShapeAttribute>(inherit: false).ToList();
 
         // Honor KnownTypeAttribute annotations only when no DerivedTypeShapeAttribute is present,
         // which takes precedence over KnownTypeAttribute.
         if (derivedTypeAttributes.Count == 0)
         {
-            var mappedKnownTypeAttributes = unionType.GetCustomAttributes<KnownTypeAttribute>()
+            var mappedKnownTypeAttributes = unionType.GetCustomAttributes<KnownTypeAttribute>(inherit: false)
                 .Select(attr =>
                 {
                     if (attr.Type is null)
@@ -308,8 +308,11 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
                         throw new NotSupportedException("KnownTypeAttribute annotations using methods are not supported.");
                     }
 
-                    return new DerivedTypeShapeAttribute(attr.Type);
-                });
+                    return attr.Type;
+                })
+                // Only consider derived types, KnownTypeAttribute can be used for AssociatedTypes purposes
+                .Where(type => unionType.IsAssignableFrom(type) && type != unionType)
+                .Select(t => new DerivedTypeShapeAttribute(t));
 
             derivedTypeAttributes.AddRange(mappedKnownTypeAttributes);
         }

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -311,7 +311,7 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
                     return attr.Type;
                 })
                 // Only consider derived types, KnownTypeAttribute can be used for AssociatedTypes purposes
-                .Where(type => unionType.IsAssignableFrom(type) && type != unionType)
+                .Where(type => unionType.IsAssignableFrom(type))
                 .Select(t => new DerivedTypeShapeAttribute(t));
 
             derivedTypeAttributes.AddRange(mappedKnownTypeAttributes);

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProvider.cs
@@ -308,9 +308,8 @@ public class ReflectionTypeShapeProvider : ITypeShapeProvider
                         throw new NotSupportedException("KnownTypeAttribute annotations using methods are not supported.");
                     }
 
-                    return attr.Type;
-                })
-                .Select(t => new DerivedTypeShapeAttribute(t));
+                    return new DerivedTypeShapeAttribute(attr.Type);
+                });
 
             derivedTypeAttributes.AddRange(mappedKnownTypeAttributes);
         }

--- a/tests/PolyType.Tests/DataContractShapeTests.cs
+++ b/tests/PolyType.Tests/DataContractShapeTests.cs
@@ -89,9 +89,19 @@ public abstract partial class DataContractShapeTests(ProviderUnderTest providerU
     {
         var shape = Assert.IsType<IUnionTypeShape>(providerUnderTest.Provider.GetTypeShape(typeof(Animal)), exactMatch: false);
 
-        Assert.Equal(2, shape.UnionCases.Count);
+        Assert.Equal(3, shape.UnionCases.Count);
         Assert.Contains(shape.UnionCases, c => c.UnionCaseType.Type == typeof(Dog));
         Assert.Contains(shape.UnionCases, c => c.UnionCaseType.Type == typeof(Cat));
+        Assert.Contains(shape.UnionCases, c => c.UnionCaseType.Type == typeof(PersianCat));
+    }
+
+    [Fact]
+    public void KnownTypeAttribute_DerivedTypesReportsUnionShape()
+    {
+        var shape = Assert.IsType<IUnionTypeShape>(providerUnderTest.Provider.GetTypeShape(typeof(Cat)), exactMatch: false);
+
+        Assert.Single(shape.UnionCases);
+        Assert.Contains(shape.UnionCases, c => c.UnionCaseType.Type == typeof(PersianCat));
     }
 
     [Fact]
@@ -193,6 +203,7 @@ public abstract partial class DataContractShapeTests(ProviderUnderTest providerU
     [DataContract]
     [KnownType(typeof(Dog))]
     [KnownType(typeof(Cat))]
+    [KnownType(typeof(PersianCat))]
     public partial class Animal
     {
         [DataMember(Order = 0)] public string? Name { get; set; }
@@ -204,10 +215,19 @@ public abstract partial class DataContractShapeTests(ProviderUnderTest providerU
         [DataMember(Order = 1)] public bool Barks { get; set; }
     }
 
+    [GenerateShape]
     [DataContract]
-    public class Cat : Animal
+    [KnownType(typeof(PersianCat))]
+    public partial class Cat : Animal
     {
         [DataMember(Order = 1)] public int Lives { get; set; }
+    }
+
+    [DataContract]
+    public class PersianCat : Cat
+    {
+        [DataMember(Order = 2)] public string? FurColor { get; set; }
+        [DataMember(Order = 3)] public bool RequiresGrooming { get; set; }
     }
 
     [GenerateShape]


### PR DESCRIPTION
The reflection provider currently fails with 
System.InvalidOperationException is not a valid subtype of 'b' for the inheritance scenario in updated test case. The bug is present for both KnownTypeAttribute and DerivedTypeShapeAttribute that unintentionally includes attributes on base classes (in contrast to code generation provider).


**Enhancements to test coverage:**

* Added `PersianCat` as a derived type of `Cat` and updated the test data model to reflect this deeper inheritance. [[1]](diffhunk://#diff-25ba926f35c0b7abe0c934b8f20704245ba5edd8f5ff5cdd50d18acc9ec3eedaR218-R232) [[2]](diffhunk://#diff-25ba926f35c0b7abe0c934b8f20704245ba5edd8f5ff5cdd50d18acc9ec3eedaR206)
* Modified the `KnownTypeAttribute_ReportsUnionShape` test to expect three union cases (`Dog`, `Cat`, and `PersianCat`) for `Animal`.
* Added a new test `KnownTypeAttribute_DerivedTypesReportsUnionShape` to verify that only `PersianCat` is recognized as a union case for `Cat`. So that shapes from base classes are not propagated.