### PR TITLE
Select reflection member accessor based on IsDynamicCodeCompiled

### DIFF
--- a/src/PolyType/AGENTS.md
+++ b/src/PolyType/AGENTS.md
@@ -38,7 +38,7 @@ These types live under `Abstractions/` and are meant to be consumed by *librarie
 
 ### `ReflectionProvider/`
 
-The **runtime reflection-based provider**: `ReflectionTypeShapeProvider` uses `System.Reflection` to build shapes on the fly, with no build-time step. Where available it uses `Reflection.Emit`-based member accessors (under `MemberAccessors/`) for performance, falling back to plain reflection otherwise. These implementations are **not trimming- or AOT-safe** — they depend on unreferenced/dynamic code — so the source-generated provider is the path for those scenarios.
+The **runtime reflection-based provider**: `ReflectionTypeShapeProvider` uses `System.Reflection` to build shapes on the fly, with no build-time step. By default it uses `Reflection.Emit`-based member accessors (under `MemberAccessors/`) for performance on runtimes that JIT-compile dynamic code (`RuntimeFeature.IsDynamicCodeCompiled`), and falls back to plain reflection accessors otherwise — including on runtimes where dynamic code is supported but only interpreted (Mono interpreter, WebAssembly, iOS), where emitted IL would offer no throughput benefit. Both accessor implementations propagate user-code exceptions unwrapped (never as `TargetInvocationException`). These implementations are **not trimming- or AOT-safe** — they depend on unreferenced/dynamic code — so the source-generated provider is the path for those scenarios.
 
 ### `SourceGenModel/`
 

--- a/src/PolyType/AGENTS.md
+++ b/src/PolyType/AGENTS.md
@@ -38,7 +38,7 @@ These types live under `Abstractions/` and are meant to be consumed by *librarie
 
 ### `ReflectionProvider/`
 
-The **runtime reflection-based provider**: `ReflectionTypeShapeProvider` uses `System.Reflection` to build shapes on the fly, with no build-time step. By default it uses `Reflection.Emit`-based member accessors (under `MemberAccessors/`) for performance on runtimes that JIT-compile dynamic code (`RuntimeFeature.IsDynamicCodeCompiled`), and falls back to plain reflection accessors otherwise — including on runtimes where dynamic code is supported but only interpreted (Mono interpreter, WebAssembly, iOS), where emitted IL would offer no throughput benefit. Both accessor implementations propagate user-code exceptions unwrapped (never as `TargetInvocationException`). These implementations are **not trimming- or AOT-safe** — they depend on unreferenced/dynamic code — so the source-generated provider is the path for those scenarios.
+The **runtime reflection-based provider**: `ReflectionTypeShapeProvider` uses `System.Reflection` to build shapes on the fly, with no build-time step. Where available it uses `Reflection.Emit`-based member accessors (under `MemberAccessors/`) for performance, falling back to plain reflection otherwise. These implementations are **not trimming- or AOT-safe** — they depend on unreferenced/dynamic code — so the source-generated provider is the path for those scenarios.
 
 ### `SourceGenModel/`
 

