### PR TITLE
Use Reflection.Emit accessors when dynamic code is supported

### DIFF
--- a/src/PolyType/ReflectionProvider/ReflectionTypeShapeProviderOptions.cs
+++ b/src/PolyType/ReflectionProvider/ReflectionTypeShapeProviderOptions.cs
@@ -16,13 +16,9 @@ public sealed record ReflectionTypeShapeProviderOptions
     /// Gets a value indicating whether System.Reflection.Emit should be used when generating member accessors.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>true</c> if the runtime supports and JIT-compiles dynamic code.
-    /// On runtimes where dynamic code is supported but only interpreted (such as the Mono interpreter,
-    /// WebAssembly and iOS), the emitted IL would itself be interpreted, offering no throughput benefit
-    /// over plain reflection while still pulling in the System.Reflection.Emit stack; the default is
-    /// therefore <c>false</c> in those environments.
+    /// Defaults to <c>true</c> if the runtime supports dynamic code generation.
     /// </remarks>
-    public bool UseReflectionEmit { get; init; } = ReflectionHelpers.IsDynamicCodeCompiled;
+    public bool UseReflectionEmit { get; init; } = ReflectionHelpers.IsDynamicCodeSupported;
 
     /// <summary>
     /// Gets the list of assemblies to scan for <see cref="TypeShapeExtensionAttribute"/> attributes.

--- a/src/Shared/Helpers/ReflectionHelpers.cs
+++ b/src/Shared/Helpers/ReflectionHelpers.cs
@@ -31,23 +31,6 @@ internal static class ReflectionHelpers
 #endif
     }
 
-    public static bool IsDynamicCodeCompiled { get; } = IsDynamicCodeCompiledCore();
-    private static bool IsDynamicCodeCompiledCore()
-    {
-#if NET
-        return RuntimeFeature.IsDynamicCodeCompiled;
-#else
-        if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.Ordinal))
-        {
-            return true; // .NET Framework JIT-compiles dynamic code.
-        }
-
-        // Check for the presence of the property in .NET 6+.
-        PropertyInfo? prop = Type.GetType("System.Runtime.CompilerServices.RuntimeFeature")?.GetProperty("IsDynamicCodeCompiled", BindingFlags.Public | BindingFlags.Static);
-        return prop is not null && (bool)prop.GetValue(null);
-#endif
-    }
-
     public static bool IsMonoRuntime { get; } = Type.GetType("Mono.Runtime") is not null;
     public static bool IsNetFramework { get; } = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.Ordinal);
 


### PR DESCRIPTION
Restores `Reflection.Emit` member accessors as the default whenever dynamic code is supported, mirroring dotnet/runtime#131452. This reverts the accessor-selection portion of #473 while retaining its reflection invocation and exception-propagation changes.

The `IsDynamicCodeCompiled` gate assumed emitted IL offered no throughput benefit under interpreters. The measurements behind dotnet/runtime#131452 show that interpreted `DynamicMethod` accessors substantially outperform repeated reflection invocation, so the default now uses `IsDynamicCodeSupported` and the unused compatibility helper is removed.

Validation: `make test`