### PR TITLE
Modernize C# syntax through C# 14

### DIFF
--- a/eng/AotSizeCheck/Program.cs
+++ b/eng/AotSizeCheck/Program.cs
@@ -323,12 +323,14 @@ internal sealed class Baselines
             throw new InvalidDataException($"Baselines file '{path}' is not a JSON object.");
         }
 
-        Baselines b = new() { _raw = obj };
-
-        b.ToleranceBytes = obj["tolerance_bytes"]?.GetValue<long>()
-            ?? throw new InvalidDataException("Baselines file is missing required field 'tolerance_bytes'.");
-        b.TolerancePercent = obj["tolerance_percent"]?.GetValue<double>()
-            ?? throw new InvalidDataException("Baselines file is missing required field 'tolerance_percent'.");
+        Baselines b = new()
+        {
+            _raw = obj,
+            ToleranceBytes = obj["tolerance_bytes"]?.GetValue<long>()
+                ?? throw new InvalidDataException("Baselines file is missing required field 'tolerance_bytes'."),
+            TolerancePercent = obj["tolerance_percent"]?.GetValue<double>()
+                ?? throw new InvalidDataException("Baselines file is missing required field 'tolerance_percent'."),
+        };
 
         if (obj["platforms"] is JsonObject platforms)
         {

--- a/src/PolyType.Examples/Cloner/Cloner.Builder.cs
+++ b/src/PolyType.Examples/Cloner/Cloner.Builder.cs
@@ -112,7 +112,7 @@ public static partial class Cloner
             var getter = propertyShape.GetGetter();
             var setter = propertyShape.GetSetter();
             return new PropertyCloner<TDeclaringType, TDeclaringType>(
-                (ref TDeclaringType source, ref TDeclaringType target) =>
+                (ref source, ref target) =>
                 {
                     setter(ref target, propertyTypeCloner(getter(ref source))!);
                 });
@@ -127,7 +127,7 @@ public static partial class Cloner
                 var getter = propertyShape.GetGetter();
                 var setter = parameterShape.GetSetter();
                 return new PropertyCloner<TDeclaringType, TArgumentState>(
-                    (ref TDeclaringType source, ref TArgumentState target) =>
+                    (ref source, ref target) =>
                     {
                         TPropertyType value = getter(ref source);
                         setter(ref target, elementCloner(value)!);

--- a/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
+++ b/src/PolyType.Examples/ConfigurationBinder/ConfigurationBinder.Builder.cs
@@ -104,14 +104,14 @@ public static partial class ConfigurationBinderTS
         {
             Func<IConfiguration, TPropertyType?> propertyTypeBinder = GetOrAddBinder(propertyShape.PropertyType);
             Setter<TDeclaringType, TPropertyType> setter = propertyShape.GetSetter();
-            return new PropertyBinder<TDeclaringType>((ref TDeclaringType obj, IConfigurationSection section) => setter(ref obj, propertyTypeBinder(section)!));
+            return new PropertyBinder<TDeclaringType>((ref obj, section) => setter(ref obj, propertyTypeBinder(section)!));
         }
 
         public override object? VisitParameter<TArgumentState, TParameterType>(IParameterShape<TArgumentState, TParameterType> parameterShape, object? state = null)
         {
             Func<IConfiguration, TParameterType?> parameterTypeBinder = GetOrAddBinder(parameterShape.ParameterType);
             Setter<TArgumentState, TParameterType> setter = parameterShape.GetSetter();
-            return new PropertyBinder<TArgumentState>((ref TArgumentState argState, IConfigurationSection section) => setter(ref argState, parameterTypeBinder(section)!));
+            return new PropertyBinder<TArgumentState>((ref argState, section) => setter(ref argState, parameterTypeBinder(section)!));
         }
 
         public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state = null)

--- a/src/PolyType.Examples/DependencyInjection/ServiceProviderContext.Builder.cs
+++ b/src/PolyType.Examples/DependencyInjection/ServiceProviderContext.Builder.cs
@@ -85,7 +85,7 @@ public sealed partial class ServiceProviderContext
 
             var factory = parameterTypeFactory.Factory;
             var setter = parameterShape.GetSetter();
-            var mapper = new ParameterMapper<TArgumentState>((ServiceProvider provider, ref TArgumentState state) => setter(ref state, factory(provider)));
+            var mapper = new ParameterMapper<TArgumentState>((provider, ref state) => setter(ref state, factory(provider)));
             return (mapper, parameterTypeFactory.Lifetime);
         }
 

--- a/src/PolyType.Examples/JsonSchema/JsonSchemaGenerator.cs
+++ b/src/PolyType.Examples/JsonSchema/JsonSchemaGenerator.cs
@@ -76,7 +76,7 @@ public static class JsonSchemaGenerator
                 }
             }
 