--- a/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionMemberAccessor.cs
@@ -467,7 +467,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
 
                     if (member is PropertyInfo prop)
                     {
-                        prop.GetSetMethod(nonPublic: true)!.InvokeNoWrapExceptions(obj, [memberArgs[i]]);
+                        prop.SetMethod!.InvokeNoWrapExceptions(obj, [memberArgs[i]]);
                     }
                     else
                     {

--- a/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionMemberAccessor.cs
@@ -142,11 +142,11 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
     public Setter<TDeclaringType?, TEventHandler> CreateEventAccessor<TDeclaringType, TEventHandler>(MethodInfo accessor)
     {
         return !typeof(TDeclaringType).IsValueType
-            ? (ref TDeclaringType? target, TEventHandler handler) => accessor.Invoke(target, [handler])
+            ? (ref TDeclaringType? target, TEventHandler handler) => accessor.InvokeNoWrapExceptions(target, [handler])
             : (ref TDeclaringType? target, TEventHandler handler) =>
             {
                 object? boxedTarget = target;
-                accessor.Invoke(boxedTarget, [handler]);
+                accessor.InvokeNoWrapExceptions(boxedTarget, [handler]);
                 target = (TDeclaringType?)boxedTarget;
             };
     }
@@ -154,11 +154,11 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
     public EnumerableAppender<TEnumerable, TElement> CreateEnumerableAppender<TEnumerable, TElement>(MethodInfo addMethod)
     {
         return !typeof(TEnumerable).IsValueType
-        ? (ref TEnumerable enumerable, TElement element) => addMethod.Invoke(enumerable, [element]) is not bool success || success
+        ? (ref TEnumerable enumerable, TElement element) => addMethod.InvokeNoWrapExceptions(enumerable, [element]) is not bool success || success
         : (ref TEnumerable enumerable, TElement element) =>
         {
             object boxed = enumerable!;
-            bool success = addMethod.Invoke(boxed, [element]) is not bool s || s;
+            bool success = addMethod.InvokeNoWrapExceptions(boxed, [element]) is not bool s || s;
             enumerable = (TEnumerable)boxed;
             return success;
         };
@@ -245,7 +245,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
         Debug.Assert(ctorInfo.Parameters is []);
         Debug.Assert(ctorInfo is MethodShapeInfo);
         return ((MethodShapeInfo)ctorInfo).Method is { } cI
-            ? () => (TDeclaringType)cI.Invoke(null)!
+            ? () => (TDeclaringType)cI.InvokeNoWrapExceptions(null)!
             : static () => default(TDeclaringType)!;
     }
 
@@ -419,7 +419,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
                         localParams[arity] = result;
                     }
 
-                    result = ctorInfo.Invoke(localParams);
+                    result = ctorInfo.InvokeNoWrapExceptions(localParams);
                     i -= arity;
                 }
 
@@ -437,7 +437,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
                 return (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<LargeArgumentState<(object?[], object?[])>, TDeclaringType>(
                     (ref LargeArgumentState<(object?[] ctorArgs, object?[] memberArgs)> state) =>
                     {
-                        object obj = ctor.Invoke(state.Arguments.ctorArgs)!;
+                        object obj = ctor.InvokeNoWrapExceptions(state.Arguments.ctorArgs)!;
                         PopulateMemberInitializers(ref state, obj, ctorArity, memberInitializers, state.Arguments.memberArgs);
                         return (TDeclaringType)obj!;
                     });
@@ -467,7 +467,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
 
                     if (member is PropertyInfo prop)
                     {
-                        prop.SetValue(obj, memberArgs[i]);
+                        prop.GetSetMethod(nonPublic: true)!.InvokeNoWrapExceptions(obj, [memberArgs[i]]);
                     }
                     else
                     {
@@ -481,7 +481,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
         Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<object?[]>));
         var cI = ((MethodShapeInfo)ctorInfo).Method!;
         return (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<LargeArgumentState<object?[]>, TDeclaringType>(
-            (ref LargeArgumentState<object?[]> state) => (TDeclaringType)cI.Invoke(state.Arguments)!);
+            (ref LargeArgumentState<object?[]> state) => (TDeclaringType)cI.InvokeNoWrapExceptions(state.Arguments)!);
     }
 
     public MethodInvoker<TDeclaringType?, TArgumentState, TResult> CreateMethodInvoker<TDeclaringType, TArgumentState, TResult>(MethodShapeInfo ctorInfo) where TArgumentState : IArgumentState
@@ -496,7 +496,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
             return (ref TDeclaringType? target, ref TArgumentState _) =>
             {
                 object? boxedTarget = target;
-                object? result = methodInfo.Invoke(boxedTarget, []);
+                object? result = methodInfo.InvokeNoWrapExceptions(boxedTarget, []);
                 target = (TDeclaringType?)boxedTarget;
                 return returnMarshaler(result);
             };
