### PR TITLE
Use .NET 11 RC1 SDK and C# 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,11 @@ jobs:
     - name: Setup .NET 🤖
       uses: actions/setup-dotnet@v6
       with:
+        global-json-file: global.json
         dotnet-version: |
           10.0.x
           9.0.x
+          8.0.x
 
     # Netfx testing on non-Windows OSes requires mono
     - name: Setup Mono 🙈

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -32,9 +32,11 @@ jobs:
     - name: Dotnet Setup
       uses: actions/setup-dotnet@v6
       with:
+        global-json-file: global.json
         dotnet-version: |
           10.0.x
           9.0.x
+          8.0.x
 
     - run: make generate-docs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v6
       with:
+        global-json-file: global.json
         dotnet-version: |
           10.0.x
           9.0.x
+          8.0.x
 
     - name: Setup Mono
       run: sudo apt-get install -y mono-devel

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <LangVersion>14</LangVersion>
+    <LangVersion>15.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0
+FROM mcr.microsoft.com/dotnet/sdk:11.0.100-rc.1
 
 # Install system dependencies and mono runtime
 RUN apt-get update && apt-get install -y make mono-runtime
 
-# Install .NET 8 runtime
+# Install runtimes for the existing test and tool target frameworks
 RUN wget https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh \
     && chmod +x dotnet-install.sh \
-    && ./dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir /usr/share/dotnet \
+    && ./dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir /usr/share/dotnet --skip-non-versioned-files \
+    && ./dotnet-install.sh --channel 9.0 --runtime dotnet --install-dir /usr/share/dotnet --skip-non-versioned-files \
+    && ./dotnet-install.sh --channel 10.0 --runtime dotnet --install-dir /usr/share/dotnet --skip-non-versioned-files \
     && rm -f dotnet-install.sh
 
 # Verify installations

--- a/PolyType.slnx
+++ b/PolyType.slnx
@@ -52,6 +52,7 @@
   </Folder>
   <Folder Name="/tests/">
     <File Path="tests/Directory.Build.props" />
+    <File Path="tests/Directory.Build.targets" />
     <Project Path="tests/PolyType.Benchmarks/PolyType.Benchmarks.csproj" />
     <Project Path="tests/PolyType.Roslyn.Tests/PolyType.Roslyn.Tests.csproj" />
     <Project Path="tests/PolyType.SourceGenerator.UnitTests/PolyType.SourceGenerator.UnitTests.csproj" />

--- a/PolyType.slnx
+++ b/PolyType.slnx
@@ -37,7 +37,6 @@
     <File Path="OpenKey.snk" />
     <File Path="LICENSE" />
     <File Path="Makefile" />
-    <File Path="nuget.config" />
     <File Path="README.md" />
     <File Path="version.json" />
   </Folder>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
   "sdk": {
-    "version": "10.0.100",
-    "rollForward": "minor"
+    "version": "11.0.100-rc.1.26425.128",
+    "rollForward": "minor",
+    "allowPrerelease": true
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <AnalysisModeStyle>Default</AnalysisModeStyle>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <WarningsAsErrors>Nullable</WarningsAsErrors>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(OS)' != 'Windows_NT'">
+    <RunCommand Condition="'$(RunCommand)' == ''">mono</RunCommand>
+    <RunArguments Condition="'$(RunArguments)' == ''">&quot;$(TargetPath)&quot; $(StartArguments)</RunArguments>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Update repository builds to the .NET 11 RC1 SDK and C# 15 without changing target frameworks. GitHub Actions installs the SDK from `global.json`; Docker uses the RC1 image and retains the .NET 8, 9, and 10 runtimes needed by the existing tests and tools.

Keep the existing SDK roll-forward policy and code-style severities. Remove the repository NuGet source override so restores inherit user and machine configuration.