-            JsonObject functionSchema = new JsonObject
+            JsonObject functionSchema = new()
             {
                 ["name"] = methodShape.Name,
                 ["type"] = "object",

--- a/src/PolyType.Examples/JsonSerializer/Converters/JsonEnumerableConverter.cs
+++ b/src/PolyType.Examples/JsonSerializer/Converters/JsonEnumerableConverter.cs
@@ -151,7 +151,7 @@ internal sealed class JsonMDArrayConverter<TArray, TElement>(JsonConverter<TElem
         try
         {
             ReadSubArray(ref reader, ref buffer, dimensions, options);
-            dimensions.AsSpan().Replace(-1, 0);
+            dimensions.Replace(-1, 0);
             Array result = Array.CreateInstance(typeof(TElement), dimensions);
             using Helpers.UnsafeArraySpan<TElement> unsafeArraySpan = new(result);
             buffer.AsSpan().CopyTo(unsafeArraySpan.Span);

--- a/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
+++ b/src/PolyType.Examples/JsonSerializer/JsonSerializer.Builder.cs
@@ -79,7 +79,7 @@ public static partial class JsonSerializerTS
                 if (parameter.ParameterType.Type == typeof(CancellationToken))
                 {
                     var tokenSetter = (Setter<TArgumentState, CancellationToken>)(object)parameter.GetSetter();
-                    return new MethodParameterSetter<TArgumentState>((ref TArgumentState state, IReadOnlyDictionary<string, JsonElement> _, CancellationToken token) =>
+                    return new MethodParameterSetter<TArgumentState>((ref state, _, token) =>
                     {
                         tokenSetter(ref state, token);
                     });
@@ -87,7 +87,7 @@ public static partial class JsonSerializerTS
 
                 JsonConverter<TParameter> paramConverter = GetOrAddConverter(parameter.ParameterType);
                 var setter = parameter.GetSetter();
-                return new MethodParameterSetter<TArgumentState>((ref TArgumentState state, IReadOnlyDictionary<string, JsonElement> parameters, CancellationToken cancellationToken) =>
+                return new MethodParameterSetter<TArgumentState>((ref state, parameters, cancellationToken) =>
                 {
                     if (parameters.TryGetValue(parameter.Name, out JsonElement value))
                     {
@@ -103,10 +103,10 @@ public static partial class JsonSerializerTS
                 {
                     var senderGetter = (Getter<TArgumentState, object?>)(object)parameter.GetGetter();
                     return new FunctionParameterGetter<TArgumentState>((
-                        ref TArgumentState state,
-                        Dictionary<string, JsonElement> _,
-                        ref object? sender,
-                        ref CancellationToken _) =>
+                        ref state,
+                        _,
+                        ref sender,
+                        ref _) =>
                     {
                         sender = senderGetter(ref state);
                     });
@@ -116,10 +116,10 @@ public static partial class JsonSerializerTS
                 {
                     var senderGetter = (Getter<TArgumentState, CancellationToken>)(object)parameter.GetGetter();
                     return new FunctionParameterGetter<TArgumentState>((
-                        ref TArgumentState state,
-                        Dictionary<string, JsonElement> _,
-                        ref object? _, 
-                        ref CancellationToken cancellationToken) =>
+                        ref state,
+                        _,
+                        ref _,
+                        ref cancellationToken) =>
                     {
                         cancellationToken = senderGetter(ref state);
                     });
@@ -128,10 +128,10 @@ public static partial class JsonSerializerTS
                 JsonConverter<TParameter> paramConverter = GetOrAddConverter(parameter.ParameterType);
                 var getter = parameter.GetGetter();
                 return new FunctionParameterGetter<TArgumentState>((
-                    ref TArgumentState state,
-                    Dictionary<string, JsonElement> parameters,
-                    ref object? _,
-                    ref CancellationToken _) =>
+                    ref state,
+                    parameters,
+                    ref _,
+                    ref _) =>
                 {
                     TParameter value = getter(ref state);
                     parameters[parameter.Name] = paramConverter.SerializeToElement(value);
@@ -331,7 +331,7 @@ public static partial class JsonSerializerTS
                 if (functionShape.IsAsync)
                 {
                     return new Func<AsyncJsonEventHandler, TFunction>(jsonHandler =>
-                        functionShape.FromAsyncDelegate((ref TArgumentState argState) =>
+                        functionShape.FromAsyncDelegate((ref argState) =>
                         {
                             object? sender = null;
                             CancellationToken cancellationToken = default;
@@ -353,7 +353,7 @@ public static partial class JsonSerializerTS
                 else
                 {
                     return new Func<JsonEventHandler, TFunction>(jsonHandler =>
-                        functionShape.FromDelegate((ref TArgumentState argState) =>
+                        functionShape.FromDelegate((ref argState) =>
                         {
                             object? sender = null;
                             CancellationToken cancellationToken = default;

--- a/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
+++ b/src/PolyType.Examples/ObjectMapper/Mapper.Builder.cs
@@ -191,7 +191,7 @@ public static partial class Mapper
 
                 Getter<TSource, TSourceProperty> sourceGetter = sourceProperty.GetGetter();
                 Setter<TTarget, TTargetProperty> targetSetter = targetProperty.GetSetter();
-                return new PropertyMapper<TSource, TTarget>((ref TSource source, ref TTarget target) =>
+                return new PropertyMapper<TSource, TTarget>((ref source, ref target) =>
                 {
                     TSourceProperty sourcePropertyValue = sourceGetter(ref source);
                     TTargetProperty targetPropertyValue = propertyTypeMapper(sourcePropertyValue)!;
@@ -206,7 +206,7 @@ public static partial class Mapper
                 Getter<TSource, TSourceProperty> sourceGetter = sourceProperty.GetGetter();
                 Setter<TArgumentState, TTargetParameter> parameterSetter = targetParameter.GetSetter();
 
-                return new PropertyMapper<TSource, TArgumentState>((ref TSource source, ref TArgumentState target) =>
+                return new PropertyMapper<TSource, TArgumentState>((ref source, ref target) =>
                 {
                     TSourceProperty sourcePropertyValue = sourceGetter(ref source);
                     TTargetParameter targetParameterValue = propertyTypeMapper(sourcePropertyValue)!;

--- a/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
+++ b/src/PolyType.Examples/RandomGenerator/RandomGenerator.Builder.cs
@@ -46,7 +46,7 @@ public partial class RandomGenerator
         {
             Setter<TDeclaringType, TPropertyType> setter = property.GetSetter();
             RandomGenerator<TPropertyType> propertyGenerator = GetOrAddGenerator(property.PropertyType);
-            return new RandomPropertySetter<TDeclaringType>((ref TDeclaringType obj, Random random, int size) => setter(ref obj, propertyGenerator(random, size)));
+            return new RandomPropertySetter<TDeclaringType>((ref obj, random, size) => setter(ref obj, propertyGenerator(random, size)));
         }
 
         public override object? VisitConstructor<TDeclaringType, TArgumentState>(IConstructorShape<TDeclaringType, TArgumentState> constructor, object? state)
@@ -109,7 +109,7 @@ public partial class RandomGenerator
         {
             Setter<TArgumentState, TParameter> setter = parameter.GetSetter();
             RandomGenerator<TParameter> parameterGenerator = GetOrAddGenerator(parameter.ParameterType);
-            return new RandomPropertySetter<TArgumentState>((ref TArgumentState obj, Random random, int size) => setter(ref obj, parameterGenerator(random, size)));
+            return new RandomPropertySetter<TArgumentState>((ref obj, random, size) => setter(ref obj, parameterGenerator(random, size)));
         }
 
         public override object? VisitEnum<TEnum, TUnderlying>(IEnumTypeShape<TEnum, TUnderlying> enumShape, object? state)

--- a/src/PolyType.Examples/Utilities/DuplicatePropertyValidator.cs
+++ b/src/PolyType.Examples/Utilities/DuplicatePropertyValidator.cs
@@ -72,7 +72,7 @@ public struct DuplicatePropertyValidator
         return isUnset;
     }
 
-    private void ThrowDuplicateProperty(int propertyIndex)
+    private readonly void ThrowDuplicateProperty(int propertyIndex)
     {
         IPropertyShape property = _properties[propertyIndex];
         throw _throwOnDuplicateProperty(property);

--- a/src/PolyType.Examples/Validation/Validator.Builder.cs
+++ b/src/PolyType.Examples/Validation/Validator.Builder.cs
@@ -27,7 +27,7 @@ public static partial class Validator
                 return null; // Nothing to validate for this object.
             }
 
-            return new Validator<T>((T? value, List<string> path, ref List<string>? errors) =>
+            return new Validator<T>((value, path, ref errors) =>
             {
                 if (value is null)
                 {
@@ -59,7 +59,7 @@ public static partial class Validator
             }
 
             Getter<TDeclaringType, TPropertyType> getter = property.GetGetter();
-            return new Validator<TDeclaringType>((TDeclaringType? obj, List<string> path, ref List<string>? errors) =>
+            return new Validator<TDeclaringType>((obj, path, ref errors) =>
             {
                 DebugExt.Assert(obj != null);
 
@@ -93,7 +93,7 @@ public static partial class Validator
             }
 
             Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> getDictionary = dictionaryShape.GetGetDictionary();
-            return new Validator<TDictionary>((TDictionary? dict, List<string> path, ref List<string>? errors) =>
+            return new Validator<TDictionary>((dict, path, ref errors) =>
             {
                 if (dict is null)
                 {
@@ -118,7 +118,7 @@ public static partial class Validator
             }
 
             Func<TEnumerable, IEnumerable<TElement>> getEnumerable = enumerableShape.GetGetPotentiallyBlockingEnumerable();
-            return new Validator<TEnumerable>((TEnumerable? enumerable, List<string> path, ref List<string>? errors) =>
+            return new Validator<TEnumerable>((enumerable, path, ref errors) =>
             {
                 if (enumerable is null)
                 {
@@ -145,7 +145,7 @@ public static partial class Validator
             }
 
             var deconstructor = optionalShape.GetDeconstructor();
-            return new Validator<TOptional>((TOptional? optional, List<string> path, ref List<string>? errors) =>
+            return new Validator<TOptional>((optional, path, ref errors) =>
             {
                 if (deconstructor(optional, out TElement? element))
                 {
@@ -165,7 +165,7 @@ public static partial class Validator
             var marshaler = surrogateShape.Marshaler;
 
             return surrogateValidator is null ? null : 
-                new Validator<T>((T? value, List<string> path, ref List<string>? errors) => 
+                new Validator<T>((value, path, ref errors) =>
                     surrogateValidator(marshaler.Marshal(value), path, ref errors));
         }
 
@@ -182,7 +182,7 @@ public static partial class Validator
                 return null;
             }
 
-            return new Validator<TUnion>((TUnion? value, List<string> path, ref List<string>? errors) =>
+            return new Validator<TUnion>((value, path, ref errors) =>
             {
                 if (value is null)
                 {
@@ -209,7 +209,7 @@ public static partial class Validator
             }
 
             var marshaler = unionCaseShape.Marshaler;
-            return new Validator<TUnion>((TUnion? value, List<string> path, ref List<string>? errors) => underlying(marshaler.Unmarshal(value), path, ref errors));
+            return new Validator<TUnion>((value, path, ref errors) => underlying(marshaler.Unmarshal(value), path, ref errors));
         }
 
         public override object? VisitFunction<TFunction, TArgumentState, TResult>(IFunctionTypeShape<TFunction, TArgumentState, TResult> functionShape, object? state = null)
@@ -220,12 +220,12 @@ public static partial class Validator
         /// <summary>
         /// Creates a trivial validator that always succeeds.
         /// </summary>
-        public static Validator<T> CreateNullValidator<T>() => new((T? value, List<string> path, ref List<string>? errors) => { });
+        public static Validator<T> CreateNullValidator<T>() => new((value, path, ref errors) => { });
     }
 
     private sealed class DelayedValidatorFactory : IDelayedValueFactory
     {
         public DelayedValue Create<T>(ITypeShape<T> typeShape) =>
-            new DelayedValue<Validator<T>>(self => (T? value, List<string> path, ref List<string>? errors) => self.Result(value, path, ref errors));
+            new DelayedValue<Validator<T>>(self => (value, path, ref errors) => self.Result(value, path, ref errors));
     }
 }

--- a/src/PolyType.Examples/YamlSerializer/Converters/YamlWriter.cs
+++ b/src/PolyType.Examples/YamlSerializer/Converters/YamlWriter.cs
@@ -141,7 +141,7 @@ public sealed class YamlWriter : IDisposable
         // Strip leading document start marker ("---") if present
         if (result.StartsWith("--- ", StringComparison.Ordinal))
         {
-            result = result.Substring(4);
+            result = result[4..];
         }
         else if (result is "---")
         {

--- a/src/PolyType.Roslyn/Helpers/RoslynHelpers.cs
+++ b/src/PolyType.Roslyn/Helpers/RoslynHelpers.cs
@@ -330,9 +330,11 @@ internal static class RoslynHelpers
                 }
             }
             else if (
-                attributeData.ConstructorArguments.Length == 2 &&
-                attributeData.ConstructorArguments[0].Value is INamedTypeSymbol typeParam &&
-                attributeData.ConstructorArguments[1].Value is string methodName)
+                attributeData.ConstructorArguments is
+                [
+                    { Value: INamedTypeSymbol typeParam },
+                    { Value: string methodName },
+                ])
             {
                 builderType = typeParam;
                 builderMethod = methodName;

--- a/src/PolyType.Roslyn/IncrementalTypes/ImmutableEquatableDictionary.cs
+++ b/src/PolyType.Roslyn/IncrementalTypes/ImmutableEquatableDictionary.cs
@@ -230,14 +230,11 @@ public static class ImmutableEquatableDictionary
         where TKey : IEquatable<TKey>
         where TValue : IEquatable<TValue>
     {
-        switch (values)
+        return values switch
         {
-            case ICollection<KeyValuePair<TKey, TValue>> { Count: 0 }:
-                return ImmutableEquatableDictionary<TKey, TValue>.Empty;
-            case IDictionary<TKey, TValue> idict:
-                return ImmutableEquatableDictionary<TKey, TValue>.UnsafeCreateFromDictionary(new(idict));
-            default:
-                return ImmutableEquatableDictionary<TKey, TValue>.UnsafeCreateFromDictionary(values.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
-        }
+            ICollection<KeyValuePair<TKey, TValue>> { Count: 0 } => ImmutableEquatableDictionary<TKey, TValue>.Empty,
+            IDictionary<TKey, TValue> idict => ImmutableEquatableDictionary<TKey, TValue>.UnsafeCreateFromDictionary(new(idict)),
+            _ => ImmutableEquatableDictionary<TKey, TValue>.UnsafeCreateFromDictionary(values.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)),
+        };
     }
 }

--- a/src/PolyType.Roslyn/KnownSymbols.cs
+++ b/src/PolyType.Roslyn/KnownSymbols.cs
@@ -316,29 +316,28 @@ public class KnownSymbols(Compilation compilation)
     /// </summary>
     public bool IsSimpleType(ITypeSymbol type)
     {
-        switch (type.SpecialType)
+        return type.SpecialType switch
         {
             // Primitive types
-            case SpecialType.System_Boolean:
-            case SpecialType.System_Char:
-            case SpecialType.System_SByte:
-            case SpecialType.System_Byte:
-            case SpecialType.System_Int16:
-            case SpecialType.System_UInt16:
-            case SpecialType.System_Int32:
-            case SpecialType.System_UInt32:
-            case SpecialType.System_Int64:
-            case SpecialType.System_UInt64:
-            case SpecialType.System_Single:
-            case SpecialType.System_Double:
-            // CoreLib non-primitives that represent a single value.
-            case SpecialType.System_String:
-            case SpecialType.System_Decimal:
-            case SpecialType.System_DateTime:
-                return true;
-        }
+            SpecialType.System_Boolean or
+            SpecialType.System_Char or
+            SpecialType.System_SByte or
+            SpecialType.System_Byte or
+            SpecialType.System_Int16 or
+            SpecialType.System_UInt16 or
+            SpecialType.System_Int32 or
+            SpecialType.System_UInt32 or
+            SpecialType.System_Int64 or
+            SpecialType.System_UInt64 or
+            SpecialType.System_Single or
+            SpecialType.System_Double => true,
 
-        return (_simpleTypes ??= CreateSimpleTypes(Compilation)).Contains(type);
+            // CoreLib non-primitives that represent a single value.
+            SpecialType.System_String or
+            SpecialType.System_Decimal or
+            SpecialType.System_DateTime => true,
+            _ => (_simpleTypes ??= CreateSimpleTypes(Compilation)).Contains(type),
+        };
 
         static HashSet<ITypeSymbol> CreateSimpleTypes(Compilation compilation)
         {

--- a/src/PolyType.Roslyn/KnownSymbols.cs
+++ b/src/PolyType.Roslyn/KnownSymbols.cs
@@ -16,14 +16,12 @@ public class KnownSymbols(Compilation compilation)
     /// <summary>
     /// The assembly symbol for the core library.
     /// </summary>
-    public IAssemblySymbol CoreLibAssembly => _CoreLibAssembly ??= Compilation.GetSpecialType(SpecialType.System_Int32).ContainingAssembly;
-    private IAssemblySymbol? _CoreLibAssembly;
+    public IAssemblySymbol CoreLibAssembly => field ??= Compilation.GetSpecialType(SpecialType.System_Int32).ContainingAssembly;
 
     /// <summary>
     /// The type symbol for <see cref="System.ValueType"/>.
     /// </summary>
-    public INamedTypeSymbol SystemValueType => _ValueTypeType ??= Compilation.GetSpecialType(SpecialType.System_ValueType);
-    private INamedTypeSymbol? _ValueTypeType;
+    public INamedTypeSymbol SystemValueType => field ??= Compilation.GetSpecialType(SpecialType.System_ValueType);
 
     /// <summary>
     /// The type symbol for <see cref="System.Reflection.MemberInfo"/>.
@@ -100,14 +98,12 @@ public class KnownSymbols(Compilation compilation)
     /// <summary>
     /// The type symbol for <see cref="IEnumerable{T}"/>.
     /// </summary>
-    public INamedTypeSymbol IEnumerableOfT => _IEnumerableOfT ??= Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T);
-    private INamedTypeSymbol? _IEnumerableOfT;
+    public INamedTypeSymbol IEnumerableOfT => field ??= Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T);
 
     /// <summary>
     /// The type symbol for <see cref="System.Collections.IEnumerable"/>.
     /// </summary>
-    public INamedTypeSymbol IEnumerable => _IEnumerable ??= Compilation.GetSpecialType(SpecialType.System_Collections_IEnumerable);
-    private INamedTypeSymbol? _IEnumerable;
+    public INamedTypeSymbol IEnumerable => field ??= Compilation.GetSpecialType(SpecialType.System_Collections_IEnumerable);
     
     /// <summary>
     /// The type symbol for IAsyncEnumerable{T}.

--- a/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.cs
+++ b/src/PolyType.Roslyn/ModelGenerator/TypeDataModelGenerator.cs
@@ -12,7 +12,6 @@ namespace PolyType.Roslyn;
 public partial class TypeDataModelGenerator
 {
     private ImmutableDictionary<ITypeSymbol, TypeDataModel> _generatedModels;
-    private List<Diagnostic>? _diagnostics;
     private ImmutableDictionary<ITypeSymbol, ImmutableArray<AssociatedTypeModel>> _associatedTypes;
 
     /// <summary>
@@ -91,7 +90,7 @@ public partial class TypeDataModelGenerator
     /// <summary>
     /// Gets the list of diagnostics that have been recorded by this model generator.
     /// </summary>
-    public List<Diagnostic> Diagnostics => _diagnostics ??= [];
+    public List<Diagnostic> Diagnostics => field ??= [];
 
     /// <summary>
     /// Adds a new diagnostic to the <see cref="Diagnostics"/> property.

--- a/src/PolyType.SourceGenerator/Analyzers/TypeShapeExtensionAnalyzer.cs
+++ b/src/PolyType.SourceGenerator/Analyzers/TypeShapeExtensionAnalyzer.cs
@@ -36,7 +36,7 @@ public class TypeShapeExtensionAnalyzer : DiagnosticAnalyzer
                     context =>
                     {
                         AttributeSyntax att = (AttributeSyntax)context.Node;
-                        if (att.Parent is not AttributeListSyntax { Target: { Identifier: { RawKind: (int)SyntaxKind.AssemblyKeyword } } })
+                        if (att.Parent is not AttributeListSyntax { Target.Identifier.RawKind: (int)SyntaxKind.AssemblyKeyword })
                         {
                             return;
                         }

--- a/src/PolyType.SourceGenerator/Helpers/DeconstructionExtensions.cs
+++ b/src/PolyType.SourceGenerator/Helpers/DeconstructionExtensions.cs
@@ -2,5 +2,8 @@ namespace PolyType.SourceGenerator.Helpers;
 
 internal static class DeconstructionExtensions
 {
-    internal static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> pair, out TKey key, out TValue value) => (key, value) = (pair.Key, pair.Value);
+    extension<TKey, TValue>(KeyValuePair<TKey, TValue> pair)
+    {
+        internal void Deconstruct(out TKey key, out TValue value) => (key, value) = (pair.Key, pair.Value);
+    }
 }

--- a/src/PolyType.SourceGenerator/Helpers/GlobPatternMatcher.cs
+++ b/src/PolyType.SourceGenerator/Helpers/GlobPatternMatcher.cs
@@ -40,7 +40,7 @@ internal sealed class GlobPatternMatcher
             {
                 // Pattern has wildcards, compile as regex
                 string regexPattern = ConvertGlobToRegex(pattern);
-                Regex regex = new Regex(regexPattern, RegexOptions.None);
+                Regex regex = new(regexPattern, RegexOptions.None);
                 patternList.Add((pattern, regex, attributeData, false));
             }
             else

--- a/src/PolyType.SourceGenerator/Helpers/RoslynHelpers.cs
+++ b/src/PolyType.SourceGenerator/Helpers/RoslynHelpers.cs
@@ -32,7 +32,7 @@ internal static partial class RoslynHelpers
     /// </summary>
     public static string GetReflectionToStringName(this ITypeSymbol type)
     {
-        StringBuilder builder = new StringBuilder();
+        StringBuilder builder = new();
         FormatType(type, builder);
         return builder.ToString();
 
@@ -266,7 +266,7 @@ internal static partial class RoslynHelpers
     /// </remarks>
     public static string GetDerivedTypeShapeName(this ITypeSymbol type)
     {
-        StringBuilder builder = new StringBuilder();
+        StringBuilder builder = new();
         ITypeSymbol? skipContainingType = (type as INamedTypeSymbol)?.ContainingType;
         FormatTypeWithUnderscores(type, builder, skipContainingType);
         return builder.ToString();

--- a/src/PolyType.SourceGenerator/Parser/Parser.cs
+++ b/src/PolyType.SourceGenerator/Parser/Parser.cs
@@ -1130,9 +1130,10 @@ public sealed partial class Parser : TypeDataModelGenerator
             }
             else if (
                 SymbolEqualityComparer.Default.Equals(attributeData.AttributeClass, _knownSymbols.GenerateShapeForAttribute) &&
-                attributeData.ConstructorArguments.Length == 1 &&
-                attributeData.ConstructorArguments[0].Kind == TypedConstantKind.Primitive &&
-                attributeData.ConstructorArguments[0].Value is string pattern)
+                attributeData.ConstructorArguments is
+                [
+                    { Kind: TypedConstantKind.Primitive, Value: string pattern },
+                ])
             {
                 // [GenerateShapeFor("pattern")] - collect patterns to process together
                 isWitnessTypeDeclaration = true;

--- a/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Methods.cs
+++ b/src/PolyType.SourceGenerator/SourceFormatter/SourceFormatter.Methods.cs
@@ -448,7 +448,7 @@ internal sealed partial class SourceFormatter
             return "global::System.Type.EmptyTypes";
         }
 
-        string FormatType(ParameterShapeModel p) => p.RefKind is RefKind.Out
+        static string FormatType(ParameterShapeModel p) => p.RefKind is RefKind.Out
             ? $"typeof({p.ParameterType.FullyQualifiedName}).MakeByRefType()"
             : FormatParameterTypeExpr(p);
 

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -1393,29 +1393,29 @@ public partial class ClassWithNullabilityAttributes
     [MaybeNull]
     public string MaybeNull
     {
-        get => field;
-        set => field = value;
+        get;
+        set;
     } = "str";
 
     [AllowNull]
     public string AllowNull
     {
         get => field ?? "str";
-        set => field = value;
+        set;
     } = "str";
 
     [NotNull]
     public string? NotNull
     {
         get => field ?? "str";
-        set => field = value;
+        set;
     } = "str";
 
     [DisallowNull]
     public string? DisallowNull
     {
-        get => field;
-        set => field = value;
+        get;
+        set;
     } = "str";
 
     [MaybeNull]
@@ -1462,29 +1462,29 @@ public partial struct StructWithNullabilityAttributes
     [MaybeNull]
     public int? MaybeNull
     {
-        get => field;
-        set => field = value;
+        get;
+        set;
     } = 0;
 
     [AllowNull]
     public int? AllowNull
     {
         get => field ?? 0;
-        set => field = value;
+        set;
     } = 0;
 
     [NotNull]
     public int? NotNullProperty
     {
         get => field ?? 0;
-        set => field = value;
+        set;
     } = 0;
 
     [DisallowNull]
     public int? DisallowNull
     {
-        get => field;
-        set => field = value;
+        get;
+        set;
     } = 0;
 
     [MaybeNull]

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -653,10 +653,10 @@ public static class TestTypes
         yield return TestCase.Create(new Func<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, ValueTask<int>>(
             (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => new(x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16)), p);
 
-        yield return TestCase.Create(new Getter<int, int>((ref int x) => x), p);
-        yield return TestCase.Create(new Setter<int, int>((ref int x, int value) => { x += value; }), p);
+        yield return TestCase.Create(new Getter<int, int>((ref x) => x), p);
+        yield return TestCase.Create(new Setter<int, int>((ref x, value) => { x += value; }), p);
         yield return TestCase.Create(new EventHandler((sender, args) => { }), p);
-        yield return TestCase.Create(new CustomDelegate((ref string? x, int y) => x?.Length ?? 0 + y), p);
+        yield return TestCase.Create(new CustomDelegate((ref x, y) => x?.Length ?? 0 + y), p);
         yield return TestCase.Create(new LargeDelegate(
             (p01, p02, p03, p04, p05, p06, p07, p08, p09, p10,
              p11, p12, p13, p14, p15, p16, p17, p18, p19, p20,

--- a/src/PolyType.TestCases/TestTypes.cs
+++ b/src/PolyType.TestCases/TestTypes.cs
@@ -1005,7 +1005,6 @@ public abstract partial class BaseClassWithVirtualProperties
 public partial class DerivedClassWithVirtualProperties : BaseClassWithVirtualProperties
 {
     private int? _x;
-    private string? _y;
 
     public override int X
     {
@@ -1023,15 +1022,15 @@ public partial class DerivedClassWithVirtualProperties : BaseClassWithVirtualPro
 
     public override string Y
     {
-        get => _y ?? "str";
+        get => field ?? "str";
         set
         {
-            if (_y != null)
+            if (field != null)
             {
                 throw new InvalidOperationException("Value has already been set once");
             }
 
-            _y = value;
+            field = value;
         }
     }
 
@@ -1383,46 +1382,41 @@ public class GenericContainer<T>
 [GenerateShape]
 public partial class ClassWithNullabilityAttributes
 {
-    private string? _maybeNull = "str";
-    private string? _allowNull = "str";
-    private string? _notNull = "str";
-    private string? _disallowNull = "str";
-
     public ClassWithNullabilityAttributes() { }
 
     public ClassWithNullabilityAttributes([AllowNull] string allowNull, [DisallowNull] string? disallowNull)
     {
-        _allowNull = allowNull;
-        _disallowNull = disallowNull;
+        AllowNull = allowNull;
+        DisallowNull = disallowNull;
     }
 
     [MaybeNull]
     public string MaybeNull
     {
-        get => _maybeNull;
-        set => _maybeNull = value;
-    }
+        get => field;
+        set => field = value;
+    } = "str";
 
     [AllowNull]
     public string AllowNull
     {
-        get => _allowNull ?? "str";
-        set => _allowNull = value;
-    }
+        get => field ?? "str";
+        set => field = value;
+    } = "str";
 
     [NotNull]
     public string? NotNull
     {
-        get => _notNull ?? "str";
-        set => _notNull = value;
-    }
+        get => field ?? "str";
+        set => field = value;
+    } = "str";
 
     [DisallowNull]
     public string? DisallowNull
     {
-        get => _disallowNull;
-        set => _disallowNull = value;
-    }
+        get => field;
+        set => field = value;
+    } = "str";
 
     [MaybeNull]
     public string MaybeNullField = "str";
@@ -1457,46 +1451,41 @@ public class ClassWithNotNullProperty<T> where T : notnull
 [GenerateShape]
 public partial struct StructWithNullabilityAttributes
 {
-    private int? _maybeNull = 0;
-    private int? _allowNull = 0;
-    private int? _notNull = 0;
-    private int? _disallowNull = 0;
-
     public StructWithNullabilityAttributes() { }
 
     public StructWithNullabilityAttributes([AllowNull] int? allowNull, [DisallowNull] int? disallowNull)
     {
-        _allowNull = allowNull;
-        _disallowNull = disallowNull;
+        AllowNull = allowNull;
+        DisallowNull = disallowNull;
     }
 
     [MaybeNull]
     public int? MaybeNull
     {
-        get => _maybeNull;
-        set => _maybeNull = value;
-    }
+        get => field;
+        set => field = value;
+    } = 0;
 
     [AllowNull]
     public int? AllowNull
     {
-        get => _allowNull ?? 0;
-        set => _allowNull = value;
-    }
+        get => field ?? 0;
+        set => field = value;
+    } = 0;
 
     [NotNull]
     public int? NotNullProperty
     {
-        get => _notNull ?? 0;
-        set => _notNull = value;
-    }
+        get => field ?? 0;
+        set => field = value;
+    } = 0;
 
     [DisallowNull]
     public int? DisallowNull
     {
-        get => _disallowNull;
-        set => _disallowNull = value;
-    }
+        get => field;
+        set => field = value;
+    } = 0;
 
     [MaybeNull]
     public int MaybeNullField = 0;

--- a/src/PolyType/ReflectionProvider/FSharpFunctionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/FSharpFunctionTypeShape.cs
@@ -16,14 +16,13 @@ internal sealed class FSharpFunctionTypeShape<TFunction, TArgumentState, TResult
     IFunctionTypeShape<TFunction, TArgumentState, TResult>
     where TArgumentState : IArgumentState
 {
-    private IReadOnlyList<IParameterShape>? _parameters;
     private Func<TArgumentState>? _argumentStateConstructor;
     private MethodInvoker<TFunction, TArgumentState, TResult>? _functionInvoker;
 
     public ITypeShape<TResult> ReturnType => Provider.GetTypeShape<TResult>();
     public bool IsVoidLike => fSharpFuncInfo.IsVoidLike;
     public bool IsAsync => fSharpFuncInfo.IsAsync;
-    public IReadOnlyList<IParameterShape> Parameters => _parameters ?? CommonHelpers.ExchangeIfNull(ref _parameters, GetParameters().AsReadOnlyList());
+    public IReadOnlyList<IParameterShape> Parameters => field ?? CommonHelpers.ExchangeIfNull(ref field, GetParameters().AsReadOnlyList());
     public override TypeShapeKind Kind => TypeShapeKind.Function;
     ITypeShape IFunctionTypeShape.ReturnType => ReturnType;
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitFunction(this, state);

--- a/src/PolyType/ReflectionProvider/FSharpOptionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/FSharpOptionTypeShape.cs
@@ -28,7 +28,7 @@ internal sealed class FSharpOptionTypeShape<TOptional, TElement>(FSharpUnionInfo
     {
         PropertyInfo valueGetterProp = unionInfo.UnionCases[1].Properties[0];
         var valueGetter = Provider.MemberAccessor.CreateGetter<TOptional, TElement>(valueGetterProp, null);
-        return (TOptional? optional, [MaybeNullWhen(false)] out TElement value) =>
+        return (optional, [MaybeNullWhen(false)] out value) =>
         {
             // 'None' in both FSharpOption<T> and FSharpValueOption<T> equals default
             if (typeof(TOptional).IsValueType ? optional!.Equals(default!) : optional is null)

--- a/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
@@ -16,8 +16,7 @@ internal sealed class FSharpUnionTypeShape<TUnion>(FSharpUnionInfo unionInfo, Re
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitUnion(this, state);
     public ITypeShape<TUnion> BaseType { get; } = new FSharpUnionCaseTypeShape<TUnion>(null, provider, options);
 
-    public IReadOnlyList<IUnionCaseShape> UnionCases => _unionCases ?? CommonHelpers.ExchangeIfNull(ref _unionCases, CreateUnionCaseShapes().AsReadOnlyList());
-    private IReadOnlyList<IUnionCaseShape>? _unionCases;
+    public IReadOnlyList<IUnionCaseShape> UnionCases => field ?? CommonHelpers.ExchangeIfNull(ref field, CreateUnionCaseShapes().AsReadOnlyList());
 
     public Getter<TUnion, int> GetGetUnionCaseIndex() => _unionCaseIndexReader ?? CommonHelpers.ExchangeIfNull(ref _unionCaseIndexReader, CreateUnionCaseIndex());
     private Getter<TUnion, int>? _unionCaseIndexReader;

--- a/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/FSharpUnionTypeShape.cs
@@ -29,7 +29,7 @@ internal sealed class FSharpUnionTypeShape<TUnion>(FSharpUnionInfo unionInfo, Re
         {
             case MethodInfo tagReaderMethod:
                 var func = tagReaderMethod.CreateDelegate<Func<TUnion, int>>();
-                return (ref TUnion value) => func(value);
+                return (ref value) => func(value);
 
             case PropertyInfo tagReaderProperty:
                 return Provider.MemberAccessor.CreateGetter<TUnion, int>(tagReaderProperty, null);

--- a/src/PolyType/ReflectionProvider/FSharpUnitTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/FSharpUnitTypeShape.cs
@@ -15,12 +15,10 @@ internal sealed class FSharpUnitTypeShape<TUnit>(ReflectionTypeShapeProvider pro
     IObjectTypeShape<TUnit>
     where TUnit : class?
 {
-    private UnitConstructorShape? _constructor;
-
     public bool IsRecordType => false;
     public bool IsTupleType => false;
     public IReadOnlyList<IPropertyShape> Properties => [];
-    public IConstructorShape? Constructor => _constructor ?? CommonHelpers.ExchangeIfNull(ref _constructor, new(this));
+    public IConstructorShape? Constructor => field ?? CommonHelpers.ExchangeIfNull(ref field, new UnitConstructorShape(this));
     public override TypeShapeKind Kind => TypeShapeKind.Object;
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitObject(this, state);
 

--- a/src/PolyType/ReflectionProvider/IMethodShapeInfo.cs
+++ b/src/PolyType/ReflectionProvider/IMethodShapeInfo.cs
@@ -58,8 +58,6 @@ internal sealed class TupleConstructorShapeInfo(
     MethodParameterShapeInfo[] constructorParameters,
     TupleConstructorShapeInfo? nestedTupleCtor) : IMethodShapeInfo
 {
-    private IParameterShapeInfo[]? _allParameters;
-
     public Type ReturnType { get; } = constructedType;
     public ConstructorInfo ConstructorInfo { get; } = constructorInfo;
     public MethodParameterShapeInfo[] ConstructorParameters { get; } = constructorParameters;
@@ -67,7 +65,7 @@ internal sealed class TupleConstructorShapeInfo(
     public bool IsValueTuple => ReturnType.IsValueType;
 
     public MethodBase? Method => ConstructorInfo;
-    public IParameterShapeInfo[] Parameters => _allParameters ??= GetAllParameters().ToArray();
+    public IParameterShapeInfo[] Parameters => field ??= GetAllParameters().ToArray();
     public bool IsPublic => true;
 
     private IEnumerable<IParameterShapeInfo> GetAllParameters()

--- a/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionEmitMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionEmitMemberAccessor.cs
@@ -956,7 +956,7 @@ internal sealed class ReflectionEmitMemberAccessor : IReflectionMemberAccessor
                 LdArgsAsTuple(generator, shapeInfo, argumentType); // Load the arguments as a tuple
                 LdLiteral(generator, typeof(int), shapeInfo.Parameters.Length); // Load the count
                 generator.Emit(OpCodes.Ldarg_0); // Load the argument mask from the environment
-                generator.Emit(OpCodes.Ldfld, typeof(DelegateWrapperEnvironment<TArgumentState, TResult>).GetField(nameof(DelegateWrapperEnvironment<TArgumentState, TResult>.LargeRequiredParametersMask))!);
+                generator.Emit(OpCodes.Ldfld, typeof(DelegateWrapperEnvironment<TArgumentState, TResult>).GetField(nameof(DelegateWrapperEnvironment<,>.LargeRequiredParametersMask))!);
                 LdLiteral(generator, typeof(bool), true); // Load the markAllArgumentsSet (true)
 
                 ConstructorInfo cI = typeof(TArgumentState).GetConstructor([argumentType, typeof(int), typeof(ValueBitArray), typeof(bool)])!;
@@ -982,7 +982,7 @@ internal sealed class ReflectionEmitMemberAccessor : IReflectionMemberAccessor
 
         // 2. Invoke the inner delegate
         generator.Emit(OpCodes.Ldarg_0); // Load the inner delegate from the environment argument
-        generator.Emit(OpCodes.Ldfld, typeof(DelegateWrapperEnvironment<TArgumentState, TResult>).GetField(nameof(DelegateWrapperEnvironment<TArgumentState, TResult>.InnerFunc))!);
+        generator.Emit(OpCodes.Ldfld, typeof(DelegateWrapperEnvironment<TArgumentState, TResult>).GetField(nameof(DelegateWrapperEnvironment<,>.InnerFunc))!);
         generator.Emit(OpCodes.Ldloca_S, argStateLocal); // Load the argument state
         generator.Emit(OpCodes.Callvirt, innerDelegateInvoker); // Call the inner delegate
 
@@ -1498,7 +1498,7 @@ internal sealed class ReflectionEmitMemberAccessor : IReflectionMemberAccessor
                     Debug.Assert(parameterTypes.Length == 2 && parameterTypes[0].GetGenericTypeDefinition() == typeof(ReadOnlySpan<>));
                     MethodInfo createHashSetMethod = typeof(CollectionHelpers).GetMethod(nameof(CollectionHelpers.CreateHashSet), BindingFlags.Public | BindingFlags.Static)!;
                     il.Emit(OpCodes.Ldarg_0);
-                    LdOptionsProperty(nameof(CollectionConstructionOptions<int>.EqualityComparer));
+                    LdOptionsProperty(nameof(CollectionConstructionOptions<>.EqualityComparer));
                     il.Emit(OpCodes.Call, createHashSetMethod.MakeGenericMethod(keyType));
                     break;
 
@@ -1509,7 +1509,7 @@ internal sealed class ReflectionEmitMemberAccessor : IReflectionMemberAccessor
                     MethodInfo createDictionaryMethod = typeof(CollectionHelpers).GetMethod(nameof(CollectionHelpers.CreateDictionary), BindingFlags.Public | BindingFlags.Static)!;
 
                     il.Emit(OpCodes.Ldarg_0);
-                    LdOptionsProperty(nameof(CollectionConstructionOptions<int>.EqualityComparer));
+                    LdOptionsProperty(nameof(CollectionConstructionOptions<>.EqualityComparer));
                     il.Emit(OpCodes.Call, createDictionaryMethod.MakeGenericMethod(elementType.GetGenericArguments()));
                     break;
 
@@ -1526,7 +1526,7 @@ internal sealed class ReflectionEmitMemberAccessor : IReflectionMemberAccessor
                 case CollectionConstructorParameter.Capacity:
                 case CollectionConstructorParameter.CapacityOptional:
                 {
-                    LdOptionsProperty(nameof(CollectionConstructionOptions<int>.Capacity));
+                    LdOptionsProperty(nameof(CollectionConstructionOptions<>.Capacity));
 
                     LocalBuilder nullable = il.DeclareLocal(typeof(int?));
                     il.Emit(OpCodes.Stloc, nullable);
@@ -1540,7 +1540,7 @@ internal sealed class ReflectionEmitMemberAccessor : IReflectionMemberAccessor
                 case CollectionConstructorParameter.EqualityComparer:
                 case CollectionConstructorParameter.EqualityComparerOptional:
                 {
-                    LdOptionsProperty(nameof(CollectionConstructionOptions<int>.EqualityComparer));
+                    LdOptionsProperty(nameof(CollectionConstructionOptions<>.EqualityComparer));
 
                     if (parameterType is CollectionConstructorParameter.EqualityComparer)
                     {
@@ -1570,7 +1570,7 @@ internal sealed class ReflectionEmitMemberAccessor : IReflectionMemberAccessor
                 case CollectionConstructorParameter.Comparer:
                 case CollectionConstructorParameter.ComparerOptional:
                 {
-                    LdOptionsProperty(nameof(CollectionConstructionOptions<int>.Comparer));
+                    LdOptionsProperty(nameof(CollectionConstructionOptions<>.Comparer));
 
                     if (parameterType is CollectionConstructorParameter.Comparer)
                     {

--- a/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionMemberAccessor.cs
+++ b/src/PolyType/ReflectionProvider/MemberAccessors/ReflectionMemberAccessor.cs
@@ -29,14 +29,14 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
 
                 // Reference types can't be wrapped directly, so we create an intermediate func delegate.
                 Func<TDeclaringType, TPropertyType> getterDelegate = p.GetMethod!.CreateDelegate<Func<TDeclaringType, TPropertyType>>();
-                return (ref TDeclaringType obj) => getterDelegate(obj);
+                return (ref obj) => getterDelegate(obj);
             }
 
             // https://github.com/mono/mono/issues/10372
             var f = (FieldInfo)memberInfo;
             return ReflectionHelpers.IsMonoRuntime
-                ? (ref TDeclaringType obj) => (TPropertyType)f.GetValue(obj)!
-                : (ref TDeclaringType obj) => (TPropertyType)f.GetValueDirect(__makeref(obj))!;
+                ? (ref obj) => (TPropertyType)f.GetValue(obj)!
+                : (ref obj) => (TPropertyType)f.GetValueDirect(__makeref(obj))!;
         }
 
         Debug.Assert(typeof(TDeclaringType).IsNestedTupleRepresentation());
@@ -48,7 +48,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
 
             var fieldInfo = (FieldInfo)memberInfo;
             var parentFields = (FieldInfo[])parentMembers;
-            return (ref TDeclaringType obj) =>
+            return (ref obj) =>
             {
                 object boxedObj = obj!;
                 for (int i = 0; i < parentFields.Length; i++)
@@ -66,7 +66,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
 
             var propertyInfo = (PropertyInfo)memberInfo;
             var parentProperties = (PropertyInfo[])parentMembers;
-            return (ref TDeclaringType obj) =>
+            return (ref obj) =>
             {
                 object boxedObj = obj!;
                 for (int i = 0; i < parentProperties.Length; i++)
@@ -96,19 +96,19 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
 
                 // Reference types can't be wrapped directly, so we create an intermediate action delegate.
                 Action<TDeclaringType, TPropertyType> setterDelegate = setter.CreateDelegate<Action<TDeclaringType, TPropertyType>>();
-                return (ref TDeclaringType obj, TPropertyType value) => setterDelegate(obj, value);
+                return (ref obj, value) => setterDelegate(obj, value);
             }
 
             // https://github.com/mono/mono/issues/10372
             var f = (FieldInfo)memberInfo;
             return ReflectionHelpers.IsMonoRuntime
-                ? (ref TDeclaringType obj, TPropertyType value) =>
+                ? (ref obj, value) =>
                 {
                     object boxedObj = obj!;
                     f.SetValue(boxedObj, value);
                     obj = (TDeclaringType)boxedObj;
                 }
-            : (ref TDeclaringType obj, TPropertyType value) => f.SetValueDirect(__makeref(obj), value!);
+            : (ref obj, value) => f.SetValueDirect(__makeref(obj), value!);
         }
 
         Debug.Assert(typeof(TDeclaringType).IsNestedTupleRepresentation());
@@ -118,7 +118,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
 
         var fieldInfo = (FieldInfo)memberInfo;
         var parentFields = (FieldInfo[])parentMembers;
-        return (ref TDeclaringType obj, TPropertyType value) =>
+        return (ref obj, value) =>
         {
             object?[] boxedValues = new object[parentFields.Length + 1];
             boxedValues[0] = obj;
@@ -142,8 +142,8 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
     public Setter<TDeclaringType?, TEventHandler> CreateEventAccessor<TDeclaringType, TEventHandler>(MethodInfo accessor)
     {
         return !typeof(TDeclaringType).IsValueType
-            ? (ref TDeclaringType? target, TEventHandler handler) => accessor.InvokeNoWrapExceptions(target, [handler])
-            : (ref TDeclaringType? target, TEventHandler handler) =>
+            ? (ref target, handler) => accessor.InvokeNoWrapExceptions(target, [handler])
+            : (ref target, handler) =>
             {
                 object? boxedTarget = target;
                 accessor.InvokeNoWrapExceptions(boxedTarget, [handler]);
@@ -154,8 +154,8 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
     public EnumerableAppender<TEnumerable, TElement> CreateEnumerableAppender<TEnumerable, TElement>(MethodInfo addMethod)
     {
         return !typeof(TEnumerable).IsValueType
-        ? (ref TEnumerable enumerable, TElement element) => addMethod.InvokeNoWrapExceptions(enumerable, [element]) is not bool success || success
-        : (ref TEnumerable enumerable, TElement element) =>
+        ? (ref enumerable, element) => addMethod.InvokeNoWrapExceptions(enumerable, [element]) is not bool success || success
+        : (ref enumerable, element) =>
         {
             object boxed = enumerable!;
             bool success = addMethod.InvokeNoWrapExceptions(boxed, [element]) is not bool s || s;
@@ -174,7 +174,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
                 if (typeof(TDictionary).IsValueType)
                 {
                     var setDelegate = insertMethod.CreateDelegate<RefAction<TDictionary, TKey, TValue>>();
-                    return (ref TDictionary dict, TKey key, TValue value) =>
+                    return (ref dict, key, value) =>
                     {
                         setDelegate(ref dict, key, value);
                         return true;
@@ -183,7 +183,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
                 else
                 {
                     var setDelegate = insertMethod.CreateDelegate<Action<TDictionary, TKey, TValue>>();
-                    return (ref TDictionary dict, TKey key, TValue value) =>
+                    return (ref dict, key, value) =>
                     {
                         setDelegate(dict, key, value);
                         return true; // Always returns true since it overwrites existing keys.
@@ -198,7 +198,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
                 else
                 {
                     var tryAddDelegate = ctorInfo.TryAddMethod.CreateDelegate<Func<TDictionary, TKey, TValue, bool>>();
-                    return (ref TDictionary dict, TKey key, TValue value) => tryAddDelegate(dict, key, value);
+                    return (ref dict, key, value) => tryAddDelegate(dict, key, value);
                 }
 
             case DictionaryInsertionMode.Discard:
@@ -208,7 +208,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
                 {
                     var containsKeyDelegate = ctorInfo.ContainsKeyMethod.CreateDelegate<RefFunc<TDictionary, TKey, bool>>();
                     var addMethodDelegate = addMethod!.CreateDelegate<RefAction<TDictionary, TKey, TValue>>();
-                    return (ref TDictionary dict, TKey key, TValue value) =>
+                    return (ref dict, key, value) =>
                     {
                         if (containsKeyDelegate(ref dict, key))
                         {
@@ -223,7 +223,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
                 {
                     var containsKeyDelegate = ctorInfo.ContainsKeyMethod.CreateDelegate<Func<TDictionary, TKey, bool>>();
                     var addMethodDelegate = addMethod!.CreateDelegate<Action<TDictionary, TKey, TValue>>();
-                    return (ref TDictionary dict, TKey key, TValue value) =>
+                    return (ref dict, key, value) =>
                     {
                         if (containsKeyDelegate(dict, key))
                         {
@@ -337,7 +337,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
         {
             Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<object?[]>));
             return (Getter<TArgumentState, TParameter>)(object)new Getter<LargeArgumentState<object?[]>, TParameter>(
-                (ref LargeArgumentState<object?[]> state) => Cast(state.Arguments[parameterIndex]));
+                (ref state) => Cast(state.Arguments[parameterIndex]));
         }
 
         static TParameter Cast(object? value) => typeof(TParameter).IsValueType && value is null ? default! : (TParameter)value!;
@@ -370,7 +370,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
         {
             Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<object?[]>));
             return (Setter<TArgumentState, TParameter>)(object)new Setter<LargeArgumentState<object?[]>, TParameter>(
-                (ref LargeArgumentState<object?[]> state, TParameter value) =>
+                (ref state, value) =>
                 {
                     state.Arguments[parameterIndex] = value;
                     state.MarkArgumentSet(parameterIndex);
@@ -394,7 +394,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
             ctorStack.Reverse();
 
             return (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<LargeArgumentState<object?[]>, TDeclaringType>(
-                (ref LargeArgumentState<object?[]> state) =>
+                (ref state) =>
             {
                 object?[] arguments = state.Arguments;
                 object? result = null;
@@ -481,7 +481,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
         Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<object?[]>));
         var cI = ((MethodShapeInfo)ctorInfo).Method!;
         return (Constructor<TArgumentState, TDeclaringType>)(object)new Constructor<LargeArgumentState<object?[]>, TDeclaringType>(
-            (ref LargeArgumentState<object?[]> state) => (TDeclaringType)cI.InvokeNoWrapExceptions(state.Arguments)!);
+            (ref state) => (TDeclaringType)cI.InvokeNoWrapExceptions(state.Arguments)!);
     }
 
     public MethodInvoker<TDeclaringType?, TArgumentState, TResult> CreateMethodInvoker<TDeclaringType, TArgumentState, TResult>(MethodShapeInfo ctorInfo) where TArgumentState : IArgumentState
@@ -493,7 +493,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
         if (ctorInfo.Parameters is [])
         {
             Debug.Assert(typeof(TArgumentState) == typeof(EmptyArgumentState));
-            return (ref TDeclaringType? target, ref TArgumentState _) =>
+            return (ref target, ref _) =>
             {
                 object? boxedTarget = target;
                 object? result = methodInfo.InvokeNoWrapExceptions(boxedTarget, []);
@@ -504,7 +504,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
 
         Debug.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<object?[]>));
         return (MethodInvoker<TDeclaringType?, TArgumentState, TResult>)(object)new MethodInvoker<TDeclaringType?, LargeArgumentState<object?[]>, TResult>(
-            (ref TDeclaringType? target, ref LargeArgumentState<object?[]> state) =>
+            (ref target, ref state) =>
             {
                 object? boxedTarget = target;
                 object? result = methodInfo.InvokeNoWrapExceptions(boxedTarget, state.Arguments);
@@ -524,7 +524,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
             MethodInfo invokeMethod = funcInfo.CurriedInvocationChain[0];
             object?[] args = [null]; // single argument is F# unit type represented using null.
             return (MethodInvoker<TFunction, TArgumentState, TResult>)(object)new MethodInvoker<TFunction, EmptyArgumentState, TResult>(
-                (ref TFunction target, ref EmptyArgumentState state) =>
+                (ref target, ref state) =>
                 {
                     object? result = invokeMethod.InvokeNoWrapExceptions(target, args);
                     return resultMarshaler(result);
@@ -533,7 +533,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
 
         DebugExt.Assert(typeof(TArgumentState) == typeof(LargeArgumentState<object?[]>));
         return (MethodInvoker<TFunction, TArgumentState, TResult>)(object)new MethodInvoker<TFunction, LargeArgumentState<object?[]>, TResult>(
-            (ref TFunction target, ref LargeArgumentState<object?[]> state) =>
+            (ref target, ref state) =>
             {
                 object? current = target;
                 int i = 0;
@@ -619,7 +619,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
         // Add the base type as a sentinel value if it hasn't been added by the attributes yet.
         cache.TryAdd(typeof(TUnion), defaultIndex);
 
-        return (ref TUnion union) =>
+        return (ref union) =>
         {
             if (union is null)
             {
@@ -700,7 +700,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
             .ToArray();
 
         var ctorInfo = collectionCtorInfo.Factory;
-        return (in CollectionConstructionOptions<TKey> opts) =>
+        return (in opts) =>
         {
             var args = new object?[argumentSetters.Length];
             for (int i = 0; i < argumentSetters.Length; i++)
@@ -717,13 +717,13 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
         if (constructorInfo is { Factory: MethodInfo methodInfo, Signature: [CollectionConstructorParameter.Span] })
         {
             SpanFunc<TElement, TCollection> spanFunc = methodInfo.CreateDelegate<SpanFunc<TElement, TCollection>>();
-            return (ReadOnlySpan<TElement> span, in CollectionConstructionOptions<TKey> _) => spanFunc(span);
+            return (span, in _) => spanFunc(span);
         }
 
         if (constructorInfo is { Factory: MethodInfo methodInfo2, Signature: [CollectionConstructorParameter.Span, CollectionConstructorParameter.EqualityComparerOptional] })
         {
             SpanFunc<TElement, IEqualityComparer<TKey>?, TCollection> spanFunc = methodInfo2.CreateDelegate<SpanFunc<TElement, IEqualityComparer<TKey>?, TCollection>>();
-            return (ReadOnlySpan<TElement> span, in CollectionConstructionOptions<TKey> options) => spanFunc(span, options.EqualityComparer);
+            return (span, in options) => spanFunc(span, options.EqualityComparer);
         }
 
         SpanAction<TElement, CollectionConstructionOptions<TKey>, object?[]>[] argumentSetters = constructorInfo.Signature
@@ -731,7 +731,7 @@ internal sealed class ReflectionMemberAccessor : IReflectionMemberAccessor
             .ToArray();
 
         MethodBase factory = constructorInfo.Factory;
-        return (ReadOnlySpan<TElement> span, in CollectionConstructionOptions<TKey> opts) =>
+        return (span, in opts) =>
         {
             var args = new object?[argumentSetters.Length];
             for (int i = 0; i < argumentSetters.Length; i++)

--- a/src/PolyType/ReflectionProvider/ReflectionConstructorShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionConstructorShape.cs
@@ -14,7 +14,6 @@ internal sealed class ReflectionConstructorShape<TDeclaringType, TArgumentState>
     : IConstructorShape<TDeclaringType, TArgumentState>
     where TArgumentState : IArgumentState
 {
-    private IReadOnlyList<IParameterShape>? _parameters;
     private Func<TArgumentState>? _argumentStateConstructor;
     private Constructor<TArgumentState, TDeclaringType>? _parameterizedConstructor;
     private Func<TDeclaringType>? _defaultConstructor;
@@ -22,14 +21,13 @@ internal sealed class ReflectionConstructorShape<TDeclaringType, TArgumentState>
     public IObjectTypeShape<TDeclaringType> DeclaringType { get; } = declaringType;
     public MethodBase? MethodBase => ctorInfo.Method;
 
-    public IGenericCustomAttributeProvider AttributeProvider => _attributeProvider ?? CommonHelpers.ExchangeIfNull(ref _attributeProvider, ReflectionCustomAttributeProvider.Create(ctorInfo.Method));
-    private IGenericCustomAttributeProvider? _attributeProvider;
+    public IGenericCustomAttributeProvider AttributeProvider => field ?? CommonHelpers.ExchangeIfNull(ref field, ReflectionCustomAttributeProvider.Create(ctorInfo.Method));
 
     public bool IsPublic => ctorInfo.IsPublic;
     IObjectTypeShape IConstructorShape.DeclaringType => DeclaringType;
     object? IConstructorShape.Accept(TypeShapeVisitor visitor, object? state) => visitor.VisitConstructor(this, state);
 
-    public IReadOnlyList<IParameterShape> Parameters => _parameters ?? CommonHelpers.ExchangeIfNull(ref _parameters, GetParameters().AsReadOnlyList());
+    public IReadOnlyList<IParameterShape> Parameters => field ?? CommonHelpers.ExchangeIfNull(ref field, GetParameters().AsReadOnlyList());
 
     public Func<TArgumentState> GetArgumentStateConstructor()
     {

--- a/src/PolyType/ReflectionProvider/ReflectionDelegateTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionDelegateTypeShape.cs
@@ -12,7 +12,6 @@ internal sealed class ReflectionDelegateTypeShape<TDelegate, TArgumentState, TRe
     where TDelegate : Delegate
     where TArgumentState : IArgumentState
 {
-    private IReadOnlyList<IParameterShape>? _parameters;
     private Func<TArgumentState>? _argumentStateConstructor;
     private MethodInvoker<TDelegate, TArgumentState, TResult>? _functionInvoker;
     private Func<RefFunc<TArgumentState, TResult>, TDelegate>? _fromDelegate;
@@ -20,7 +19,7 @@ internal sealed class ReflectionDelegateTypeShape<TDelegate, TArgumentState, TRe
 
     public bool IsVoidLike => methodShapeInfo.IsVoidLike;
     public bool IsAsync => methodShapeInfo.IsAsync;
-    public IReadOnlyList<IParameterShape> Parameters => _parameters ?? CommonHelpers.ExchangeIfNull(ref _parameters, GetParameters().AsReadOnlyList());
+    public IReadOnlyList<IParameterShape> Parameters => field ?? CommonHelpers.ExchangeIfNull(ref field, GetParameters().AsReadOnlyList());
     public override TypeShapeKind Kind => TypeShapeKind.Function;
     public ITypeShape<TResult> ReturnType => Provider.GetTypeShape<TResult>();
     ITypeShape IFunctionTypeShape.ReturnType => ReturnType;

--- a/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
@@ -17,14 +17,13 @@ namespace PolyType.ReflectionProvider;
 internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(ReflectionTypeShapeProvider provider, ReflectionTypeShapeOptions options)
     : ReflectionTypeShape<TEnumerable>(provider, options), IEnumerableTypeShape<TEnumerable, TElement>
 {
-    private CollectionConstructorInfo? _constructorInfo;
     private EnumerableAppender<TEnumerable, TElement>? _addDelegate;
     private MutableCollectionConstructor<TElement, TEnumerable>? _mutableCtorDelegate;
     private ParameterizedCollectionConstructor<TElement, TElement, TEnumerable>? _spanCtorDelegate;
 
     private CollectionConstructorInfo ConstructorInfo
     {
-        get => _constructorInfo ?? CommonHelpers.ExchangeIfNull(ref _constructorInfo, DetermineConstructorInfo());
+        get => field ?? CommonHelpers.ExchangeIfNull(ref field, DetermineConstructorInfo());
     }
 
     public virtual CollectionConstructionStrategy ConstructionStrategy => ConstructorInfo.Strategy;

--- a/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionEnumerableTypeShape.cs
@@ -239,7 +239,7 @@ internal abstract class ReflectionEnumerableTypeShape<TEnumerable, TElement>(Ref
                 // If no Add method was found, check for potential explicit interface implementations.
                 if (addMethod is null && typeof(ICollection<TElement>).IsAssignableFrom(enumerableType))
                 {
-                    addMethod = typeof(ICollection<TElement>).GetMethod(nameof(ICollection<TElement>.Add));
+                    addMethod = typeof(ICollection<TElement>).GetMethod(nameof(ICollection<>.Add));
                 }
 
                 if (addMethod is null && typeof(IList).IsAssignableFrom(enumerableType) && typeof(TElement) == typeof(object))
@@ -291,7 +291,7 @@ internal sealed class ReflectionArrayTypeShape<TElement>(ReflectionTypeShapeProv
     public override CollectionComparerOptions SupportedComparer => CollectionComparerOptions.None;
     public override CollectionConstructionStrategy ConstructionStrategy => CollectionConstructionStrategy.Parameterized;
     public override Func<TElement[], IEnumerable<TElement>> GetGetEnumerable() => static array => array;
-    public override ParameterizedCollectionConstructor<TElement, TElement, TElement[]> GetParameterizedConstructor() => static (ReadOnlySpan<TElement> span, in CollectionConstructionOptions<TElement> options) => span.ToArray();
+    public override ParameterizedCollectionConstructor<TElement, TElement, TElement[]> GetParameterizedConstructor() => static (span, in options) => span.ToArray();
 }
 
 [RequiresUnreferencedCode(ReflectionTypeShapeProvider.RequiresUnreferencedCodeMessage)]
@@ -315,7 +315,7 @@ internal sealed class ReadOnlyMemoryTypeShape<TElement>(ReflectionTypeShapeProvi
     public override CollectionComparerOptions SupportedComparer => CollectionComparerOptions.None;
     public override CollectionConstructionStrategy ConstructionStrategy => CollectionConstructionStrategy.Parameterized;
     public override Func<ReadOnlyMemory<TElement>, IEnumerable<TElement>> GetGetEnumerable() => static memory => MemoryMarshal.ToEnumerable(memory);
-    public override ParameterizedCollectionConstructor<TElement, TElement, ReadOnlyMemory<TElement>> GetParameterizedConstructor() => static (ReadOnlySpan<TElement> span, in CollectionConstructionOptions<TElement> options) => span.ToArray();
+    public override ParameterizedCollectionConstructor<TElement, TElement, ReadOnlyMemory<TElement>> GetParameterizedConstructor() => static (span, in options) => span.ToArray();
 }
 
 [RequiresUnreferencedCode(ReflectionTypeShapeProvider.RequiresUnreferencedCodeMessage)]
@@ -326,7 +326,7 @@ internal sealed class MemoryTypeShape<TElement>(ReflectionTypeShapeProvider prov
     public override CollectionComparerOptions SupportedComparer => CollectionComparerOptions.None;
     public override CollectionConstructionStrategy ConstructionStrategy => CollectionConstructionStrategy.Parameterized;
     public override Func<Memory<TElement>, IEnumerable<TElement>> GetGetEnumerable() => static memory => MemoryMarshal.ToEnumerable((ReadOnlyMemory<TElement>)memory);
-    public override ParameterizedCollectionConstructor<TElement, TElement, Memory<TElement>> GetParameterizedConstructor() => static (ReadOnlySpan<TElement> span, in CollectionConstructionOptions<TElement> options) => span.ToArray();
+    public override ParameterizedCollectionConstructor<TElement, TElement, Memory<TElement>> GetParameterizedConstructor() => static (span, in options) => span.ToArray();
 }
 
 [RequiresUnreferencedCode(ReflectionTypeShapeProvider.RequiresUnreferencedCodeMessage)]
@@ -356,7 +356,7 @@ internal sealed class ReflectionInlineArrayTypeShape<TArray, TElement>(int lengt
 
     public override ParameterizedCollectionConstructor<TElement, TElement, TArray> GetParameterizedConstructor()
     {
-        return (ReadOnlySpan<TElement> span, in CollectionConstructionOptions<TElement> options) =>
+        return (span, in options) =>
         {
             if (span.Length != length)
             {

--- a/src/PolyType/ReflectionProvider/ReflectionNullableTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionNullableTypeShape.cs
@@ -17,7 +17,7 @@ internal sealed class ReflectionNullableTypeShape<T>(ReflectionTypeShapeProvider
     public Func<T?> GetNoneConstructor() => static () => null;
     public Func<T, T?> GetSomeConstructor() => static t => t;
     public OptionDeconstructor<T?, T> GetDeconstructor() =>
-        static (T? optional, out T value) =>
+        static (optional, out value) =>
         {
             if (optional is null)
             {

--- a/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionObjectTypeShape.cs
@@ -30,17 +30,16 @@ internal abstract class ReflectionObjectTypeShape<T>(ReflectionTypeShapeProvider
                 IConstructorShape? constructor = GetConstructor();
                 if (constructor is not null)
                 {
-                    constructor = CommonHelpers.ExchangeIfNull(ref _constructor, constructor);
+                    constructor = CommonHelpers.ExchangeIfNull(ref field, constructor);
                 }
 
                 Volatile.Write(ref _isConstructorResolved, true);
             }
 
-            return _constructor;
+            return field;
         }
     }
 
-    private IConstructorShape? _constructor;
     private bool _isConstructorResolved;
 
     protected abstract IEnumerable<IPropertyShape> GetProperties();

--- a/src/PolyType/ReflectionProvider/ReflectionParameterShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionParameterShape.cs
@@ -44,8 +44,7 @@ internal sealed class ReflectionParameterShape<TArgumentState, TParameter> : IPa
     public ParameterInfo? ParameterInfo => _parameterInfo.AttributeProvider as ParameterInfo;
     public MemberInfo? MemberInfo => _parameterInfo.AttributeProvider as MemberInfo;
 
-    public IGenericCustomAttributeProvider AttributeProvider => _attributeProvider ?? CommonHelpers.ExchangeIfNull(ref _attributeProvider, ReflectionCustomAttributeProvider.Create(_parameterInfo.AttributeProvider));
-    private IGenericCustomAttributeProvider? _attributeProvider;
+    public IGenericCustomAttributeProvider AttributeProvider => field ?? CommonHelpers.ExchangeIfNull(ref field, ReflectionCustomAttributeProvider.Create(_parameterInfo.AttributeProvider));
 
     ITypeShape IParameterShape.ParameterType => ParameterType;
     object? IParameterShape.Accept(TypeShapeVisitor visitor, object? state) => visitor.VisitParameter(this, state);

--- a/src/PolyType/ReflectionProvider/ReflectionUnionCaseShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionUnionCaseShape.cs
@@ -9,8 +9,7 @@ namespace PolyType.ReflectionProvider;
 internal sealed class ReflectionUnionCaseShape<TUnionCase, TUnion>(IUnionTypeShape unionType, DerivedTypeInfo derivedTypeInfo, ReflectionTypeShapeProvider provider) : IUnionCaseShape<TUnionCase, TUnion>
     where TUnionCase : TUnion
 {
-    public ITypeShape<TUnionCase> UnionCaseType => _type ?? CommonHelpers.ExchangeIfNull(ref _type, typeof(TUnionCase) == typeof(TUnion) ? (ITypeShape<TUnionCase>)unionType.BaseType : provider.GetTypeShape<TUnionCase>());
-    private ITypeShape<TUnionCase>? _type;
+    public ITypeShape<TUnionCase> UnionCaseType => field ?? CommonHelpers.ExchangeIfNull(ref field, typeof(TUnionCase) == typeof(TUnion) ? (ITypeShape<TUnionCase>)unionType.BaseType : provider.GetTypeShape<TUnionCase>());
 
     public IMarshaler<TUnionCase, TUnion> Marshaler => SubtypeMarshaler<TUnionCase, TUnion>.Instance;
 

--- a/src/PolyType/ReflectionProvider/ReflectionUnionTypeShape.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionUnionTypeShape.cs
@@ -14,11 +14,9 @@ internal sealed class ReflectionUnionTypeShape<TUnion>(DerivedTypeInfo[] derived
     public override TypeShapeKind Kind => TypeShapeKind.Union;
     public override object? Accept(TypeShapeVisitor visitor, object? state = null) => visitor.VisitUnion(this, state);
 
-    public ITypeShape<TUnion> BaseType => _baseType ?? CommonHelpers.ExchangeIfNull(ref _baseType, (ITypeShape<TUnion>)Provider.CreateTypeShapeCore(typeof(TUnion), allowUnionShapes: false));
-    private ITypeShape<TUnion>? _baseType;
+    public ITypeShape<TUnion> BaseType => field ?? CommonHelpers.ExchangeIfNull(ref field, (ITypeShape<TUnion>)Provider.CreateTypeShapeCore(typeof(TUnion), allowUnionShapes: false));
 
-    public IReadOnlyList<IUnionCaseShape> UnionCases => _unionCases ?? CommonHelpers.ExchangeIfNull(ref _unionCases, CreateUnionCaseShapes().AsReadOnlyList());
-    private IReadOnlyList<IUnionCaseShape>? _unionCases;
+    public IReadOnlyList<IUnionCaseShape> UnionCases => field ?? CommonHelpers.ExchangeIfNull(ref field, CreateUnionCaseShapes().AsReadOnlyList());
 
     public Getter<TUnion, int> GetGetUnionCaseIndex() => _unionCaseIndexReader ??= CommonHelpers.ExchangeIfNull(ref _unionCaseIndexReader, Provider.MemberAccessor.CreateGetUnionCaseIndex<TUnion>(derivedTypeInfos));
     private Getter<TUnion, int>? _unionCaseIndexReader;

--- a/src/PolyType/SourceGenModel/Helpers/CollectionHelpers.cs
+++ b/src/PolyType/SourceGenModel/Helpers/CollectionHelpers.cs
@@ -128,7 +128,7 @@ public static class CollectionHelpers
     public static EnumerableAppender<TEnumerable, TElement> CreateEnumerableAppender<TEnumerable, TElement>()
         where TEnumerable : ICollection<TElement>
     {
-        return (ref TEnumerable enumerable, TElement element) =>
+        return (ref enumerable, element) =>
         {
             enumerable.Add(element);
             return true;
@@ -143,7 +143,7 @@ public static class CollectionHelpers
     public static EnumerableAppender<TEnumerable, object?> CreateEnumerableAppender<TEnumerable>()
         where TEnumerable : IList
     {
-        return (ref TEnumerable enumerable, object? element) =>
+        return (ref enumerable, element) =>
         {
             enumerable.Add(element);
             return true;
@@ -164,13 +164,13 @@ public static class CollectionHelpers
     {
         return insertionMode switch
         {
-            DictionaryInsertionMode.Overwrite => static (ref TDictionary dictionary, TKey key, TValue value) =>
+            DictionaryInsertionMode.Overwrite => static (ref dictionary, key, value) =>
             {
                 dictionary[key] = value;
                 return true;
             },
 
-            DictionaryInsertionMode.Discard => static (ref TDictionary dictionary, TKey key, TValue value) =>
+            DictionaryInsertionMode.Discard => static (ref dictionary, key, value) =>
             {
                 if (dictionary.ContainsKey(key))
                 {
@@ -181,7 +181,7 @@ public static class CollectionHelpers
                 return true;
             },
 
-            DictionaryInsertionMode.Throw => static (ref TDictionary dictionary, TKey key, TValue value) =>
+            DictionaryInsertionMode.Throw => static (ref dictionary, key, value) =>
             {
                 dictionary.Add(key, value);
                 return true;
@@ -203,13 +203,13 @@ public static class CollectionHelpers
     {
         return insertionMode switch
         {
-            DictionaryInsertionMode.Overwrite => static (ref TDictionary dictionary, object key, object? value) =>
+            DictionaryInsertionMode.Overwrite => static (ref dictionary, key, value) =>
             {
                 dictionary[key] = value;
                 return true;
             },
 
-            DictionaryInsertionMode.Discard => static (ref TDictionary dictionary, object key, object? value) =>
+            DictionaryInsertionMode.Discard => static (ref dictionary, key, value) =>
             {
                 if (dictionary.Contains(key))
                 {
@@ -220,7 +220,7 @@ public static class CollectionHelpers
                 return true;
             },
 
-            DictionaryInsertionMode.Throw => static (ref TDictionary dictionary, object key, object? value) =>
+            DictionaryInsertionMode.Throw => static (ref dictionary, key, value) =>
             {
                 dictionary.Add(key, value);
                 return true;

--- a/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
+++ b/src/PolyType/SourceGenModel/SourceGenDictionaryTypeShape.cs
@@ -131,19 +131,14 @@ public sealed class SourceGenDictionaryTypeShape<TDictionary, TKey, TValue> : So
             static void Throw() => throw new InvalidOperationException("Dictionary shape does not specify a default constructor.");
         }
 
-        switch (insertionMode)
+        return insertionMode switch
         {
-            case DictionaryInsertionMode.None:
-                return OverwritingInserter ?? DiscardingInserter ?? ThrowingInserter ?? Fail();
-            case DictionaryInsertionMode.Overwrite when OverwritingInserter is { } inserter:
-                return inserter;
-            case DictionaryInsertionMode.Discard when DiscardingInserter is { } inserter:
-                return inserter;
-            case DictionaryInsertionMode.Throw when ThrowingInserter is { } inserter:
-                return inserter;
-            default:
-                return Fail();
-        }
+            DictionaryInsertionMode.None => OverwritingInserter ?? DiscardingInserter ?? ThrowingInserter ?? Fail(),
+            DictionaryInsertionMode.Overwrite when OverwritingInserter is { } inserter => inserter,
+            DictionaryInsertionMode.Discard when DiscardingInserter is { } inserter => inserter,
+            DictionaryInsertionMode.Throw when ThrowingInserter is { } inserter => inserter,
+            _ => Fail(),
+        };
 
         static DictionaryInserter<TDictionary, TKey, TValue> Fail() =>
             throw new ArgumentOutOfRangeException(nameof(insertionMode), "Unsupported dictionary insertion mode.");

--- a/src/PolyType/Utilities/ReflectionUtilities.cs
+++ b/src/PolyType/Utilities/ReflectionUtilities.cs
@@ -109,7 +109,7 @@ public static class ReflectionUtilities
             int backtickIndex = name.IndexOf('`');
             if (backtickIndex >= 0)
             {
-                name = name.Substring(0, backtickIndex);
+                name = name[..backtickIndex];
             }
 
             builder.Append(name);

--- a/src/Shared/Helpers/CommonHelpers.cs
+++ b/src/Shared/Helpers/CommonHelpers.cs
@@ -97,7 +97,7 @@ internal static class CommonHelpers
                 {
                     childMap[nextIndex] = false;
 
-                    if (childMap.AsSpan().IndexOf(true) == -1)
+                    if (childMap.IndexOf(true) == -1)
                     {
                         // nextIndex was the last child removed from i, add to queue.
                         childlessQueue.Enqueue(i);

--- a/tests/PolyType.Benchmarks/CounterBenchmark.cs
+++ b/tests/PolyType.Benchmarks/CounterBenchmark.cs
@@ -10,7 +10,7 @@ public partial class CounterBenchmark
     private static readonly ReflectionTypeShapeProvider EmitProvider = ReflectionTypeShapeProvider.Create(new() { UseReflectionEmit = true });
     private static readonly ReflectionTypeShapeProvider NoEmitProvider = ReflectionTypeShapeProvider.Create(new() { UseReflectionEmit = false });
 
-    private readonly MyPoco _value = new MyPoco(@string: "myString")
+    private readonly MyPoco _value = new(@string: "myString")
     {
         List = [1, 2, 3],
         Dict = new() { ["key1"] = 42, ["key2"] = -1 },

--- a/tests/PolyType.Benchmarks/JsonBenchmark.cs
+++ b/tests/PolyType.Benchmarks/JsonBenchmark.cs
@@ -9,7 +9,7 @@ using PolyType.ReflectionProvider;
 
 public static class JsonData
 {
-    public static readonly MyPoco Value = new MyPoco(@string: "myString")
+    public static readonly MyPoco Value = new(@string: "myString")
     {
         List = [1, 2, 3],
         Dict = new() { ["key1"] = 42, ["key2"] = -1 },

--- a/tests/PolyType.Roslyn.Tests/SourceWriterTests.cs
+++ b/tests/PolyType.Roslyn.Tests/SourceWriterTests.cs
@@ -97,7 +97,7 @@ public static class SourceWriterTests
         
         int intValue = 42;
         double doubleValue = 3.14159;
-        DateTime dateValue = new DateTime(2024, 1, 15, 14, 30, 0);
+        DateTime dateValue = new(2024, 1, 15, 14, 30, 0);
         decimal decimalValue = 1234.5678m;
         
         writer.WriteLine($"Integer: {intValue:X8}");
@@ -144,8 +144,10 @@ public static class SourceWriterTests
     [Fact]
     public static void Dispose_PropertiesRemainAccessible()
     {
-        SourceWriter writer = new('\t', 2);
-        writer.Indentation = 5;
+        SourceWriter writer = new('\t', 2)
+        {
+            Indentation = 5,
+        };
         writer.WriteLine("test");
         writer.Dispose();
         

--- a/tests/PolyType.SourceGenerator.UnitTests/CompilationHelpers.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/CompilationHelpers.cs
@@ -20,7 +20,7 @@ public record PolyTypeSourceGeneratorResult
 
 public static class CompilationHelpers
 {
-    private static readonly string FileSeparator = new string('=', 140);
+    private static readonly string FileSeparator = new('=', 140);
 
     private static readonly CSharpParseOptions s_defaultParseOptions = CreateParseOptions();
 #if NET

--- a/tests/PolyType.SourceGenerator.UnitTests/NumberedLineWriter.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/NumberedLineWriter.cs
@@ -7,7 +7,7 @@ using Xunit;
 internal class NumberedLineWriter : TextWriter
 {
     private readonly ITestOutputHelper logger;
-    private readonly StringBuilder lineBuilder = new StringBuilder();
+    private readonly StringBuilder lineBuilder = new();
     private int lineNumber;
 
     internal NumberedLineWriter(ITestOutputHelper logger)
@@ -32,11 +32,11 @@ internal class NumberedLineWriter : TextWriter
 
         if (value.EndsWith("\r\n", StringComparison.Ordinal))
         {
-            this.WriteLine(value.Substring(0, value.Length - 2));
+            this.WriteLine(value[..^2]);
         }
         else if (value.EndsWith("\n", StringComparison.Ordinal))
         {
-            this.WriteLine(value.Substring(0, value.Length - 1));
+            this.WriteLine(value[..^1]);
         }
         else
         {

--- a/tests/PolyType.SourceGenerator.UnitTests/Verifiers/CodeFixVerifier`2.cs
+++ b/tests/PolyType.SourceGenerator.UnitTests/Verifiers/CodeFixVerifier`2.cs
@@ -25,7 +25,7 @@ internal class CodeFixVerifier<TAnalyzer, TCodeFix>
         => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(diagnosticId);
 
     public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
-        => new DiagnosticResult(descriptor);
+        => new(descriptor);
 
     public static Task VerifyAnalyzerAsync([StringSyntax("c#-test")] string source, params DiagnosticResult[] expected)
     {
@@ -90,7 +90,7 @@ internal class CodeFixVerifier<TAnalyzer, TCodeFix>
                 return from resourceName in Assembly.GetExecutingAssembly().GetManifestResourceNames()
                        where resourceName.StartsWith(additionalFilePrefix, StringComparison.Ordinal)
                        let content = ReadManifestResource(Assembly.GetExecutingAssembly(), resourceName)
-                       select (filename: resourceName.Substring(additionalFilePrefix.Length), SourceText.From(content));
+                       select (filename: resourceName[additionalFilePrefix.Length..], SourceText.From(content));
             });
         }
 
@@ -128,10 +128,8 @@ internal class CodeFixVerifier<TAnalyzer, TCodeFix>
 
         private static string ReadManifestResource(Assembly assembly, string resourceName)
         {
-            using (var reader = new StreamReader(assembly.GetManifestResourceStream(resourceName) ?? throw new ArgumentException("No such resource stream", nameof(resourceName))))
-            {
-                return reader.ReadToEnd();
-            }
+            using var reader = new StreamReader(assembly.GetManifestResourceStream(resourceName) ?? throw new ArgumentException("No such resource stream", nameof(resourceName)));
+            return reader.ReadToEnd();
         }
     }
 }

--- a/tests/PolyType.Tests/ConfigurationBinderTests.cs
+++ b/tests/PolyType.Tests/ConfigurationBinderTests.cs
@@ -62,7 +62,7 @@ public abstract class ConfigurationBinderTests(ProviderUnderTest providerUnderTe
         
         string rootJson = $$"""{ "Root" : {{json}} }""";
         var builder = new ConfigurationBuilder();
-        using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(rootJson));
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(rootJson));
         builder.AddJsonStream(stream);
         return (builder.Build().GetSection("Root"), json);
     }

--- a/tests/PolyType.Tests/SourceGenModel/ObsoletePropertyTests.cs
+++ b/tests/PolyType.Tests/SourceGenModel/ObsoletePropertyTests.cs
@@ -25,8 +25,8 @@ public static class ObsoletePropertyTests
             GetEnumerable = list => list,
             SupportedComparer = CollectionComparerOptions.None,
             ConstructionStrategy = CollectionConstructionStrategy.Mutable,
-            DefaultConstructor = (in CollectionConstructionOptions<int> _) => [],
-            Appender = (ref List<int> list, int value) => { list.Add(value); return true; },
+            DefaultConstructor = (in _) => [],
+            Appender = (ref list, value) => { list.Add(value); return true; },
         };
 #pragma warning restore CS0618
 
@@ -60,8 +60,8 @@ public static class ObsoletePropertyTests
             GetDictionary = dict => dict,
             SupportedComparer = CollectionComparerOptions.None,
             ConstructionStrategy = CollectionConstructionStrategy.Mutable,
-            DefaultConstructor = (in CollectionConstructionOptions<string> _) => [],
-            OverwritingInserter = (ref Dictionary<string, int> dict, string key, int value) => { dict[key] = value; return true; },
+            DefaultConstructor = (in _) => [],
+            OverwritingInserter = (ref dict, key, value) => { dict[key] = value; return true; },
         };
 #pragma warning restore CS0618
 
@@ -95,8 +95,8 @@ public static class ObsoletePropertyTests
             GetDictionary = dict => dict,
             SupportedComparer = CollectionComparerOptions.None,
             ConstructionStrategy = CollectionConstructionStrategy.Mutable,
-            DefaultConstructor = (in CollectionConstructionOptions<string> _) => [],
-            OverwritingInserter = (ref Dictionary<string, int> dict, string key, int value) => { dict[key] = value; return true; },
+            DefaultConstructor = (in _) => [],
+            OverwritingInserter = (ref dict, key, value) => { dict[key] = value; return true; },
         };
 #pragma warning restore CS0618
 
@@ -124,7 +124,7 @@ public static class ObsoletePropertyTests
             ElementType = expectedElementType,
             NoneConstructor = () => null,
             SomeConstructor = value => value,
-            Deconstructor = (int? optional, out int value) =>
+            Deconstructor = (optional, out value) =>
             {
                 if (optional.HasValue)
                 {
@@ -187,7 +187,7 @@ public static class ObsoletePropertyTests
             BaseTypeFactory = () => throw new InvalidOperationException("BaseTypeFactory should not be called"),
             BaseType = expectedBaseType,
             UnionCasesFactory = () => [],
-            GetUnionCaseIndex = (ref object _) => 0,
+            GetUnionCaseIndex = (ref _) => 0,
         };
 #pragma warning restore CS0618
 
@@ -268,7 +268,7 @@ public static class ObsoletePropertyTests
             ReturnTypeFactory = () => throw new InvalidOperationException("ReturnTypeFactory should not be called"),
             ReturnType = expectedReturnType,
             ArgumentStateConstructor = () => EmptyArgumentState.Instance,
-            FunctionInvoker = (ref Func<int> func, ref EmptyArgumentState state) => new ValueTask<int>(func()),
+            FunctionInvoker = (ref func, ref state) => new ValueTask<int>(func()),
         };
 #pragma warning restore CS0618
 

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -696,7 +696,7 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
                     uncurriedParams.Add(parameterInfos[0]);
                 }
                 
-                if (uncurriedParams.Count == 1 && uncurriedParams[0].ParameterType is { Name: "Unit", Namespace: "Microsoft.FSharp.Core" })
+                if (uncurriedParams is [{ ParameterType: { Name: "Unit", Namespace: "Microsoft.FSharp.Core" } }])
                 {
                     uncurriedParams.Clear();
                 }

--- a/tests/PolyType.Tests/TypeShapeProviderTests.cs
+++ b/tests/PolyType.Tests/TypeShapeProviderTests.cs
@@ -748,13 +748,13 @@ public abstract class TypeShapeProviderTests(ProviderUnderTest providerUnderTest
             Assert.Equal(functionShape.IsVoidLike, result is Unit);
 
             // FromDelegate/FromAsyncDelegate round-trip test
-            RefFunc<TArgumentState, TResult> wrappedInvoker = (ref TArgumentState arg) =>
+            RefFunc<TArgumentState, TResult> wrappedInvoker = (ref arg) =>
             {
                 Assert.True(arg.AreRequiredArgumentsSet);
                 return functionInvoker(ref func, ref arg).GetAwaiter().GetResult();
             };
 
-            RefFunc<TArgumentState, ValueTask<TResult>> wrappedInvokerAsync = (ref TArgumentState arg) =>
+            RefFunc<TArgumentState, ValueTask<TResult>> wrappedInvokerAsync = (ref arg) =>
             {
                 Assert.True(arg.AreRequiredArgumentsSet);
                 return functionInvoker(ref func, ref arg);


### PR DESCRIPTION
## Summary
- replace 27 accessor-owned backing fields with C# 14 `field` storage
- adopt inferred modified lambda parameters, an extension block, unbound generic `nameof`, and first-class span receivers
- apply 40 additional behavior-neutral modernizations, including target-typed construction, list/property patterns, switch expressions, ranges, and simplified accessors
- preserve public API metadata and C# 12-compatible generated-source fixtures

## Testing
- `make test` (277,827 CLR tests and 29 Native AOT tests passed)