@@ -507,7 +507,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
             (ref TDeclaringType? target, ref LargeArgumentState<object?[]> state) =>
             {
                 object? boxedTarget = target;
-                object? result = methodInfo.Invoke(boxedTarget, state.Arguments);
+                object? result = methodInfo.InvokeNoWrapExceptions(boxedTarget, state.Arguments);
                 target = (TDeclaringType?)boxedTarget;
                 return returnMarshaler(result);
             });
@@ -526,7 +526,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
             return (MethodInvoker<TFunction, TArgumentState, TResult>)(object)new MethodInvoker<TFunction, EmptyArgumentState, TResult>(
                 (ref TFunction target, ref EmptyArgumentState state) =>
                 {
-                    object? result = invokeMethod.Invoke(target, args);
+                    object? result = invokeMethod.InvokeNoWrapExceptions(target, args);
                     return resultMarshaler(result);
                 });
         }
@@ -541,7 +541,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
                 foreach (MethodInfo method in funcInfo.CurriedInvocationChain)
                 {
                     args[0] = state.Arguments[i++];
-                    current = method.Invoke(current, args);
+                    current = method.InvokeNoWrapExceptions(current, args);
                 }
 
                 return resultMarshaler(current);
@@ -708,7 +708,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
                 argumentSetters[i]([], opts, args);
             }
 
-            return (TDeclaringType)ctorInfo.Invoke(args)!;
+            return (TDeclaringType)ctorInfo.InvokeNoWrapExceptions(args)!;
         };
     }
 
@@ -739,7 +739,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
                 argumentSetters[i](span, opts, args);
             }
 
-            return (TCollection)factory.Invoke(args)!;
+            return (TCollection)factory.InvokeNoWrapExceptions(args)!;
         };
     }
 

--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProviderOptions.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProviderOptions.cs
@@ -16,9 +16,13 @@ public sealed record ReflectionTypeShapeProviderOptions
     /// Gets a value indicating whether System.Reflection.Emit should be used when generating member accessors.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>true</c> if the runtime supports dynamic code generation.
+    /// Defaults to <c>true</c> if the runtime supports and JIT-compiles dynamic code.
+    /// On runtimes where dynamic code is supported but only interpreted (such as the Mono interpreter,
+    /// WebAssembly and iOS), the emitted IL would itself be interpreted, offering no throughput benefit
+    /// over plain reflection while still pulling in the System.Reflection.Emit stack; the default is
+    /// therefore <c>false</c> in those environments.
     /// </remarks>
-    public bool UseReflectionEmit { get; init; } = ReflectionHelpers.IsDynamicCodeSupported;
+    public bool UseReflectionEmit { get; init; } = ReflectionHelpers.IsDynamicCodeCompiled;
 
     /// <summary>
     /// Gets the list of assemblies to scan for <see cref="TypeShapeExtensionAttribute"/> attributes.

--- a/src/Shared/Helpers/ReflectionHelpers.cs
+++ b/src/Shared/Helpers/ReflectionHelpers.cs
@@ -330,12 +330,6 @@ internal static class ReflectionHelpers
 #endif
     }
 
-    public static object? Invoke(this MethodBase methodBase, params object?[]? args)
-    {
-        DebugExt.Assert(methodBase is ConstructorInfo or MethodBase { IsStatic: true });
-        return methodBase is ConstructorInfo ctor ? ctor.Invoke(args) : methodBase.Invoke(null, args);
-    }
-
     /// <summary>
     /// Invokes the specified constructor or static factory method without wrapping any exception
     /// thrown by the invoked member in a <see cref="TargetInvocationException"/>. This matches the

--- a/src/Shared/Helpers/ReflectionHelpers.cs
+++ b/src/Shared/Helpers/ReflectionHelpers.cs
@@ -366,7 +366,8 @@ internal static class ReflectionHelpers
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)
         {
-            throw RethrowInnerException(ex);
+            ExceptionDispatchInfo.Capture(ex.InnerException!).Throw();
+            throw; // unreachable
         }
 #endif
     }
@@ -390,26 +391,11 @@ internal static class ReflectionHelpers
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)
         {
-            throw RethrowInnerException(ex);
+            ExceptionDispatchInfo.Capture(ex.InnerException!).Throw();
+            throw; // unreachable
         }
 #endif
     }
-
-#if !NET
-    /// <summary>
-    /// Re-throws the inner exception of a reflection <see cref="TargetInvocationException"/> while
-    /// preserving its original stack trace, so user-code exceptions surface exactly as the
-    /// Reflection.Emit accessor would raise them. On .NET this is handled natively via
-    /// <see cref="BindingFlags.DoNotWrapExceptions"/>, so this helper is only compiled downlevel.
-    /// </summary>
-    /// <param name="ex">The wrapper exception whose <see cref="Exception.InnerException"/> should be re-thrown.</param>
-    /// <returns>Never returns; declared to return an exception so callers can write <c>throw RethrowInnerException(ex);</c>.</returns>
-    private static TargetInvocationException RethrowInnerException(TargetInvocationException ex)
-    {
-        ExceptionDispatchInfo.Capture(ex.InnerException!).Throw();
-        return ex; // unreachable
-    }
-#endif
 
     public static bool IsMemoryType(this Type type, [NotNullWhen(true)] out Type? elementType, out bool isReadOnlyMemory)
     {

--- a/src/Shared/Helpers/ReflectionHelpers.cs
+++ b/src/Shared/Helpers/ReflectionHelpers.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -26,6 +27,23 @@ internal static class ReflectionHelpers
 
         // Check for the presence of the property in .NET 6+.
         PropertyInfo? prop = Type.GetType("System.Runtime.CompilerServices.RuntimeFeature")?.GetProperty("IsDynamicCodeSupported", BindingFlags.Public | BindingFlags.Static);
+        return prop is not null && (bool)prop.GetValue(null);
+#endif
+    }
+
+    public static bool IsDynamicCodeCompiled { get; } = IsDynamicCodeCompiledCore();
+    private static bool IsDynamicCodeCompiledCore()
+    {
+#if NET
+        return RuntimeFeature.IsDynamicCodeCompiled;
+#else
+        if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.Ordinal))
+        {
+            return true; // .NET Framework JIT-compiles dynamic code.
+        }
+
+        // Check for the presence of the property in .NET 6+.
+        PropertyInfo? prop = Type.GetType("System.Runtime.CompilerServices.RuntimeFeature")?.GetProperty("IsDynamicCodeCompiled", BindingFlags.Public | BindingFlags.Static);
         return prop is not null && (bool)prop.GetValue(null);
 #endif
     }
@@ -316,6 +334,73 @@ internal static class ReflectionHelpers
     {
         DebugExt.Assert(methodBase is ConstructorInfo or MethodBase { IsStatic: true });
         return methodBase is ConstructorInfo ctor ? ctor.Invoke(args) : methodBase.Invoke(null, args);
+    }
+
+    /// <summary>
+    /// Invokes the specified constructor or static factory method without wrapping any exception
+    /// thrown by the invoked member in a <see cref="TargetInvocationException"/>. This matches the
+    /// behavior of the Reflection.Emit-based accessor, which emits direct calls into user code.
+    /// </summary>
+    /// <param name="methodBase">The constructor or static method to invoke.</param>
+    /// <param name="args">The arguments to pass to the invocation.</param>
+    /// <returns>The result of the invocation.</returns>
+    public static object? InvokeNoWrapExceptions(this MethodBase methodBase, params object?[]? args)
+    {
+        DebugExt.Assert(methodBase is ConstructorInfo or MethodBase { IsStatic: true });
+        return methodBase is ConstructorInfo ctor
+            ? ctor.InvokeNoWrapExceptions(args)
+            : methodBase.InvokeNoWrapExceptions(null, args);
+    }
+
+    /// <summary>
+    /// Invokes <paramref name="methodBase"/> against <paramref name="obj"/> without wrapping any
+    /// exception thrown by the target method in a <see cref="TargetInvocationException"/>. This
+    /// matches the behavior of the Reflection.Emit-based accessor, which emits direct calls.
+    /// </summary>
+    /// <param name="methodBase">The method to invoke.</param>
+    /// <param name="obj">The target instance, or <see langword="null"/> for static methods.</param>
+    /// <param name="parameters">The arguments to pass to the invocation.</param>
+    /// <returns>The result of the invocation.</returns>
+    public static object? InvokeNoWrapExceptions(this MethodBase methodBase, object? obj, object?[]? parameters)
+    {
+#if NET
+        return methodBase.Invoke(obj, BindingFlags.DoNotWrapExceptions, binder: null, parameters, culture: null);
+#else
+        try
+        {
+            return methodBase.Invoke(obj, parameters);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw; // unreachable
+        }
+#endif
+    }
+
+    /// <summary>
+    /// Invokes <paramref name="constructorInfo"/> without wrapping any exception thrown by the
+    /// constructor in a <see cref="TargetInvocationException"/>. This matches the behavior of the
+    /// Reflection.Emit-based accessor, which emits direct calls into user code.
+    /// </summary>
+    /// <param name="constructorInfo">The constructor to invoke.</param>
+    /// <param name="parameters">The arguments to pass to the constructor.</param>
+    /// <returns>The newly constructed instance.</returns>
+    public static object InvokeNoWrapExceptions(this ConstructorInfo constructorInfo, object?[]? parameters)
+    {
+#if NET
+        return constructorInfo.Invoke(BindingFlags.DoNotWrapExceptions, binder: null, parameters, culture: null);
+#else
+        try
+        {
+            return constructorInfo.Invoke(parameters);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw; // unreachable
+        }
+#endif
     }
 
     public static bool IsMemoryType(this Type type, [NotNullWhen(true)] out Type? elementType, out bool isReadOnlyMemory)

--- a/src/Shared/Helpers/ReflectionHelpers.cs
+++ b/src/Shared/Helpers/ReflectionHelpers.cs
@@ -372,8 +372,7 @@ internal static class ReflectionHelpers
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)
         {
-            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-            throw; // unreachable
+            throw RethrowInnerException(ex);
         }
 #endif
     }
@@ -397,11 +396,26 @@ internal static class ReflectionHelpers
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)
         {
-            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-            throw; // unreachable
+            throw RethrowInnerException(ex);
         }
 #endif
     }
+
+#if !NET
+    /// <summary>
+    /// Re-throws the inner exception of a reflection <see cref="TargetInvocationException"/> while
+    /// preserving its original stack trace, so user-code exceptions surface exactly as the
+    /// Reflection.Emit accessor would raise them. On .NET this is handled natively via
+    /// <see cref="BindingFlags.DoNotWrapExceptions"/>, so this helper is only compiled downlevel.
+    /// </summary>
+    /// <param name="ex">The wrapper exception whose <see cref="Exception.InnerException"/> should be re-thrown.</param>
+    /// <returns>Never returns; declared to return an exception so callers can write <c>throw RethrowInnerException(ex);</c>.</returns>
+    private static TargetInvocationException RethrowInnerException(TargetInvocationException ex)
+    {
+        ExceptionDispatchInfo.Capture(ex.InnerException!).Throw();
+        return ex; // unreachable
+    }
+#endif
 
     public static bool IsMemoryType(this Type type, [NotNullWhen(true)] out Type? elementType, out bool isReadOnlyMemory)
     {

--- a/tests/PolyType.Tests/MemberAccessorExceptionTests.cs
+++ b/tests/PolyType.Tests/MemberAccessorExceptionTests.cs
@@ -1,0 +1,132 @@
+namespace PolyType.Tests;
+
+/// <summary>
+/// Verifies that member accessors surface exceptions thrown by user code without wrapping them
+/// in a <see cref="System.Reflection.TargetInvocationException"/>. The Reflection.Emit accessor
+/// emits direct calls and never wrapped exceptions; this exercises the reflection accessor (and
+/// the source generator) to guarantee the same behavior. See dotnet/runtime#130503.
+/// </summary>
+public abstract partial class MemberAccessorExceptionTests(ProviderUnderTest providerUnderTest)
+{
+    [Fact]
+    public void DefaultConstructor_PropagatesUserExceptionUnwrapped()
+    {
+        var shape = (IObjectTypeShape<ThrowingDefaultConstructor>)providerUnderTest.Provider.GetTypeShapeOrThrow<ThrowingDefaultConstructor>();
+        Func<ThrowingDefaultConstructor>? constructor = shape.GetDefaultConstructor();
+        Assert.NotNull(constructor);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => constructor());
+        Assert.Equal(ThrowingMember.Message, ex.Message);
+    }
+
+    [Fact]
+    public void ParameterizedConstructor_PropagatesUserExceptionUnwrapped()
+    {
+        var shape = (IObjectTypeShape<ThrowingParameterizedConstructor>)providerUnderTest.Provider.GetTypeShapeOrThrow<ThrowingParameterizedConstructor>();
+        Assert.NotNull(shape.Constructor);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => shape.Constructor.Accept(MemberInvoker.Instance));
+        Assert.Equal(ThrowingMember.Message, ex.Message);
+    }
+
+    [Fact]
+    public void PropertyGetter_PropagatesUserExceptionUnwrapped()
+    {
+        var shape = (IObjectTypeShape<ThrowingGetter>)providerUnderTest.Provider.GetTypeShapeOrThrow<ThrowingGetter>();
+        IPropertyShape property = shape.Properties.Single(p => p.Name == nameof(ThrowingGetter.Value));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => property.Accept(MemberInvoker.Instance, new ThrowingGetter()));
+        Assert.Equal(ThrowingMember.Message, ex.Message);
+    }
+
+    [Fact]
+    public void PropertySetter_PropagatesUserExceptionUnwrapped()
+    {
+        var shape = (IObjectTypeShape<ThrowingSetter>)providerUnderTest.Provider.GetTypeShapeOrThrow<ThrowingSetter>();
+        IPropertyShape property = shape.Properties.Single(p => p.Name == nameof(ThrowingSetter.Value));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => property.Accept(MemberInvoker.Instance, new ThrowingSetter()));
+        Assert.Equal(ThrowingMember.Message, ex.Message);
+    }
+
+    private sealed class MemberInvoker : TypeShapeVisitor
+    {
+        public static readonly MemberInvoker Instance = new();
+
+        public override object? VisitConstructor<TDeclaringType, TArgumentState>(IConstructorShape<TDeclaringType, TArgumentState> constructor, object? state)
+        {
+            TArgumentState argumentState = constructor.GetArgumentStateConstructor()();
+            foreach (IParameterShape parameter in constructor.Parameters)
+            {
+                argumentState = (TArgumentState)parameter.Accept(this, argumentState)!;
+            }
+
+            return constructor.GetParameterizedConstructor()(ref argumentState);
+        }
+
+        public override object? VisitParameter<TArgumentState, TParameter>(IParameterShape<TArgumentState, TParameter> parameter, object? state)
+        {
+            var argumentState = (TArgumentState)state!;
+            parameter.GetSetter()(ref argumentState, default!);
+            return argumentState;
+        }
+
+        public override object? VisitProperty<TDeclaringType, TPropertyType>(IPropertyShape<TDeclaringType, TPropertyType> property, object? state)
+        {
+            var obj = (TDeclaringType)state!;
+            TPropertyType value = default!;
+            if (property.HasGetter)
+            {
+                value = property.GetGetter()(ref obj);
+            }
+
+            if (property.HasSetter)
+            {
+                property.GetSetter()(ref obj, value);
+            }
+
+            return null;
+        }
+    }
+
+    private static class ThrowingMember
+    {
+        public const string Message = "Thrown from user code.";
+    }
+
+    public sealed class ThrowingDefaultConstructor
+    {
+        public ThrowingDefaultConstructor() => throw new InvalidOperationException(ThrowingMember.Message);
+    }
+
+    public sealed class ThrowingParameterizedConstructor
+    {
+        public ThrowingParameterizedConstructor(int value) => throw new InvalidOperationException(ThrowingMember.Message);
+
+        public int Value { get; }
+    }
+
+    public sealed class ThrowingGetter
+    {
+        public int Value => throw new InvalidOperationException(ThrowingMember.Message);
+    }
+
+    public sealed class ThrowingSetter
+    {
+        public int Value
+        {
+            get => 0;
+            set => throw new InvalidOperationException(ThrowingMember.Message);
+        }
+    }
+
+    [GenerateShapeFor<ThrowingDefaultConstructor>]
+    [GenerateShapeFor<ThrowingParameterizedConstructor>]
+    [GenerateShapeFor<ThrowingGetter>]
+    [GenerateShapeFor<ThrowingSetter>]
+    protected partial class Witness;
+
+    public sealed class Reflection() : MemberAccessorExceptionTests(ReflectionProviderUnderTest.NoEmit);
+    public sealed class ReflectionEmit() : MemberAccessorExceptionTests(ReflectionProviderUnderTest.Emit);
+    public sealed class SourceGen() : MemberAccessorExceptionTests(new SourceGenProviderUnderTest(Witness.GeneratedTypeShapeProvider));
+}


### PR DESCRIPTION
Ports the fix from [dotnet/runtime#130503](https://github.com/dotnet/runtime/pull/130503) to PolyType's reflection shape provider.

## Motivation

The reflection provider chose its `Reflection.Emit`-based member accessors whenever `RuntimeFeature.IsDynamicCodeSupported` was `true`. On runtimes where dynamic code is *supported but only interpreted* — the Mono interpreter, WebAssembly, and iOS — the emitted IL is itself interpreted, so it offers **no throughput benefit** over plain reflection while still pulling in the un-trimmable `System.Reflection.Emit` stack. `RuntimeFeature.IsDynamicCodeCompiled` is the correct signal for "emitting IL is actually worthwhile."

## Changes

**Primary fix** — accessor selection
- `ReflectionTypeShapeProviderOptions.UseReflectionEmit` now defaults to `ReflectionHelpers.IsDynamicCodeCompiled` instead of `IsDynamicCodeSupported`, so interpreted-only runtimes fall back to plain reflection accessors.
- Added `ReflectionHelpers.IsDynamicCodeCompiled` (uses `RuntimeFeature.IsDynamicCodeCompiled` on `NET`, with a framework/reflection probe downlevel).
- The provider constructor guard remains on `IsDynamicCodeSupported` (unchanged) — only the *default selection* moved.

**Coupled fix** — exception propagation
- To keep behavior identical regardless of which accessor is selected, the reflection accessor now propagates user-code exceptions **unwrapped** instead of surfacing them as `TargetInvocationException`. Added `InvokeNoWrapExceptions` helpers (`BindingFlags.DoNotWrapExceptions` on `NET`; `ExceptionDispatchInfo`-rethrow downlevel) and routed the user-code invoke sites in `ReflectionMemberAccessor` through them. This matches the `Reflection.Emit` accessor, which emits direct calls.

## Tests
- Added `MemberAccessorExceptionTests` asserting that getters, setters, default constructors, and parameterized constructors surface the original user exception (not `TargetInvocationException`) across the reflection, reflection-emit, and source-gen providers. Verified to fail without the coupled fix.
- `make test-clr`: **277919 total, 0 failed** (Release; net8.0/net9.0/net10.0/net472; with coverage + crash/hang dumps).
- `make test-aot`: **29 total, 0 failed** (NativeAOT publish + source-generated smoke test).